### PR TITLE
Feat/update 1

### DIFF
--- a/attocode/package-lock.json
+++ b/attocode/package-lock.json
@@ -47,6 +47,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
       "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "is-fullwidth-code-point": "^4.0.0"
@@ -55,21 +56,11 @@
         "node": ">=14.13.1"
       }
     },
-    "node_modules/@alcalzone/ansi-tokenize/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -82,6 +73,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -98,6 +90,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -114,6 +107,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -130,6 +124,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -146,6 +141,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -162,6 +158,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -178,6 +175,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -194,6 +192,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -210,6 +209,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -226,6 +226,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -242,6 +243,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -258,6 +260,7 @@
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -274,6 +277,7 @@
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -290,6 +294,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -306,6 +311,7 @@
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -322,6 +328,7 @@
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -338,6 +345,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -354,6 +362,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -370,6 +379,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -386,6 +396,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -402,6 +413,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -418,6 +430,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -434,6 +447,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -450,6 +464,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -466,6 +481,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -482,6 +498,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -495,6 +512,7 @@
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -506,6 +524,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.13.tgz",
       "integrity": "sha512-9edAxu7N2FX7vzkdl5Jo1BbACfycUtBQX+XBMcHA2bk62P8R0otgkHg798frgAk/WxQIzwxqOH6wMiCwrlAzdQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -519,6 +538,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.13.tgz",
       "integrity": "sha512-qXpA1tzTnlkTku9yqtuRtS/wVntvE6f3m3GNxdTdtmc+O+Wcg9Xo2ABPMh7Nc0AHbMKzwvwgB2JnjZmlmJEObg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -537,6 +557,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.13.tgz",
       "integrity": "sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/core": "^0.16.13"
@@ -546,6 +567,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.13.tgz",
       "integrity": "sha512-yFAMZGv3o+YcjXilMWWwS/bv1iSqykFahFMSO169uVMtfQVfa90kt4/kDwrXNR6Q9i6VHpFiGZMlF2UnHClBvg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -560,6 +582,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.13.tgz",
       "integrity": "sha512-BJHlDxzTlCqP2ThqP8J0eDrbBfod7npWCbJAcfkKqdQuFk0zBPaZ6KKaQKyKxmWJ87Z6ohANZoMKEbtvrwz1AA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -573,6 +596,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.13.tgz",
       "integrity": "sha512-8Z1k96ZFxlhK2bgrY1JNWNwvaBeI/bciLM0yDOni2+aZwfIIiC7Y6PeWHTAvjHNjphz+XCt01WQmOYWCn0ML6g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -585,6 +609,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.13.tgz",
       "integrity": "sha512-PvLrfa8vkej3qinlebyhLpksJgCF5aiysDMSVhOZqwH5nQLLtDE9WYbnsofGw4r0VVpyw3H/ANCIzYTyCtP9Cg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -597,6 +622,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.13.tgz",
       "integrity": "sha512-RNave7EFgZrb5V5EpdvJGAEHMnDAJuwv05hKscNfIYxf0kR3KhViBTDy+MoTnMlIvaKFULfwIgaZWzyhuINMzA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -609,6 +635,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.13.tgz",
       "integrity": "sha512-xW+9BtEvoIkkH/Wde9ql4nAFbYLkVINhpgAE7VcBUsuuB34WUbcBl/taOuUYQrPEFQJ4jfXiAJZ2H/rvKjCVnQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -622,6 +649,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.13.tgz",
       "integrity": "sha512-QayTXw4tXMwU6q6acNTQrTTFTXpNRBe+MgTGMDU0lk+23PjlFCO/9sacflelG8lsp7vNHhAxFeHptDMAksEYzg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -637,6 +665,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.13.tgz",
       "integrity": "sha512-BSsP71GTNaqWRcvkbWuIVH+zK7b3TSNebbhDkFK0fVaUTzHuKMS/mgY4hDZIEVt7Rf5FjadAYtsujHN9w0iSYA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -652,6 +681,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.13.tgz",
       "integrity": "sha512-WEl2tPVYwzYL8OKme6Go2xqiWgKsgxlMwyHabdAU4tXaRwOCnOI7v4021gCcBb9zn/oWwguHuKHmK30Fw2Z/PA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -664,6 +694,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.13.tgz",
       "integrity": "sha512-qt9WKq8vWrcjySa9DyQ0x/RBMHQeiVjdVSY1SJsMjssPUf0pS74qorcuAkGi89biN3YoGUgPkpqECnAWnYwgGA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -676,6 +707,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.13.tgz",
       "integrity": "sha512-5/N3yJggbWQTlGZHQYJPmQXEwR52qaXjEzkp1yRBbtdaekXE3BG/suo0fqeoV/csf8ooI78sJzYmIrxNoWVtgQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -688,6 +720,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.13.tgz",
       "integrity": "sha512-2rZmTdFbT/cF9lEZIkXCYO0TsT114Q27AX5IAo0Sju6jVQbvIk1dFUTnwLDadTo8wkJlFzGqMQ24Cs8cHWOliA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -700,6 +733,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.13.tgz",
       "integrity": "sha512-EmcgAA74FTc5u7Z+hUO/sRjWwfPPLuOQP5O64x5g4j0T12Bd29IgsYZxoutZo/rb3579+JNa/3wsSEmyVv1EpA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -713,6 +747,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.13.tgz",
       "integrity": "sha512-A1XKfGQD0iDdIiKqFYi8nZMv4dDVYdxbrmgR7y/CzUHhSYdcmoljLIIsZZM3Iks/Wa353W3vtvkWLuDbQbch1w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -725,6 +760,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.13.tgz",
       "integrity": "sha512-xFMrIn7czEZbdbMzZWuaZFnlLGJDVJ82y5vlsKsXRTG2kcxRsMPXvZRWHV57nSs1YFsNqXSbrC8B98n0E32njQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -737,6 +773,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.13.tgz",
       "integrity": "sha512-wLRYKVBXql2GAYgt6FkTnCfE+q5NomM7Dlh0oIPGAoMBWDyTx0eYutRK6PlUrRK2yMHuroAJCglICTbxqGzowQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -749,6 +786,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.13.tgz",
       "integrity": "sha512-3tfad0n9soRna4IfW9NzQdQ2Z3ijkmo21DREHbE6CGcMIxOSvfRdSvf1qQPApxjTSo8LTU4MCi/fidx/NZ0GqQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -761,6 +799,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.13.tgz",
       "integrity": "sha512-0m6i3p01PGRkGAK9r53hDYrkyMq+tlhLOIbsSTmZyh6HLshUKlTB7eXskF5OpVd5ZUHoltlNc6R+ggvKIzxRFw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -775,6 +814,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.13.tgz",
       "integrity": "sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -787,6 +827,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.13.tgz",
       "integrity": "sha512-Ev+Jjmj1nHYw897z9C3R9dYsPv7S2/nxdgfFb/h8hOwK0Ovd1k/+yYS46A0uj/JCKK0pQk8wOslYBkPwdnLorw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -802,6 +843,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.13.tgz",
       "integrity": "sha512-05POQaEJVucjTiSGMoH68ZiELc7QqpIpuQlZ2JBbhCV+WCbPFUBcGSmE7w4Jd0E2GvCho/NoMODLwgcVGQA97A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -815,6 +857,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.13.tgz",
       "integrity": "sha512-nmu5VSZ9hsB1JchTKhnnCY+paRBnwzSyK5fhkhtQHHoFD5ArBQ/5wU8y6tCr7k/GQhhGq1OrixsECeMjPoc8Zw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -829,6 +872,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.13.tgz",
       "integrity": "sha512-+3zArBH0OE3Rhjm4HyAokMsZlIq5gpQec33CncyoSwxtRBM2WAhUVmCUKuBo+Lr/2/4ISoY4BWpHKhMLDix6cA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -843,6 +887,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.13.tgz",
       "integrity": "sha512-CJLdqODEhEVs4MgWCxpWL5l95sCBlkuSLz65cxEm56X5akIsn4LOlwnKoSEZioYcZUBvHhCheH67AyPTudfnQQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/plugin-blit": "^0.16.13",
@@ -876,6 +921,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.13.tgz",
       "integrity": "sha512-8cGqINvbWJf1G0Her9zbq9I80roEX0A+U45xFby3tDWfzn+Zz8XKDF1Nv9VUwVx0N3zpcG1RPs9hfheG4Cq2kg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -889,6 +935,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.13.tgz",
       "integrity": "sha512-oJY8d9u95SwW00VPHuCNxPap6Q1+E/xM5QThb9Hu+P6EGuu6lIeLaNBMmFZyblwFbwrH+WBOZlvIzDhi4Dm/6Q==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "utif": "^2.0.1"
@@ -901,6 +948,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.13.tgz",
       "integrity": "sha512-mC0yVNUobFDjoYLg4hoUwzMKgNlxynzwt3cDXzumGvRJ7Kb8qQGOWJQjQFo5OxmGExqzPphkirdbBF88RVLBCg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/bmp": "^0.16.13",
@@ -918,6 +966,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.13.tgz",
       "integrity": "sha512-VyCpkZzFTHXtKgVO35iKN0sYR10psGpV6SkcSeV4oF7eSYlR8Bl6aQLCzVeFjvESF7mxTmIiI3/XrMobVrtxDA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "regenerator-runtime": "^0.13.3"
@@ -927,7 +976,8 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.56.0",
@@ -937,6 +987,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -950,6 +1001,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -963,6 +1015,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -976,6 +1029,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -989,6 +1043,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1002,6 +1057,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1015,6 +1071,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1028,6 +1085,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1041,6 +1099,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1054,6 +1113,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1067,6 +1127,7 @@
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1080,6 +1141,7 @@
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1093,6 +1155,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1106,6 +1169,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1119,6 +1183,7 @@
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1132,6 +1197,7 @@
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1145,6 +1211,7 @@
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1158,6 +1225,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1171,6 +1239,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1184,6 +1253,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -1197,6 +1267,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -1210,6 +1281,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1223,6 +1295,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1236,6 +1309,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1249,6 +1323,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1258,18 +1333,21 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
       "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1278,13 +1356,15 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.30",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1293,13 +1373,15 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.27",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1310,6 +1392,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
       "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "1.6.1",
         "@vitest/utils": "1.6.1",
@@ -1324,6 +1407,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
       "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "1.6.1",
         "p-limit": "^5.0.0",
@@ -1338,6 +1422,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
       "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "magic-string": "^0.30.5",
         "pathe": "^1.1.1",
@@ -1352,6 +1437,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
       "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tinyspy": "^2.2.0"
       },
@@ -1364,6 +1450,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
       "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "diff-sequences": "^29.6.3",
         "estree-walker": "^3.0.3",
@@ -1378,6 +1465,7 @@
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
       "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1386,6 +1474,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -1398,6 +1487,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1410,6 +1500,7 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -1421,6 +1512,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
       "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.16"
       },
@@ -1432,6 +1524,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1440,12 +1533,12 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1454,12 +1547,14 @@
     "node_modules/any-base": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==",
+      "license": "MIT"
     },
     "node_modules/app-path": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/app-path/-/app-path-4.0.0.tgz",
       "integrity": "sha512-mgBO9PZJ3MpbKbwFTljTi36ZKBvG5X/fkVR1F85ANsVcVllEb+C0LGNdJfGUm84GpC4xxgN6HFkmkMU8VEO4mA==",
+      "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0"
       },
@@ -1470,114 +1565,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/app-path/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/app-path/node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/app-path/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/app-path/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/app-path/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/app-path/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/app-path/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/app-path/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
-    "node_modules/app-path/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/array-range": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
-      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA=="
+      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA==",
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -1586,6 +1585,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1594,6 +1594,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -1618,13 +1619,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/better-sqlite3": {
       "version": "12.6.2",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
       "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -1637,6 +1640,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -1645,29 +1649,18 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/bl/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
-      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==",
+      "license": "MIT"
     },
     "node_modules/buffer": {
       "version": "5.7.1",
@@ -1687,6 +1680,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -1696,6 +1690,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -1705,6 +1700,7 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1713,6 +1709,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
       "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6"
       }
@@ -1722,6 +1719,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -1739,6 +1737,7 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -1751,6 +1750,7 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
       "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.2"
       },
@@ -1761,7 +1761,8 @@
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -1773,6 +1774,7 @@
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1781,6 +1783,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1792,6 +1795,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
       "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -1806,6 +1810,7 @@
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
       "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -1817,6 +1822,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
       "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+      "license": "MIT",
       "dependencies": {
         "slice-ansi": "^5.0.0",
         "string-width": "^5.0.0"
@@ -1828,21 +1834,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-truncate/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/cli-truncate/node_modules/slice-ansi": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
       "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.0.0",
         "is-fullwidth-code-point": "^4.0.0"
@@ -1858,6 +1854,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
       "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
+      "license": "MIT",
       "dependencies": {
         "convert-to-spaces": "^2.0.1"
       },
@@ -1869,6 +1866,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1879,18 +1877,21 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-to-spaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -1899,6 +1900,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1912,12 +1914,14 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/cycled": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/cycled/-/cycled-1.2.0.tgz",
       "integrity": "sha512-/BOOCEohSBflVHHtY/wUc1F6YDYPqyVs/A837gDoq4H1pm72nU/yChyGt91V4ML+MbbAmHs8uo2l1yJkkTIUdg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -1930,6 +1934,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1946,6 +1951,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/decode-gif/-/decode-gif-1.0.1.tgz",
       "integrity": "sha512-L0MT527mwlkil9TiN1xwnJXzUxCup55bUT91CPmQlc9zYejXJ8xp17d5EVnwM80JOIGImBUk1ptJQ+hDihyzwg==",
+      "license": "MIT",
       "dependencies": {
         "array-range": "^1.0.1",
         "omggif": "^1.0.10"
@@ -1958,6 +1964,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -1973,6 +1980,7 @@
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
       "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -1984,6 +1992,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
       }
@@ -1992,6 +2001,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.1.tgz",
       "integrity": "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -2003,6 +2013,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -2012,6 +2023,7 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -2025,6 +2037,7 @@
       "version": "17.2.3",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
       "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -2035,17 +2048,20 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -2056,6 +2072,7 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2095,6 +2112,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2104,6 +2122,7 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -2112,6 +2131,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2120,28 +2140,29 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
-      "dev": true,
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
-        "is-stream": "^3.0.0",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
         "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^3.0.0"
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
       },
       "engines": {
-        "node": ">=16.17"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
@@ -2156,6 +2177,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
       }
@@ -2164,6 +2186,7 @@
       "version": "16.5.4",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
       "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.2.4",
@@ -2179,7 +2202,8 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -2191,6 +2215,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -2203,7 +2228,8 @@
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2211,6 +2237,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2224,17 +2251,18 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2245,6 +2273,7 @@
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
       "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -2256,6 +2285,7 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
       "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
+      "license": "MIT",
       "dependencies": {
         "image-q": "^4.0.0",
         "omggif": "^1.0.10"
@@ -2264,12 +2294,14 @@
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/global": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "license": "MIT",
       "dependencies": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -2279,17 +2311,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=10.17.0"
       }
     },
     "node_modules/ieee754": {
@@ -2309,12 +2342,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/image-q": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
       "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "16.9.1"
       }
@@ -2322,12 +2357,14 @@
     "node_modules/image-q/node_modules/@types/node": {
       "version": "16.9.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "license": "MIT"
     },
     "node_modules/indent-string": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2338,17 +2375,20 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
     },
     "node_modules/ink": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/ink/-/ink-4.4.1.tgz",
       "integrity": "sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==",
+      "license": "MIT",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.1.3",
         "ansi-escapes": "^6.0.0",
@@ -2397,6 +2437,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
       "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
+      "license": "MIT",
       "dependencies": {
         "cli-spinners": "^2.7.0"
       },
@@ -2412,6 +2453,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-5.0.1.tgz",
       "integrity": "sha512-crnsYJalG4EhneOFnr/q+Kzw1RgmXI2KsBaLFE6mpiIKxAtJLUnvygOF2IUKO8z4nwkSkveGRBMd81RoYdRSag==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.2.0",
         "type-fest": "^3.6.1"
@@ -2428,6 +2470,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
       "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=14.16"
       },
@@ -2435,15 +2478,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/ink/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
     "node_modules/is-ci": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
       "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "license": "MIT",
       "dependencies": {
         "ci-info": "^3.2.0"
       },
@@ -2455,6 +2494,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2465,23 +2505,25 @@
     "node_modules/is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "license": "MIT"
     },
     "node_modules/is-lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-lower-case/-/is-lower-case-2.0.2.tgz",
       "integrity": "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
     },
     "node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2491,6 +2533,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-upper-case/-/is-upper-case-2.0.2.tgz",
       "integrity": "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
@@ -2498,12 +2541,14 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
     },
     "node_modules/iterm2-version": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/iterm2-version/-/iterm2-version-5.0.0.tgz",
       "integrity": "sha512-WdLXcMYvN3SXT6vEtuW78vnZs4pVWm2nBnb4VKjOPPXmdlR1xTHmBgqKacOzAe4RXOiY/V+0u/0zsU3LoGQoBg==",
+      "license": "MIT",
       "dependencies": {
         "app-path": "^4.0.0",
         "plist": "^3.0.2"
@@ -2519,6 +2564,7 @@
       "version": "0.16.13",
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.13.tgz",
       "integrity": "sha512-Bxz8q7V4rnCky9A0ktTNGA9SkNFVWRHodddI/DaAWZJzF7sVUlFYKQ60y9JGqrKpi48ECA/TnfMzzc5C70VByA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/custom": "^0.16.13",
@@ -2530,18 +2576,20 @@
     "node_modules/jpeg-js": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
-      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
     },
     "node_modules/load-bmfont": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
       "integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
+      "license": "MIT",
       "dependencies": {
         "buffer-equal": "0.0.1",
         "mime": "^1.3.4",
@@ -2558,6 +2606,7 @@
       "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
       "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
       "dependencies": {
         "centra": "^2.7.0"
       },
@@ -2570,6 +2619,7 @@
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
       "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mlly": "^1.7.3",
         "pkg-types": "^1.2.1"
@@ -2584,12 +2634,14 @@
     "node_modules/lodash": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/log-update": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
       "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^4.3.0",
         "cli-cursor": "^3.1.0",
@@ -2607,6 +2659,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -2621,6 +2674,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2629,6 +2683,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2643,6 +2698,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
       "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
       },
@@ -2653,42 +2709,23 @@
     "node_modules/log-update/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/log-update/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/log-update/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/log-update/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/log-update/node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
       "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -2697,15 +2734,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/log-update/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
     "node_modules/log-update/node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
       "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "astral-regex": "^2.0.0",
@@ -2722,6 +2755,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2735,6 +2769,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2746,6 +2781,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -2757,6 +2793,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2770,6 +2807,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -2777,16 +2815,12 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/loose-envify/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
       "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
@@ -2796,6 +2830,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -2803,12 +2838,14 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -2817,21 +2854,19 @@
       }
     },
     "node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -2843,6 +2878,7 @@
       "version": "2.19.2",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
       "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "license": "MIT",
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
@@ -2851,6 +2887,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2859,6 +2896,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -2869,13 +2907,15 @@
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
       "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.15.0",
         "pathe": "^2.0.3",
@@ -2887,13 +2927,15 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2906,6 +2948,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2916,12 +2959,14 @@
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
     },
     "node_modules/node-abi": {
       "version": "3.87.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
       "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -2930,55 +2975,42 @@
       }
     },
     "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
-      "dev": true,
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "license": "MIT",
       "dependencies": {
-        "path-key": "^4.0.0"
+        "path-key": "^3.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/omggif": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
-      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw==",
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/onetime": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
-      "dev": true,
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
       "dependencies": {
-        "mimic-fn": "^4.0.0"
+        "mimic-fn": "^2.1.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2989,6 +3021,7 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
       "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -3002,22 +3035,26 @@
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse-bmfont-ascii": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
+      "license": "MIT"
     },
     "node_modules/parse-bmfont-binary": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
+      "license": "MIT"
     },
     "node_modules/parse-bmfont-xml": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
       "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "license": "MIT",
       "dependencies": {
         "xml-parse-from-string": "^1.0.0",
         "xml2js": "^0.5.0"
@@ -3026,12 +3063,14 @@
     "node_modules/parse-headers": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
-      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
     },
     "node_modules/patch-console": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -3040,6 +3079,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3048,13 +3088,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -3063,6 +3105,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
       "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -3075,18 +3118,21 @@
       "version": "2.9.3",
       "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
       "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pixelmatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
       "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
+      "license": "ISC",
       "dependencies": {
         "pngjs": "^3.0.0"
       },
@@ -3099,6 +3145,7 @@
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
       "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
@@ -3109,12 +3156,14 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
       "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.5.1",
@@ -3128,6 +3177,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
       "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
       }
@@ -3151,6 +3201,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3164,6 +3215,7 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -3190,6 +3242,7 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -3199,10 +3252,24 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -3211,6 +3278,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -3220,6 +3288,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -3234,6 +3303,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3245,12 +3315,14 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-reconciler": {
       "version": "0.29.2",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3263,21 +3335,36 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">= 6"
       }
     },
-    "node_modules/readable-stream/node_modules/buffer": {
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
@@ -3295,35 +3382,39 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
-      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
       "dependencies": {
-        "readable-stream": "^4.7.0"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT"
     },
     "node_modules/render-gif": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/render-gif/-/render-gif-2.0.4.tgz",
       "integrity": "sha512-l5X7EwbEvdflnvVAzjL7njizwZN8ATqJ0rdaQ5WwMJ55vyWXIXIUE9Ut7W6hm+KE+HMYn5C0a+7t0B6JjGfxQA==",
+      "license": "MIT",
       "dependencies": {
         "cycled": "^1.2.0",
         "decode-gif": "^1.0.1",
@@ -3338,6 +3429,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.14.0.tgz",
       "integrity": "sha512-5RkX6tSS7K3K3xNEb2ygPuvyL9whjanhoaB/WmmXlJS6ub4DjTqrapu8j4qnIWmO4YYtFeTbDTXV6v9P1yMA5A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0",
@@ -3351,6 +3443,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.14.0.tgz",
       "integrity": "sha512-S62FcKdtLtj3yWsGfJRdFXSutjvHg7aQNiFogMbwq19RP4XJWqS2nOphu7ScB8KrSlyy5nPF2hkWNhLRLyD82w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0",
@@ -3369,6 +3462,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.14.0.tgz",
       "integrity": "sha512-kQJMeH87+kWJdVw8F9GQhtsageqqxrvzg7yyOw3Tx/s7v5RToe8RnKyMM+kVtBJtNAG+Xyv/z01uYQ2jiZ3GwA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/core": "^0.14.0"
@@ -3378,6 +3472,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.14.0.tgz",
       "integrity": "sha512-DHjoOSfCaCz72+oGGEh8qH0zE6pUBaBxPxxmpYJjkNyDZP7RkbBkZJScIYeQ7BmJxmGN4/dZn+MxamoQlr+UYg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0",
@@ -3392,6 +3487,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.14.0.tgz",
       "integrity": "sha512-561neGbr+87S/YVQYnZSTyjWTHBm9F6F1obYHiyU3wVmF+1CLbxY3FQzt4YolwyQHIBv36Bo0PY2KkkU8BEeeQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0",
@@ -3405,6 +3501,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.14.0.tgz",
       "integrity": "sha512-YoYOrnVHeX3InfgbJawAU601iTZMwEBZkyqcP1V/S33Qnz9uzH1Uj1NtC6fNgWzvX6I4XbCWwtr4RrGFb5CFrw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3417,6 +3514,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.14.0.tgz",
       "integrity": "sha512-9WhZcofLrT0hgI7t0chf7iBQZib//0gJh9WcQMUt5+Q1Bk04dWs8vTgLNj61GBqZXgHSPzE4OpCrrLDBG8zlhQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3429,6 +3527,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.14.0.tgz",
       "integrity": "sha512-o5L+wf6QA44tvTum5HeLyLSc5eVfIUd5ZDVi5iRfO4o6GT/zux9AxuTSkKwnjhsG8bn1dDmywAOQGAx7BjrQVA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3441,6 +3540,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.14.0.tgz",
       "integrity": "sha512-JJz512SAILYV0M5LzBb9sbOm/XEj2fGElMiHAxb7aLI6jx+n0agxtHpfpV/AePTLm1vzzDxx6AJxXbKv355hBQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0",
@@ -3454,6 +3554,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.14.0.tgz",
       "integrity": "sha512-RX2q233lGyaxiMY6kAgnm9ScmEkNSof0hdlaJAVDS1OgXphGAYAeSIAwzESZN4x3ORaWvkFefeVH9O9/698Evg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3469,6 +3570,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.14.0.tgz",
       "integrity": "sha512-0P/5XhzWES4uMdvbi3beUgfvhn4YuQ/ny8ijs5kkYIw6K8mHcl820HahuGpwWMx56DJLHRl1hFhJwo9CeTRJtQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3484,6 +3586,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.14.0.tgz",
       "integrity": "sha512-Ojtih+XIe6/XSGtpWtbAXBozhCdsDMmy+THUJAGu2x7ZgKrMS0JotN+vN2YC3nwDpYkM+yOJImQeptSfZb2Sug==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3496,6 +3599,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.14.0.tgz",
       "integrity": "sha512-c75uQUzMgrHa8vegkgUvgRL/PRvD7paFbFJvzW0Ugs8Wl+CDMGIPYQ3j7IVaQkIS+cAxv+NJ3TIRBQyBrfVEOg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3508,6 +3612,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.14.0.tgz",
       "integrity": "sha512-g8SJqFLyYexXQQsoh4dc1VP87TwyOgeTElBcxSXX2LaaMZezypmxQfLTzOFzZoK8m39NuaoH21Ou1Ftsq7LzVQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3520,6 +3625,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.14.0.tgz",
       "integrity": "sha512-BFfUZ64EikCaABhCA6mR3bsltWhPpS321jpeIQfJyrILdpFsZ/OccNwCgpW1XlbldDHIoNtXTDGn3E+vCE7vDg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3532,6 +3638,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.14.0.tgz",
       "integrity": "sha512-WtL1hj6ryqHhApih+9qZQYA6Ye8a4HAmdTzLbYdTMrrrSUgIzFdiZsD0WeDHpgS/+QMsWwF+NFmTZmxNWqKfXw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3545,6 +3652,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.14.0.tgz",
       "integrity": "sha512-uaLwQ0XAQoydDlF9tlfc7iD9drYPriFe+jgYnWm8fbw5cN+eOIcnneEX9XCOOzwgLPkNCxGox6Kxjn8zY6GxtQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3557,6 +3665,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.14.0.tgz",
       "integrity": "sha512-UaQW9X9vx8orQXYSjT5VcITkJPwDaHwrBbxxPoDG+F/Zgv4oV9fP+udDD6qmkgI9taU+44Fy+zm/J/gGcMWrdg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3569,6 +3678,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.14.0.tgz",
       "integrity": "sha512-tdiGM69OBaKtSPfYSQeflzFhEpoRZ+BvKfDEoivyTjauynbjpRiwB1CaiS8En1INTDwzLXTT0Be9SpI3LkJoEA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3581,6 +3691,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.14.0.tgz",
       "integrity": "sha512-AfY8sqlsbbdVwFGcyIPy5JH/7fnBzlmuweb+Qtx2vn29okq6+HelLjw2b+VT2btgGUmWWHGEHd86oRGSoWGyEQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3593,6 +3704,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.14.0.tgz",
       "integrity": "sha512-MwP3sH+VS5AhhSTXk7pui+tEJFsxnTKFY3TraFJb8WFbA2Vo2qsRCZseEGwpTLhENB7p/JSsLvWoSSbpmxhFAQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0",
@@ -3607,6 +3719,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.14.0.tgz",
       "integrity": "sha512-qFeMOyXE/Bk6QXN0GQo89+CB2dQcXqoxUcDb2Ah8wdYlKqpi53skABkgVy5pW3EpiprDnzNDboMltdvDslNgLQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3619,6 +3732,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.14.0.tgz",
       "integrity": "sha512-aGaicts44bvpTcq5Dtf93/8TZFu5pMo/61lWWnYmwJJU1RqtQlxbCLEQpMyRhKDNSfPbuP8nyGmaqXlM/82J0Q==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3634,6 +3748,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.14.0.tgz",
       "integrity": "sha512-ZcJk0hxY5ZKZDDwflqQNHEGRblgaR+piePZm7dPwPUOSeYEH31P0AwZ1ziceR74zd8N80M0TMft+e3Td6KGBHw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3647,6 +3762,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.14.0.tgz",
       "integrity": "sha512-p2igcEr/iGrLiTu0YePNHyby0WYAXM14c5cECZIVnq/UTOOIQ7xIcWZJ1lRbAEPxVVXPN1UibhZAbr3HAb5BjQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3661,6 +3777,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.14.0.tgz",
       "integrity": "sha512-N4BlDgm/FoOMV/DQM2rSpzsgqAzkP0DXkWZoqaQrlRxQBo4zizQLzhEL00T/YCCMKnddzgEhnByaocgaaa0fKw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0"
@@ -3675,6 +3792,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.14.0.tgz",
       "integrity": "sha512-vDO3XT/YQlFlFLq5TqNjQkISqjBHT8VMhpWhAfJVwuXIpilxz5Glu4IDLK6jp4IjPR6Yg2WO8TmRY/HI8vLrOw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/plugin-blit": "^0.14.0",
@@ -3708,6 +3826,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.14.0.tgz",
       "integrity": "sha512-0RV/mEIDOrPCcNfXSPmPBqqSZYwGADNRVUTyMt47RuZh7sugbYdv/uvKmQSiqRdR0L1sfbCBMWUEa5G/8MSbdA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.14.0",
@@ -3721,6 +3840,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.14.0.tgz",
       "integrity": "sha512-zBYDTlutc7j88G/7FBCn3kmQwWr0rmm1e0FKB4C3uJ5oYfT8645lftUsvosKVUEfkdmOaMAnhrf4ekaHcb5gQw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "utif": "^2.0.1"
@@ -3733,6 +3853,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.14.0.tgz",
       "integrity": "sha512-hx3cXAW1KZm+b+XCrY3LXtdWy2U+hNtq0rPyJ7NuXCjU7lZR3vIkpz1DLJ3yDdS70hTi5QDXY3Cd9kd6DtloHQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/bmp": "^0.14.0",
@@ -3750,6 +3871,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.14.0.tgz",
       "integrity": "sha512-MY5KFYUru0y74IsgM/9asDwb3ERxWxXEu3CRCZEvE7DtT86y1bR1XgtlSliMrptjz4qbivNGMQSvUBpEFJDp1A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "regenerator-runtime": "^0.13.3"
@@ -3759,6 +3881,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-9.0.0.tgz",
       "integrity": "sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3767,6 +3890,7 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.14.0.tgz",
       "integrity": "sha512-8BXU+J8+SPmwwyq9ELihpSV4dWPTiOKBWCEgtkbnxxAVMjXdf3yGmyaLSshBfXc8sP/JQ9OZj5R8nZzz2wPXgA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/custom": "^0.14.0",
@@ -3780,6 +3904,7 @@
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -3788,6 +3913,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -3799,38 +3925,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/restore-cursor/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/restore-cursor/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
-    },
     "node_modules/rollup": {
       "version": "4.56.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.56.0.tgz",
       "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3887,12 +3987,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
       }
@@ -3901,6 +4003,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -3909,6 +4012,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3920,6 +4024,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -3931,6 +4036,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3939,19 +4045,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -3970,7 +4071,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -3990,6 +4092,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -4000,6 +4103,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-6.0.0.tgz",
       "integrity": "sha512-6bn4hRfkTvDfUoEQYkERg0BVF1D0vrX9HEkMl08uDiNWvVvjylLHvZFZWkDo6wjT8tUctbYl1nCOuE66ZTaUtA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "is-fullwidth-code-point": "^4.0.0"
@@ -4011,22 +4115,12 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
-    "node_modules/slice-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4035,6 +4129,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -4046,18 +4141,21 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -4066,6 +4164,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -4082,6 +4181,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -4093,21 +4193,19 @@
       }
     },
     "node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4117,6 +4215,7 @@
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
       "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
       },
@@ -4124,10 +4223,18 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strtok3": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
       "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -4144,6 +4251,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4155,6 +4263,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -4166,6 +4275,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -4177,23 +4287,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/term-img": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/term-img/-/term-img-6.0.0.tgz",
       "integrity": "sha512-R4c+XtUiN/9lMlw+wldmxjPO/xlG3sIE79tcnE3A8CtcYMTDiOgAKy/EhroI+rmjB3cVyCkYSzTPBBjPsC7YdQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^5.0.0",
         "iterm2-version": "^5.0.0"
@@ -4209,6 +4307,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
       "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^1.0.2"
       },
@@ -4223,6 +4322,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
       "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -4234,6 +4334,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/terminal-image/-/terminal-image-2.0.0.tgz",
       "integrity": "sha512-25HcdYC79g0rPxk9o7RIp3i0/ebP+viR6vj2Fsxh1a9pE6o7PfXz4HlmdYLGsQsmBeQNK88BA2UJo4IzBRfzaA==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.1",
         "jimp": "^0.16.1",
@@ -4252,6 +4353,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4266,6 +4368,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4280,24 +4383,28 @@
     "node_modules/timm": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
-      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
+      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
-      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinypool": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
       "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4307,6 +4414,7 @@
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
       "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4315,6 +4423,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
       "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -4330,13 +4439,15 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4355,6 +4466,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -4367,6 +4479,7 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
       "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -4375,6 +4488,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.12.0.tgz",
       "integrity": "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -4387,6 +4501,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4399,6 +4514,7 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-5.1.3.tgz",
       "integrity": "sha512-r+pAcYtWdN8tKlYZPwiiHNA2QPjXnI02NrW5Sf2cVM3TRtuQ3V9EKKwOxqwaQ0krsaEXk/CbN90I5erBuf84Vg==",
+      "license": "Apache-2.0",
       "bin": {
         "typescript-language-server": "lib/cli.mjs"
       },
@@ -4410,18 +4526,21 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utif": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
       "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
+      "license": "MIT",
       "dependencies": {
         "pako": "^1.0.5"
       }
@@ -4429,13 +4548,15 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4495,6 +4616,7 @@
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
       "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
@@ -4520,6 +4642,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -4536,6 +4659,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4552,6 +4676,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4568,6 +4693,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -4584,6 +4710,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4600,6 +4727,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -4616,6 +4744,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -4632,6 +4761,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -4648,6 +4778,7 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4664,6 +4795,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4680,6 +4812,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4696,6 +4829,7 @@
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4712,6 +4846,7 @@
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4728,6 +4863,7 @@
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4744,6 +4880,7 @@
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4760,6 +4897,7 @@
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4776,6 +4914,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -4792,6 +4931,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -4808,6 +4948,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -4824,6 +4965,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -4840,6 +4982,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4856,6 +4999,7 @@
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4872,6 +5016,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -4886,6 +5031,7 @@
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4923,6 +5069,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",
@@ -4983,10 +5130,155 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/vitest/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/vitest/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vitest/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5002,6 +5294,7 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -5017,6 +5310,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
       "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "license": "MIT",
       "dependencies": {
         "string-width": "^5.0.1"
       },
@@ -5031,6 +5325,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -5043,26 +5338,17 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5083,6 +5369,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
       "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+      "license": "MIT",
       "dependencies": {
         "global": "~4.4.0",
         "is-function": "^1.0.1",
@@ -5093,12 +5380,14 @@
     "node_modules/xml-parse-from-string": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
+      "license": "MIT"
     },
     "node_modules/xml2js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
       "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -5111,6 +5400,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       }
@@ -5119,6 +5409,7 @@
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
       "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.0"
       }
@@ -5127,6 +5418,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4"
       }
@@ -5136,6 +5428,7 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
       "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -5146,12 +5439,14 @@
     "node_modules/yoga-wasm-web": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/yoga-wasm-web/-/yoga-wasm-web-0.3.3.tgz",
-      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA=="
+      "integrity": "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/attocode/package.json
+++ b/attocode/package.json
@@ -1,16 +1,24 @@
 {
   "name": "attocode",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Standalone production coding agent extracted from first-principles-agent",
   "type": "module",
   "main": "dist/src/main.js",
+  "bin": {
+    "attocode": "./dist/src/main.js"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/main.ts",
     "start": "tsx src/main.ts",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "better-sqlite3": "^12.6.2",

--- a/attocode/src/core/index.ts
+++ b/attocode/src/core/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Core Module
+ *
+ * Unified exports for the core infrastructure layer including:
+ * - Op/Event Protocol: Typed message passing between UI and agent
+ * - Queue System: Bounded submission queue and unbounded event queue
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   // Protocol types
+ *   type Operation,
+ *   type AgentEvent,
+ *   type Submission,
+ *   type EventEnvelope,
+ *   // Validation
+ *   OperationSchema,
+ *   AgentEventSchema,
+ *   // Type guards
+ *   isUserTurn,
+ *   isAgentMessage,
+ *   // Queues
+ *   SubmissionQueue,
+ *   EventQueue,
+ *   AtomicCounter,
+ * } from './core/index.js';
+ * ```
+ */
+
+// Protocol types and validation
+export * from './protocol/index.js';
+
+// Queue system
+export * from './queues/index.js';

--- a/attocode/src/core/protocol/bridge.ts
+++ b/attocode/src/core/protocol/bridge.ts
@@ -1,0 +1,216 @@
+/**
+ * Protocol Bridge
+ *
+ * Connects UI layer to Agent layer via queue-based communication.
+ * Maps internal agent events to protocol events with submission correlation.
+ *
+ * Architecture:
+ * ```
+ * UI (REPL/TUI)                    Agent Core
+ *      |                                |
+ *      └─── Op ──► SubmissionQueue ───► handleOperation()
+ *                       (64)                  |
+ *                                            |
+ *      ◄── Event ─ EventQueue ◄───────── emit()
+ *                 (unbounded)
+ * ```
+ */
+
+import type { AgentEvent, Submission, SubmissionId } from './types.js';
+import type { SubmissionQueue } from '../queues/submission-queue.js';
+import type { EventQueue } from '../queues/event-queue.js';
+
+/**
+ * Handler for incoming operations from the UI.
+ */
+export type OperationHandler = (submission: Submission) => Promise<void>;
+
+/**
+ * Protocol bridge interface for UI/Agent communication.
+ */
+export interface IProtocolBridge {
+  /**
+   * Starts the bridge, consuming from the submission queue.
+   * @param submissionQueue - Queue for incoming operations from UI
+   * @param eventQueue - Queue for outgoing events to UI
+   */
+  start(submissionQueue: SubmissionQueue, eventQueue: EventQueue): void;
+
+  /**
+   * Stops the bridge and cleans up resources.
+   */
+  stop(): void;
+
+  /**
+   * Registers a handler for incoming operations.
+   * Only one handler is supported - subsequent calls replace the previous handler.
+   * @param handler - The handler function for operations
+   */
+  onOperation(handler: OperationHandler): void;
+
+  /**
+   * Emits an event to the UI, correlated with a submission.
+   * @param submissionId - The submission this event relates to
+   * @param event - The event to emit
+   */
+  emit(submissionId: SubmissionId, event: AgentEvent): void;
+
+  /**
+   * Returns true if the bridge is currently running.
+   */
+  isRunning(): boolean;
+
+  /**
+   * Returns a promise that resolves when the bridge stops.
+   * Useful for testing or waiting for graceful shutdown.
+   */
+  waitForStop(): Promise<void>;
+}
+
+/**
+ * Protocol bridge implementation.
+ *
+ * Manages the async loop that consumes from the submission queue
+ * and dispatches to the registered operation handler.
+ */
+export class ProtocolBridge implements IProtocolBridge {
+  private submissionQueue: SubmissionQueue | null = null;
+  private eventQueue: EventQueue | null = null;
+  private operationHandler: OperationHandler | null = null;
+  private running = false;
+  private consumePromise: Promise<void> | null = null;
+
+  /**
+   * Starts the bridge, consuming from the submission queue.
+   * @throws Error if the bridge is already running
+   */
+  start(submissionQueue: SubmissionQueue, eventQueue: EventQueue): void {
+    if (this.running) {
+      throw new Error('ProtocolBridge is already running');
+    }
+
+    this.submissionQueue = submissionQueue;
+    this.eventQueue = eventQueue;
+    this.running = true;
+
+    // Start the consume loop
+    this.consumePromise = this.consumeLoop();
+  }
+
+  /**
+   * Stops the bridge and cleans up resources.
+   * Waits for the current operation to complete before stopping.
+   */
+  stop(): void {
+    this.running = false;
+
+    // The consume loop will exit on the next iteration
+    // We don't close the queues - that's the caller's responsibility
+  }
+
+  /**
+   * Registers a handler for incoming operations.
+   * Only one handler is supported - subsequent calls replace the previous handler.
+   */
+  onOperation(handler: OperationHandler): void {
+    this.operationHandler = handler;
+  }
+
+  /**
+   * Emits an event to the UI, correlated with a submission.
+   * @throws Error if the bridge is not started
+   */
+  emit(submissionId: SubmissionId, event: AgentEvent): void {
+    if (!this.eventQueue) {
+      throw new Error('ProtocolBridge not started - cannot emit events');
+    }
+
+    this.eventQueue.emit(submissionId, event);
+  }
+
+  /**
+   * Returns true if the bridge is currently running.
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Returns a promise that resolves when the bridge stops.
+   * Useful for testing or waiting for graceful shutdown.
+   */
+  async waitForStop(): Promise<void> {
+    if (this.consumePromise) {
+      await this.consumePromise;
+    }
+  }
+
+  /**
+   * The main consume loop that processes submissions.
+   * Runs until stop() is called or the queue is closed.
+   */
+  private async consumeLoop(): Promise<void> {
+    if (!this.submissionQueue) {
+      return;
+    }
+
+    while (this.running) {
+      try {
+        // Take the next submission (blocks if empty)
+        const submission = await this.submissionQueue.take();
+
+        // null means the queue was closed
+        if (submission === null) {
+          this.running = false;
+          break;
+        }
+
+        // Dispatch to handler if one is registered
+        if (this.operationHandler) {
+          try {
+            await this.operationHandler(submission);
+          } catch (error) {
+            // Log handler errors but don't crash the bridge
+            // The handler is responsible for emitting error events
+            this.handleOperationError(submission, error);
+          }
+        }
+      } catch (error) {
+        // Queue errors (closed, etc.) - stop the loop
+        if (this.running) {
+          this.running = false;
+        }
+        break;
+      }
+    }
+  }
+
+  /**
+   * Handles errors from the operation handler.
+   * Emits an error event to the UI.
+   */
+  private handleOperationError(submission: Submission, error: unknown): void {
+    // Only emit error event if we have an event queue
+    if (!this.eventQueue) {
+      return;
+    }
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorStack = error instanceof Error ? error.stack : undefined;
+
+    this.eventQueue.emit(submission.id, {
+      type: 'error',
+      code: 'OPERATION_HANDLER_ERROR',
+      message: `Operation handler failed: ${errorMessage}`,
+      recoverable: true,
+      stack: errorStack,
+    });
+  }
+}
+
+/**
+ * Creates a new ProtocolBridge instance.
+ */
+export function createProtocolBridge(): ProtocolBridge {
+  return new ProtocolBridge();
+}

--- a/attocode/src/core/protocol/index.ts
+++ b/attocode/src/core/protocol/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Op/Event Protocol Module
+ *
+ * Codex-inspired protocol layer for clean UI/agent separation.
+ * Re-exports all types, schemas, and guards from the protocol module.
+ */
+
+export * from './types.js';

--- a/attocode/src/core/protocol/types.ts
+++ b/attocode/src/core/protocol/types.ts
@@ -1,0 +1,416 @@
+/**
+ * Op/Event Protocol Types
+ *
+ * Codex-inspired protocol layer for clean UI/agent separation.
+ * Operations flow from client to agent, Events flow from agent to client.
+ */
+
+import { z } from 'zod';
+import type { TokenUsage } from '../../types.js';
+
+// =============================================================================
+// BASIC TYPES
+// =============================================================================
+
+/**
+ * Unique identifier for a submission (operation sent to agent).
+ */
+export type SubmissionId = string;
+
+/**
+ * Risk level for tool execution.
+ */
+export type RiskLevel = 'safe' | 'moderate' | 'dangerous';
+
+/**
+ * Attachment for user messages (images, files).
+ */
+export interface Attachment {
+  type: 'image' | 'file';
+  path?: string;
+  data?: string; // base64 encoded
+  mimeType?: string;
+}
+
+// =============================================================================
+// OPERATIONS (Client -> Agent)
+// =============================================================================
+
+/**
+ * User sends a message/turn to the agent.
+ */
+export interface OpUserTurn {
+  type: 'user_turn';
+  content: string;
+  attachments?: Attachment[];
+}
+
+/**
+ * User requests to interrupt the current operation.
+ */
+export interface OpInterrupt {
+  type: 'interrupt';
+  reason?: string;
+}
+
+/**
+ * User responds to an execution approval request.
+ */
+export interface OpExecApproval {
+  type: 'exec_approval';
+  toolCallId: string;
+  approved: boolean;
+  /** If true, auto-approve similar operations in this session */
+  persistent?: boolean;
+}
+
+/**
+ * User responds to a context compaction approval request.
+ */
+export interface OpCompactApproval {
+  type: 'compact_approval';
+  approved: boolean;
+  strategy?: 'summarize' | 'truncate' | 'hybrid';
+}
+
+/**
+ * User configures session settings.
+ */
+export interface OpConfigureSession {
+  type: 'configure_session';
+  config: {
+    model?: string;
+    maxIterations?: number;
+    autoCompact?: boolean;
+    approvalPolicy?: 'never' | 'on_request' | 'always';
+  };
+}
+
+/**
+ * User switches to a different session.
+ */
+export interface OpSwitchSession {
+  type: 'switch_session';
+  sessionId: string;
+}
+
+/**
+ * User forks the current session.
+ */
+export interface OpForkSession {
+  type: 'fork_session';
+  name?: string;
+}
+
+/**
+ * Union of all operation types.
+ */
+export type Operation =
+  | OpUserTurn
+  | OpInterrupt
+  | OpExecApproval
+  | OpCompactApproval
+  | OpConfigureSession
+  | OpSwitchSession
+  | OpForkSession;
+
+/**
+ * A submission wraps an operation with metadata.
+ */
+export interface Submission {
+  id: SubmissionId;
+  op: Operation;
+  timestamp: number;
+  /** Optional correlation ID for request/response tracking */
+  correlationId?: string;
+}
+
+// =============================================================================
+// EVENTS (Agent -> Client)
+// =============================================================================
+
+/**
+ * Agent sends a message (streaming or complete).
+ */
+export interface EventAgentMessage {
+  type: 'agent_message';
+  content: string;
+  /** True when message is complete (no more chunks) */
+  done: boolean;
+  model?: string;
+}
+
+/**
+ * Agent requests approval to execute a tool.
+ */
+export interface EventExecApprovalRequest {
+  type: 'exec_approval_request';
+  toolCallId: string;
+  toolName: string;
+  toolArgs: Record<string, unknown>;
+  risk: RiskLevel;
+  description?: string;
+}
+
+/**
+ * Agent requests approval to compact context.
+ */
+export interface EventCompactApprovalRequest {
+  type: 'compact_approval_request';
+  currentTokens: number;
+  maxTokens: number;
+  proposedStrategy: 'summarize' | 'truncate' | 'hybrid';
+  estimatedTokensAfter: number;
+  summaryPreview?: string;
+}
+
+/**
+ * Agent signals task completion.
+ */
+export interface EventTaskComplete {
+  type: 'task_complete';
+  usage: TokenUsage;
+  status: 'success' | 'interrupted' | 'error';
+  durationMs: number;
+}
+
+/**
+ * Streaming output from tool execution (stdout/stderr).
+ */
+export interface EventExecOutput {
+  type: 'exec_output';
+  toolCallId: string;
+  stream: 'stdout' | 'stderr';
+  data: string;
+}
+
+/**
+ * Tool execution result.
+ */
+export interface EventToolResult {
+  type: 'tool_result';
+  toolCallId: string;
+  toolName: string;
+  result: unknown;
+  error?: string;
+  durationMs: number;
+}
+
+/**
+ * Error event.
+ */
+export interface EventError {
+  type: 'error';
+  code: string;
+  message: string;
+  recoverable: boolean;
+  stack?: string;
+}
+
+/**
+ * Token count update.
+ */
+export interface EventTokenCount {
+  type: 'token_count';
+  input: number;
+  output: number;
+  cached?: number;
+  total: number;
+}
+
+/**
+ * Session lifecycle events.
+ */
+export interface EventSession {
+  type: 'session';
+  action: 'created' | 'loaded' | 'switched' | 'forked' | 'compacted';
+  sessionId: string;
+  parentSessionId?: string;
+  name?: string;
+}
+
+/**
+ * Union of all event types.
+ */
+export type AgentEvent =
+  | EventAgentMessage
+  | EventExecApprovalRequest
+  | EventCompactApprovalRequest
+  | EventTaskComplete
+  | EventExecOutput
+  | EventToolResult
+  | EventError
+  | EventTokenCount
+  | EventSession;
+
+/**
+ * An event envelope wraps an event with metadata.
+ */
+export interface EventEnvelope {
+  submissionId: SubmissionId;
+  event: AgentEvent;
+  timestamp: number;
+}
+
+// =============================================================================
+// ZOD SCHEMAS (Runtime Validation)
+// =============================================================================
+
+/**
+ * Schema for Attachment.
+ */
+export const AttachmentSchema = z.object({
+  type: z.enum(['image', 'file']),
+  path: z.string().optional(),
+  data: z.string().optional(),
+  mimeType: z.string().optional(),
+});
+
+/**
+ * Schema for OpUserTurn - content must be non-empty.
+ */
+export const OpUserTurnSchema = z.object({
+  type: z.literal('user_turn'),
+  content: z.string().min(1, 'Content must not be empty'),
+  attachments: z.array(AttachmentSchema).optional(),
+});
+
+/**
+ * Schema for OpInterrupt.
+ */
+export const OpInterruptSchema = z.object({
+  type: z.literal('interrupt'),
+  reason: z.string().optional(),
+});
+
+/**
+ * Schema for OpExecApproval.
+ */
+export const OpExecApprovalSchema = z.object({
+  type: z.literal('exec_approval'),
+  toolCallId: z.string(),
+  approved: z.boolean(),
+  persistent: z.boolean().optional(),
+});
+
+/**
+ * Schema for OpCompactApproval.
+ */
+export const OpCompactApprovalSchema = z.object({
+  type: z.literal('compact_approval'),
+  approved: z.boolean(),
+  strategy: z.enum(['summarize', 'truncate', 'hybrid']).optional(),
+});
+
+/**
+ * Schema for OpConfigureSession.
+ */
+export const OpConfigureSessionSchema = z.object({
+  type: z.literal('configure_session'),
+  config: z.object({
+    model: z.string().optional(),
+    maxIterations: z.number().int().positive().optional(),
+    autoCompact: z.boolean().optional(),
+    approvalPolicy: z.enum(['never', 'on_request', 'always']).optional(),
+  }),
+});
+
+/**
+ * Schema for OpSwitchSession.
+ */
+export const OpSwitchSessionSchema = z.object({
+  type: z.literal('switch_session'),
+  sessionId: z.string(),
+});
+
+/**
+ * Schema for OpForkSession.
+ */
+export const OpForkSessionSchema = z.object({
+  type: z.literal('fork_session'),
+  name: z.string().optional(),
+});
+
+/**
+ * Discriminated union schema for all operations.
+ */
+export const OperationSchema = z.discriminatedUnion('type', [
+  OpUserTurnSchema,
+  OpInterruptSchema,
+  OpExecApprovalSchema,
+  OpCompactApprovalSchema,
+  OpConfigureSessionSchema,
+  OpSwitchSessionSchema,
+  OpForkSessionSchema,
+]);
+
+// =============================================================================
+// TYPE GUARDS
+// =============================================================================
+
+// Operation type guards
+
+/**
+ * Type guard for OpUserTurn.
+ */
+export function isUserTurn(op: Operation): op is OpUserTurn {
+  return op.type === 'user_turn';
+}
+
+/**
+ * Type guard for OpInterrupt.
+ */
+export function isInterrupt(op: Operation): op is OpInterrupt {
+  return op.type === 'interrupt';
+}
+
+/**
+ * Type guard for OpExecApproval.
+ */
+export function isExecApproval(op: Operation): op is OpExecApproval {
+  return op.type === 'exec_approval';
+}
+
+/**
+ * Type guard for OpCompactApproval.
+ */
+export function isCompactApproval(op: Operation): op is OpCompactApproval {
+  return op.type === 'compact_approval';
+}
+
+// Event type guards
+
+/**
+ * Type guard for EventAgentMessage.
+ */
+export function isAgentMessage(event: AgentEvent): event is EventAgentMessage {
+  return event.type === 'agent_message';
+}
+
+/**
+ * Type guard for EventExecApprovalRequest.
+ */
+export function isExecApprovalRequest(event: AgentEvent): event is EventExecApprovalRequest {
+  return event.type === 'exec_approval_request';
+}
+
+/**
+ * Type guard for EventCompactApprovalRequest.
+ */
+export function isCompactApprovalRequest(event: AgentEvent): event is EventCompactApprovalRequest {
+  return event.type === 'compact_approval_request';
+}
+
+/**
+ * Type guard for EventTaskComplete.
+ */
+export function isTaskComplete(event: AgentEvent): event is EventTaskComplete {
+  return event.type === 'task_complete';
+}
+
+/**
+ * Type guard for EventError.
+ */
+export function isError(event: AgentEvent): event is EventError {
+  return event.type === 'error';
+}

--- a/attocode/src/core/queues/atomic-counter.ts
+++ b/attocode/src/core/queues/atomic-counter.ts
@@ -1,0 +1,50 @@
+/**
+ * Lock-free monotonic counter for generating unique submission identifiers.
+ * Uses bigint for virtually unlimited range without overflow concerns.
+ */
+export class AtomicCounter {
+  private counter: bigint;
+
+  /**
+   * Creates a new AtomicCounter instance.
+   * @param initial - Optional initial value (default: 0n)
+   */
+  constructor(initial: bigint = 0n) {
+    this.counter = initial;
+  }
+
+  /**
+   * Generates the next unique submission ID.
+   * Increments the internal counter and returns an ID in format `sub-{base36}`.
+   * @returns Unique string ID (e.g., 'sub-0', 'sub-1', 'sub-a', 'sub-1s')
+   */
+  next(): string {
+    const id = this.counter;
+    this.counter += 1n;
+    return `sub-${id.toString(36)}`;
+  }
+
+  /**
+   * Returns the current counter value without incrementing.
+   * Useful for inspection and debugging.
+   * @returns Current counter value as bigint
+   */
+  current(): bigint {
+    return this.counter;
+  }
+
+  /**
+   * Resets the counter to a specified value or zero.
+   * Primarily useful for testing scenarios.
+   * @param value - Optional value to reset to (default: 0n)
+   */
+  reset(value: bigint = 0n): void {
+    this.counter = value;
+  }
+}
+
+/**
+ * Global singleton counter instance for generating unique submission IDs
+ * across the application.
+ */
+export const globalCounter = new AtomicCounter();

--- a/attocode/src/core/queues/event-queue.ts
+++ b/attocode/src/core/queues/event-queue.ts
@@ -1,0 +1,272 @@
+/**
+ * Unbounded pub/sub event emitter for Agent to UI communication.
+ * Unlike SubmissionQueue, this never blocks the producer (agent).
+ * Uses fire-and-forget semantics with async dispatch.
+ */
+
+import type { AgentEvent, EventEnvelope, SubmissionId } from '../protocol/types.js';
+
+/**
+ * Generic event listener that receives all events.
+ */
+export type EventListener = (envelope: EventEnvelope) => void;
+
+/**
+ * Typed event listener that receives events of a specific type.
+ */
+export type TypedEventListener<T extends AgentEvent> = (
+  envelope: EventEnvelope & { event: T }
+) => void;
+
+/**
+ * Configuration for the EventQueue.
+ */
+export interface EventQueueConfig {
+  /** Maximum number of recent events to store (default: 100) */
+  maxRecentEvents?: number;
+}
+
+/**
+ * Statistics about the event queue for debugging.
+ */
+export interface EventQueueStats {
+  /** Number of global listeners */
+  globalListeners: number;
+  /** Number of typed listeners by event type */
+  typedListeners: Record<string, number>;
+  /** Number of recent events in buffer */
+  recentEventsCount: number;
+}
+
+/**
+ * Error thrown when a once() call times out.
+ */
+export class EventTimeoutError extends Error {
+  constructor(eventType: string, timeout: number) {
+    super(`Timed out waiting for event '${eventType}' after ${timeout}ms`);
+    this.name = 'EventTimeoutError';
+  }
+}
+
+/**
+ * An unbounded pub/sub event emitter for Agent to UI communication.
+ *
+ * Features:
+ * - Fire-and-forget semantics (never blocks producer)
+ * - Typed event subscriptions
+ * - Recent events buffer for reconnection/replay
+ * - Async dispatch via queueMicrotask
+ */
+export class EventQueue {
+  private readonly maxRecentEvents: number;
+  private readonly recentEvents: EventEnvelope[] = [];
+  private readonly globalListeners: Set<EventListener> = new Set();
+  private readonly typedListeners: Map<AgentEvent['type'], Set<EventListener>> = new Map();
+
+  /**
+   * Creates a new EventQueue.
+   * @param config - Optional configuration
+   */
+  constructor(config?: EventQueueConfig) {
+    this.maxRecentEvents = config?.maxRecentEvents ?? 100;
+  }
+
+  /**
+   * Emits an event to all listeners.
+   * Never blocks - uses fire-and-forget semantics.
+   *
+   * @param submissionId - The submission this event relates to
+   * @param event - The event to emit
+   */
+  emit(submissionId: SubmissionId, event: AgentEvent): void {
+    const envelope: EventEnvelope = {
+      submissionId,
+      event,
+      timestamp: Date.now(),
+    };
+
+    // Store in recent events buffer (circular)
+    this.addToRecentEvents(envelope);
+
+    // Notify all listeners asynchronously
+    this.notifyListeners(envelope);
+  }
+
+  /**
+   * Subscribes to all events.
+   *
+   * @param listener - The listener to call for each event
+   * @returns Unsubscribe function
+   */
+  subscribe(listener: EventListener): () => void {
+    this.globalListeners.add(listener);
+
+    return () => {
+      this.globalListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Subscribes to events of a specific type.
+   *
+   * @param type - The event type to listen for
+   * @param listener - The listener to call for matching events
+   * @returns Unsubscribe function
+   */
+  on<T extends AgentEvent>(
+    type: T['type'],
+    listener: TypedEventListener<T>
+  ): () => void {
+    let listeners = this.typedListeners.get(type);
+    if (!listeners) {
+      listeners = new Set();
+      this.typedListeners.set(type, listeners);
+    }
+
+    // Cast is safe because we filter by type before calling
+    listeners.add(listener as EventListener);
+
+    return () => {
+      listeners!.delete(listener as EventListener);
+      // Clean up empty sets
+      if (listeners!.size === 0) {
+        this.typedListeners.delete(type);
+      }
+    };
+  }
+
+  /**
+   * Returns a promise that resolves with the first matching event.
+   *
+   * @param type - The event type to wait for
+   * @param timeout - Optional timeout in ms (rejects with EventTimeoutError)
+   * @returns Promise that resolves with the matching event envelope
+   */
+  once<T extends AgentEvent>(
+    type: T['type'],
+    timeout?: number
+  ): Promise<EventEnvelope & { event: T }> {
+    return new Promise((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      let unsubscribe: (() => void) | undefined;
+
+      const cleanup = () => {
+        if (timeoutId !== undefined) {
+          clearTimeout(timeoutId);
+        }
+        if (unsubscribe) {
+          unsubscribe();
+        }
+      };
+
+      // Set up listener
+      unsubscribe = this.on<T>(type, (envelope) => {
+        cleanup();
+        resolve(envelope);
+      });
+
+      // Set up timeout if specified
+      if (timeout !== undefined && timeout > 0) {
+        timeoutId = setTimeout(() => {
+          cleanup();
+          reject(new EventTimeoutError(type, timeout));
+        }, timeout);
+      }
+    });
+  }
+
+  /**
+   * Gets recent events, optionally filtered by timestamp.
+   *
+   * @param since - Optional timestamp to filter events after
+   * @returns Array of recent event envelopes
+   */
+  getRecentEvents(since?: number): EventEnvelope[] {
+    if (since === undefined) {
+      return [...this.recentEvents];
+    }
+
+    return this.recentEvents.filter((envelope) => envelope.timestamp > since);
+  }
+
+  /**
+   * Gets recent events filtered by submission ID.
+   *
+   * @param submissionId - The submission ID to filter by
+   * @returns Array of event envelopes for the submission
+   */
+  getEventsForSubmission(submissionId: SubmissionId): EventEnvelope[] {
+    return this.recentEvents.filter(
+      (envelope) => envelope.submissionId === submissionId
+    );
+  }
+
+  /**
+   * Clears all listeners and recent events.
+   */
+  clear(): void {
+    this.globalListeners.clear();
+    this.typedListeners.clear();
+    this.recentEvents.length = 0;
+  }
+
+  /**
+   * Returns statistics about the queue for debugging.
+   */
+  stats(): EventQueueStats {
+    const typedListeners: Record<string, number> = {};
+    for (const [type, listeners] of this.typedListeners) {
+      typedListeners[type] = listeners.size;
+    }
+
+    return {
+      globalListeners: this.globalListeners.size,
+      typedListeners,
+      recentEventsCount: this.recentEvents.length,
+    };
+  }
+
+  /**
+   * Adds an envelope to the recent events buffer.
+   * Maintains circular buffer semantics.
+   */
+  private addToRecentEvents(envelope: EventEnvelope): void {
+    this.recentEvents.push(envelope);
+
+    // Trim to maxRecentEvents (circular buffer)
+    while (this.recentEvents.length > this.maxRecentEvents) {
+      this.recentEvents.shift();
+    }
+  }
+
+  /**
+   * Notifies all listeners of an event asynchronously.
+   * Ignores listener errors (fire-and-forget).
+   */
+  private notifyListeners(envelope: EventEnvelope): void {
+    // Notify global listeners
+    for (const listener of this.globalListeners) {
+      queueMicrotask(() => {
+        try {
+          listener(envelope);
+        } catch {
+          // Ignore listener errors - fire and forget
+        }
+      });
+    }
+
+    // Notify typed listeners
+    const typedListeners = this.typedListeners.get(envelope.event.type);
+    if (typedListeners) {
+      for (const listener of typedListeners) {
+        queueMicrotask(() => {
+          try {
+            listener(envelope);
+          } catch {
+            // Ignore listener errors - fire and forget
+          }
+        });
+      }
+    }
+  }
+}

--- a/attocode/src/core/queues/index.ts
+++ b/attocode/src/core/queues/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Queue System Exports
+ *
+ * Provides the core queue infrastructure for UI/Agent communication:
+ * - AtomicCounter: Lock-free ID generation
+ * - SubmissionQueue: Bounded async queue with backpressure (UI -> Agent)
+ * - EventQueue: Unbounded pub/sub event emitter (Agent -> UI)
+ */
+
+// Atomic counter
+export { AtomicCounter, globalCounter } from './atomic-counter.js';
+
+// Submission queue
+export {
+  SubmissionQueue,
+  QueueTimeoutError,
+  QueueClosedError,
+  type SubmissionQueueConfig,
+} from './submission-queue.js';
+
+// Event queue
+export {
+  EventQueue,
+  EventTimeoutError,
+  type EventListener,
+  type TypedEventListener,
+  type EventQueueConfig,
+  type EventQueueStats,
+} from './event-queue.js';

--- a/attocode/src/core/queues/submission-queue.ts
+++ b/attocode/src/core/queues/submission-queue.ts
@@ -1,0 +1,287 @@
+/**
+ * Bounded async queue for operations from UI to Agent.
+ * Implements backpressure - when full, producers wait until space is available.
+ */
+
+import type { Operation, Submission, SubmissionId } from '../protocol/types.js';
+import { AtomicCounter } from './atomic-counter.js';
+
+/**
+ * Configuration for the SubmissionQueue.
+ */
+export interface SubmissionQueueConfig {
+  /** Maximum number of items in the queue (default: 64) */
+  maxSize?: number;
+  /** Timeout in ms for producers waiting for space (default: 30000) */
+  timeout?: number;
+}
+
+/**
+ * Internal representation of a waiter (producer or consumer).
+ */
+interface Waiter<T> {
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+}
+
+/**
+ * Error thrown when a queue operation times out.
+ */
+export class QueueTimeoutError extends Error {
+  constructor(message: string = 'Queue operation timed out') {
+    super(message);
+    this.name = 'QueueTimeoutError';
+  }
+}
+
+/**
+ * Error thrown when attempting to operate on a closed queue.
+ */
+export class QueueClosedError extends Error {
+  constructor(message: string = 'Queue is closed') {
+    super(message);
+    this.name = 'QueueClosedError';
+  }
+}
+
+/**
+ * A bounded async queue for operations from UI to Agent.
+ *
+ * Features:
+ * - Bounded capacity with backpressure (producers wait when full)
+ * - Async iterator support for consumption
+ * - Graceful shutdown via close()
+ * - Timeout handling for blocked producers
+ */
+export class SubmissionQueue {
+  private readonly maxSize: number;
+  private readonly timeout: number;
+  private readonly counter: AtomicCounter;
+  private readonly queue: Submission[] = [];
+  private readonly producerWaiters: Waiter<void>[] = [];
+  private readonly consumerWaiters: Waiter<Submission | null>[] = [];
+  private closed = false;
+
+  /**
+   * Creates a new SubmissionQueue.
+   * @param config - Optional configuration
+   */
+  constructor(config?: SubmissionQueueConfig) {
+    this.maxSize = config?.maxSize ?? 64;
+    this.timeout = config?.timeout ?? 30000;
+    this.counter = new AtomicCounter();
+  }
+
+  /**
+   * Submits an operation to the queue.
+   * Blocks if the queue is full (backpressure).
+   *
+   * @param op - The operation to submit
+   * @param correlationId - Optional correlation ID for request/response tracking
+   * @returns The submission ID
+   * @throws QueueClosedError if the queue is closed
+   * @throws QueueTimeoutError if waiting for space times out
+   */
+  async submit(op: Operation, correlationId?: string): Promise<SubmissionId> {
+    if (this.closed) {
+      throw new QueueClosedError('Cannot submit to a closed queue');
+    }
+
+    // Wait for space if queue is full
+    if (this.queue.length >= this.maxSize) {
+      await this.waitForSpace();
+    }
+
+    // Re-check closed status after waiting
+    if (this.closed) {
+      throw new QueueClosedError('Queue closed while waiting for space');
+    }
+
+    const id = this.counter.next();
+    const submission: Submission = {
+      id,
+      op,
+      timestamp: Date.now(),
+      ...(correlationId !== undefined && { correlationId }),
+    };
+
+    this.queue.push(submission);
+
+    // Wake up a waiting consumer if any
+    this.wakeConsumer(submission);
+
+    return id;
+  }
+
+  /**
+   * Takes the next submission from the queue.
+   * Blocks if the queue is empty.
+   *
+   * @returns The next submission, or null if the queue is closed and empty
+   */
+  async take(): Promise<Submission | null> {
+    // Return immediately if there's an item
+    if (this.queue.length > 0) {
+      const submission = this.queue.shift()!;
+      this.wakeProducer();
+      return submission;
+    }
+
+    // If closed and empty, return null
+    if (this.closed) {
+      return null;
+    }
+
+    // Wait for an item
+    return new Promise<Submission | null>((resolve, reject) => {
+      this.consumerWaiters.push({ resolve, reject });
+    });
+  }
+
+  /**
+   * Non-blocking version of take().
+   * @returns The next submission, or null if the queue is empty
+   */
+  tryTake(): Submission | null {
+    if (this.queue.length === 0) {
+      return null;
+    }
+
+    const submission = this.queue.shift()!;
+    this.wakeProducer();
+    return submission;
+  }
+
+  /**
+   * Returns the current queue size.
+   */
+  size(): number {
+    return this.queue.length;
+  }
+
+  /**
+   * Returns true if the queue is empty.
+   */
+  isEmpty(): boolean {
+    return this.queue.length === 0;
+  }
+
+  /**
+   * Returns true if the queue is full.
+   */
+  isFull(): boolean {
+    return this.queue.length >= this.maxSize;
+  }
+
+  /**
+   * Returns true if the queue is closed.
+   */
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  /**
+   * Closes the queue.
+   * - Rejects all pending producer waiters
+   * - Resolves all pending consumer waiters with null
+   * - No more submissions are accepted
+   */
+  close(): void {
+    if (this.closed) {
+      return;
+    }
+
+    this.closed = true;
+
+    // Reject all waiting producers
+    const closedError = new QueueClosedError('Queue was closed');
+    for (const waiter of this.producerWaiters) {
+      waiter.reject(closedError);
+    }
+    this.producerWaiters.length = 0;
+
+    // Resolve all waiting consumers with null
+    for (const waiter of this.consumerWaiters) {
+      waiter.resolve(null);
+    }
+    this.consumerWaiters.length = 0;
+  }
+
+  /**
+   * Async iterator for consuming submissions.
+   * Yields submissions until the queue is closed and empty.
+   */
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<Submission> {
+    while (true) {
+      const submission = await this.take();
+      if (submission === null) {
+        return;
+      }
+      yield submission;
+    }
+  }
+
+  /**
+   * Waits for space to become available in the queue.
+   * @throws QueueTimeoutError if waiting times out
+   * @throws QueueClosedError if queue is closed while waiting
+   */
+  private waitForSpace(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const waiter: Waiter<void> = { resolve, reject };
+
+      // Set up timeout
+      const timeoutId = setTimeout(() => {
+        const index = this.producerWaiters.indexOf(waiter);
+        if (index !== -1) {
+          this.producerWaiters.splice(index, 1);
+          reject(new QueueTimeoutError(`Timed out waiting for space after ${this.timeout}ms`));
+        }
+      }, this.timeout);
+
+      // Wrap resolve to clear timeout
+      const originalResolve = waiter.resolve;
+      waiter.resolve = (value: void) => {
+        clearTimeout(timeoutId);
+        originalResolve(value);
+      };
+
+      // Wrap reject to clear timeout
+      const originalReject = waiter.reject;
+      waiter.reject = (error: Error) => {
+        clearTimeout(timeoutId);
+        originalReject(error);
+      };
+
+      this.producerWaiters.push(waiter);
+    });
+  }
+
+  /**
+   * Wakes a waiting producer (called when space becomes available).
+   */
+  private wakeProducer(): void {
+    const waiter = this.producerWaiters.shift();
+    if (waiter) {
+      waiter.resolve();
+    }
+  }
+
+  /**
+   * Wakes a waiting consumer with a submission.
+   * If no consumers are waiting, the submission is already in the queue.
+   */
+  private wakeConsumer(submission: Submission): void {
+    const waiter = this.consumerWaiters.shift();
+    if (waiter) {
+      // Remove from queue since we're giving it directly to consumer
+      const index = this.queue.indexOf(submission);
+      if (index !== -1) {
+        this.queue.splice(index, 1);
+      }
+      waiter.resolve(submission);
+      // Wake a producer since we freed a slot
+      this.wakeProducer();
+    }
+  }
+}

--- a/attocode/src/costs/index.ts
+++ b/attocode/src/costs/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Cost tracking and model registry module.
+ * Provides model configuration, pricing, and cost calculation utilities.
+ *
+ * @example
+ * ```typescript
+ * import { modelRegistry, type UsageRecord } from './costs/index.js';
+ *
+ * const usage: UsageRecord = {
+ *   modelId: 'claude-3-5-sonnet-20241022',
+ *   promptTokens: 1000,
+ *   completionTokens: 500,
+ *   cacheReadTokens: 200,
+ * };
+ *
+ * const cost = modelRegistry.calculateCost(usage);
+ * console.log(cost.formatted); // '$0.0195'
+ * ```
+ */
+
+export * from './types.js';
+export * from './model-registry.js';

--- a/attocode/src/costs/model-registry.ts
+++ b/attocode/src/costs/model-registry.ts
@@ -1,0 +1,256 @@
+import type { ModelConfig, UsageRecord, CostBreakdown } from './types.js';
+
+/**
+ * Default model configurations with current pricing (2024/2025).
+ * Pricing sourced from official provider documentation.
+ */
+const DEFAULT_MODELS: ModelConfig[] = [
+  // Claude models (Anthropic)
+  {
+    modelId: 'claude-3-5-sonnet-20241022',
+    provider: 'anthropic',
+    displayName: 'Claude 3.5 Sonnet',
+    pricing: {
+      promptPerMillion: 3.0,
+      completionPerMillion: 15.0,
+      cacheReadPerMillion: 0.30,
+      cacheWritePerMillion: 3.75,
+    },
+    capabilities: {
+      maxContextTokens: 200000,
+      maxOutputTokens: 8192,
+      supportsVision: true,
+      supportsTools: true,
+      supportsCaching: true,
+    },
+  },
+  {
+    modelId: 'claude-3-5-haiku-20241022',
+    provider: 'anthropic',
+    displayName: 'Claude 3.5 Haiku',
+    pricing: {
+      promptPerMillion: 0.80,
+      completionPerMillion: 4.0,
+      cacheReadPerMillion: 0.08,
+      cacheWritePerMillion: 1.0,
+    },
+    capabilities: {
+      maxContextTokens: 200000,
+      maxOutputTokens: 8192,
+      supportsVision: true,
+      supportsTools: true,
+      supportsCaching: true,
+    },
+  },
+  {
+    modelId: 'claude-3-opus-20240229',
+    provider: 'anthropic',
+    displayName: 'Claude 3 Opus',
+    pricing: {
+      promptPerMillion: 15.0,
+      completionPerMillion: 75.0,
+      cacheReadPerMillion: 1.50,
+      cacheWritePerMillion: 18.75,
+    },
+    capabilities: {
+      maxContextTokens: 200000,
+      maxOutputTokens: 4096,
+      supportsVision: true,
+      supportsTools: true,
+      supportsCaching: true,
+    },
+  },
+  // GPT-4o models (OpenAI)
+  {
+    modelId: 'gpt-4o',
+    provider: 'openai',
+    displayName: 'GPT-4o',
+    pricing: {
+      promptPerMillion: 2.50,
+      completionPerMillion: 10.0,
+    },
+    capabilities: {
+      maxContextTokens: 128000,
+      maxOutputTokens: 16384,
+      supportsVision: true,
+      supportsTools: true,
+    },
+  },
+  {
+    modelId: 'gpt-4o-mini',
+    provider: 'openai',
+    displayName: 'GPT-4o Mini',
+    pricing: {
+      promptPerMillion: 0.15,
+      completionPerMillion: 0.60,
+    },
+    capabilities: {
+      maxContextTokens: 128000,
+      maxOutputTokens: 16384,
+      supportsVision: true,
+      supportsTools: true,
+    },
+  },
+  {
+    modelId: 'gpt-4-turbo',
+    provider: 'openai',
+    displayName: 'GPT-4 Turbo',
+    pricing: {
+      promptPerMillion: 10.0,
+      completionPerMillion: 30.0,
+    },
+    capabilities: {
+      maxContextTokens: 128000,
+      maxOutputTokens: 4096,
+      supportsVision: true,
+      supportsTools: true,
+    },
+  },
+];
+
+/**
+ * Registry for model configurations with caching and cost calculation.
+ * Provides a centralized way to manage model metadata and pricing.
+ */
+export class ModelRegistry {
+  private models: Map<string, ModelConfig> = new Map();
+  private cacheTimestamp: number = 0;
+  private readonly cacheDurationMs: number;
+
+  /**
+   * Creates a new ModelRegistry instance.
+   * @param cacheDurationMs - How long to cache model configs (default: 24 hours)
+   */
+  constructor(cacheDurationMs: number = 24 * 60 * 60 * 1000) {
+    this.cacheDurationMs = cacheDurationMs;
+    this.loadDefaults();
+  }
+
+  /**
+   * Loads default model configurations into the registry.
+   */
+  private loadDefaults(): void {
+    for (const model of DEFAULT_MODELS) {
+      this.models.set(model.modelId, model);
+    }
+    this.cacheTimestamp = Date.now();
+  }
+
+  /**
+   * Gets a model configuration by ID.
+   * @param modelId - The unique model identifier
+   * @returns The model config or undefined if not found
+   */
+  getModel(modelId: string): ModelConfig | undefined {
+    return this.models.get(modelId);
+  }
+
+  /**
+   * Gets all registered models.
+   * @returns Array of all model configurations
+   */
+  getAllModels(): ModelConfig[] {
+    return Array.from(this.models.values());
+  }
+
+  /**
+   * Gets models filtered by provider.
+   * @param provider - The provider name to filter by
+   * @returns Array of models from the specified provider
+   */
+  getModelsByProvider(provider: string): ModelConfig[] {
+    return this.getAllModels().filter(m => m.provider === provider);
+  }
+
+  /**
+   * Adds or updates a model configuration.
+   * @param config - The model configuration to set
+   */
+  setModel(config: ModelConfig): void {
+    this.models.set(config.modelId, config);
+  }
+
+  /**
+   * Calculates cost breakdown for a usage record.
+   * Uses default pricing if model is not found in registry.
+   * @param usage - The usage record with token counts
+   * @returns Cost breakdown with prompt, completion, cache, and total costs
+   */
+  calculateCost(usage: UsageRecord): CostBreakdown {
+    const model = this.getModel(usage.modelId);
+
+    // Default pricing if model not found (Claude 3.5 Sonnet pricing as fallback)
+    const pricing = model?.pricing ?? {
+      promptPerMillion: 3.0,
+      completionPerMillion: 15.0,
+    };
+
+    const promptCost = (usage.promptTokens / 1_000_000) * pricing.promptPerMillion;
+    const completionCost = (usage.completionTokens / 1_000_000) * pricing.completionPerMillion;
+
+    let cacheCost = 0;
+    if (usage.cacheReadTokens && pricing.cacheReadPerMillion) {
+      cacheCost += (usage.cacheReadTokens / 1_000_000) * pricing.cacheReadPerMillion;
+    }
+    if (usage.cacheWriteTokens && pricing.cacheWritePerMillion) {
+      cacheCost += (usage.cacheWriteTokens / 1_000_000) * pricing.cacheWritePerMillion;
+    }
+
+    const totalCost = promptCost + completionCost + cacheCost;
+
+    return {
+      promptCost,
+      completionCost,
+      cacheCost,
+      totalCost,
+      formatted: `$${totalCost.toFixed(4)}`,
+    };
+  }
+
+  /**
+   * Checks if the cache needs to be refreshed based on cache duration.
+   * @returns True if cache is stale and needs refresh
+   */
+  needsRefresh(): boolean {
+    return Date.now() - this.cacheTimestamp > this.cacheDurationMs;
+  }
+
+  /**
+   * Refreshes the cache timestamp.
+   * In future, this could fetch updated pricing from an API.
+   */
+  refreshCache(): void {
+    // In future, this could fetch from an API
+    // For now, just reset the timestamp
+    this.cacheTimestamp = Date.now();
+  }
+
+  /**
+   * Exports the current cache state for persistence.
+   * @returns Object containing models array and timestamp
+   */
+  exportCache(): { models: ModelConfig[]; timestamp: number } {
+    return {
+      models: this.getAllModels(),
+      timestamp: this.cacheTimestamp,
+    };
+  }
+
+  /**
+   * Imports a previously exported cache.
+   * @param cache - The cache object to import
+   */
+  importCache(cache: { models: ModelConfig[]; timestamp: number }): void {
+    this.models.clear();
+    for (const model of cache.models) {
+      this.models.set(model.modelId, model);
+    }
+    this.cacheTimestamp = cache.timestamp;
+  }
+}
+
+/**
+ * Singleton instance of ModelRegistry for global access.
+ * Use this for shared model configuration across the application.
+ */
+export const modelRegistry = new ModelRegistry();

--- a/attocode/src/costs/types.ts
+++ b/attocode/src/costs/types.ts
@@ -1,0 +1,51 @@
+/**
+ * Model configuration with pricing information.
+ */
+export interface ModelConfig {
+  /** Unique model identifier (e.g., 'claude-3-5-sonnet-20241022') */
+  modelId: string;
+  /** Provider name (e.g., 'anthropic', 'openai', 'openrouter') */
+  provider: 'anthropic' | 'openai' | 'openrouter' | string;
+  /** Human-readable display name */
+  displayName: string;
+  /** Pricing per million tokens */
+  pricing: {
+    promptPerMillion: number;
+    completionPerMillion: number;
+    /** Cache read pricing (if supported) */
+    cacheReadPerMillion?: number;
+    /** Cache write pricing (if supported) */
+    cacheWritePerMillion?: number;
+  };
+  /** Model capabilities */
+  capabilities: {
+    maxContextTokens: number;
+    maxOutputTokens: number;
+    supportsVision?: boolean;
+    supportsTools?: boolean;
+    supportsCaching?: boolean;
+  };
+}
+
+/**
+ * Usage record for cost calculation.
+ */
+export interface UsageRecord {
+  modelId: string;
+  promptTokens: number;
+  completionTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+}
+
+/**
+ * Calculated cost breakdown.
+ */
+export interface CostBreakdown {
+  promptCost: number;
+  completionCost: number;
+  cacheCost: number;
+  totalCost: number;
+  /** Cost formatted as string (e.g., '$0.0123') */
+  formatted: string;
+}

--- a/attocode/src/integrations/auto-compaction.ts
+++ b/attocode/src/integrations/auto-compaction.ts
@@ -1,0 +1,497 @@
+/**
+ * AutoCompactionManager - Monitors token usage and triggers compaction
+ *
+ * Implements a three-tier threshold system:
+ * - OK (< 80%): Continue normally
+ * - Warning (80-89%): Alert user, no automatic action
+ * - Auto-Compact (90-97%): Depending on mode, auto-compact or request approval
+ * - Hard Limit (>= 98%): Agent cannot continue - context too full
+ */
+
+import type { Message } from '../types.js';
+import type { Compactor, CompactionResult } from './compaction.js';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Configuration for automatic compaction behavior.
+ */
+export interface AutoCompactionConfig {
+  /** Compaction mode: auto (no approval), approval (asks user), manual (never auto) */
+  mode: 'auto' | 'approval' | 'manual';
+  /** Warning threshold as ratio (default: 0.80) */
+  warningThreshold: number;
+  /** Auto-compact threshold as ratio (default: 0.90) */
+  autoCompactThreshold: number;
+  /** Hard limit threshold as ratio (default: 0.98) */
+  hardLimitThreshold: number;
+  /** Number of recent user messages to preserve (default: 5) */
+  preserveRecentUserMessages: number;
+  /** Number of recent assistant messages to preserve (default: 5) */
+  preserveRecentAssistantMessages: number;
+  /** Cooldown between compactions in ms (default: 60000) */
+  cooldownMs: number;
+  /** Max context window tokens (default: 200000 for Claude) */
+  maxContextTokens: number;
+}
+
+/**
+ * Result of checking token usage and potentially compacting.
+ */
+export interface CompactionCheckResult {
+  /** Current status after check */
+  status: 'ok' | 'warning' | 'compacted' | 'needs_approval' | 'hard_limit';
+  /** Current token count */
+  currentTokens: number;
+  /** Maximum allowed tokens */
+  maxTokens: number;
+  /** Ratio of current to max (0-1) */
+  ratio: number;
+  /** Compacted messages if compaction occurred */
+  compactedMessages?: Message[];
+  /** Summary generated during compaction */
+  summary?: string;
+}
+
+/**
+ * Events emitted by AutoCompactionManager.
+ */
+export type AutoCompactionEvent =
+  | { type: 'autocompaction.check'; currentTokens: number; ratio: number; threshold: string }
+  | { type: 'autocompaction.warning'; currentTokens: number; ratio: number }
+  | { type: 'autocompaction.triggered'; mode: string; currentTokens: number }
+  | { type: 'autocompaction.completed'; tokensBefore: number; tokensAfter: number; reduction: number }
+  | { type: 'autocompaction.cooldown'; remainingMs: number }
+  | { type: 'autocompaction.hard_limit'; currentTokens: number; ratio: number }
+  | { type: 'autocompaction.needs_approval'; currentTokens: number; ratio: number };
+
+export type AutoCompactionEventListener = (event: AutoCompactionEvent) => void;
+
+// =============================================================================
+// DEFAULT CONFIG
+// =============================================================================
+
+const DEFAULT_CONFIG: AutoCompactionConfig = {
+  mode: 'auto',
+  warningThreshold: 0.80,
+  autoCompactThreshold: 0.90,
+  hardLimitThreshold: 0.98,
+  preserveRecentUserMessages: 5,
+  preserveRecentAssistantMessages: 5,
+  cooldownMs: 60000, // 1 minute
+  maxContextTokens: 200000, // Claude's context window
+};
+
+// =============================================================================
+// AUTO COMPACTION MANAGER
+// =============================================================================
+
+/**
+ * Monitors token usage and triggers compaction based on thresholds.
+ *
+ * Three-tier threshold design:
+ * - OK (< 80%): Normal operation
+ * - Warning (80-89%): User alerted but no action
+ * - Auto-Compact (90-97%): Automatic compaction (in auto mode) or approval request
+ * - Hard Limit (>= 98%): Cannot continue - too close to context limit
+ */
+export class AutoCompactionManager {
+  private compactor: Compactor;
+  private config: AutoCompactionConfig;
+  private lastCompactionTime: number = 0;
+  private listeners: AutoCompactionEventListener[] = [];
+
+  constructor(compactor: Compactor, config?: Partial<AutoCompactionConfig>) {
+    this.compactor = compactor;
+    this.config = { ...DEFAULT_CONFIG, ...config };
+
+    // Validate thresholds are in correct order
+    if (this.config.warningThreshold >= this.config.autoCompactThreshold) {
+      throw new Error('warningThreshold must be less than autoCompactThreshold');
+    }
+    if (this.config.autoCompactThreshold >= this.config.hardLimitThreshold) {
+      throw new Error('autoCompactThreshold must be less than hardLimitThreshold');
+    }
+  }
+
+  /**
+   * Check token usage and maybe perform compaction.
+   *
+   * @param options - Current tokens and messages
+   * @returns Result indicating status and any compaction performed
+   */
+  async checkAndMaybeCompact(options: {
+    currentTokens: number;
+    messages: Message[];
+  }): Promise<CompactionCheckResult> {
+    const { currentTokens, messages } = options;
+    const ratio = this.getTokenRatio(currentTokens);
+    const maxTokens = this.config.maxContextTokens;
+
+    // Determine which zone we're in
+    const zone = this.determineZone(ratio);
+
+    this.emit({
+      type: 'autocompaction.check',
+      currentTokens,
+      ratio,
+      threshold: zone,
+    });
+
+    // Zone: OK (< warningThreshold)
+    if (zone === 'ok') {
+      return {
+        status: 'ok',
+        currentTokens,
+        maxTokens,
+        ratio,
+      };
+    }
+
+    // Zone: Hard Limit (>= hardLimitThreshold)
+    if (zone === 'hard_limit') {
+      this.emit({
+        type: 'autocompaction.hard_limit',
+        currentTokens,
+        ratio,
+      });
+      return {
+        status: 'hard_limit',
+        currentTokens,
+        maxTokens,
+        ratio,
+      };
+    }
+
+    // Zone: Warning (warningThreshold <= ratio < autoCompactThreshold)
+    if (zone === 'warning') {
+      this.emit({
+        type: 'autocompaction.warning',
+        currentTokens,
+        ratio,
+      });
+      return {
+        status: 'warning',
+        currentTokens,
+        maxTokens,
+        ratio,
+      };
+    }
+
+    // Zone: Auto-Compact (autoCompactThreshold <= ratio < hardLimitThreshold)
+    // Check cooldown
+    if (this.isInCooldown()) {
+      const remaining = this.getRemainingCooldown();
+      this.emit({
+        type: 'autocompaction.cooldown',
+        remainingMs: remaining,
+      });
+
+      // During cooldown, treat as warning
+      return {
+        status: 'warning',
+        currentTokens,
+        maxTokens,
+        ratio,
+      };
+    }
+
+    // Handle based on mode
+    switch (this.config.mode) {
+      case 'auto':
+        return this.performCompaction(messages, currentTokens, maxTokens, ratio);
+
+      case 'approval':
+        this.emit({
+          type: 'autocompaction.needs_approval',
+          currentTokens,
+          ratio,
+        });
+        return {
+          status: 'needs_approval',
+          currentTokens,
+          maxTokens,
+          ratio,
+        };
+
+      case 'manual':
+        // In manual mode, auto-compact zone is treated as warning
+        this.emit({
+          type: 'autocompaction.warning',
+          currentTokens,
+          ratio,
+        });
+        return {
+          status: 'warning',
+          currentTokens,
+          maxTokens,
+          ratio,
+        };
+
+      default:
+        return {
+          status: 'warning',
+          currentTokens,
+          maxTokens,
+          ratio,
+        };
+    }
+  }
+
+  /**
+   * Get the current token ratio.
+   */
+  getTokenRatio(currentTokens: number): number {
+    return currentTokens / this.config.maxContextTokens;
+  }
+
+  /**
+   * Check if currently in cooldown period.
+   */
+  isInCooldown(): boolean {
+    if (this.lastCompactionTime === 0) {
+      return false;
+    }
+    return Date.now() - this.lastCompactionTime < this.config.cooldownMs;
+  }
+
+  /**
+   * Get remaining cooldown time in milliseconds.
+   */
+  getRemainingCooldown(): number {
+    if (!this.isInCooldown()) {
+      return 0;
+    }
+    return this.config.cooldownMs - (Date.now() - this.lastCompactionTime);
+  }
+
+  /**
+   * Reset cooldown (e.g., after manual compaction request).
+   */
+  resetCooldown(): void {
+    this.lastCompactionTime = 0;
+  }
+
+  /**
+   * Force compaction regardless of mode or cooldown.
+   * Useful for manual compaction requests.
+   */
+  async forceCompact(messages: Message[]): Promise<CompactionCheckResult> {
+    const currentTokens = this.compactor.estimateTokens(messages);
+    const ratio = this.getTokenRatio(currentTokens);
+    const maxTokens = this.config.maxContextTokens;
+
+    return this.performCompaction(messages, currentTokens, maxTokens, ratio);
+  }
+
+  /**
+   * Get current configuration.
+   */
+  getConfig(): AutoCompactionConfig {
+    return { ...this.config };
+  }
+
+  /**
+   * Update configuration.
+   */
+  updateConfig(updates: Partial<AutoCompactionConfig>): void {
+    this.config = { ...this.config, ...updates };
+
+    // Re-validate thresholds
+    if (this.config.warningThreshold >= this.config.autoCompactThreshold) {
+      throw new Error('warningThreshold must be less than autoCompactThreshold');
+    }
+    if (this.config.autoCompactThreshold >= this.config.hardLimitThreshold) {
+      throw new Error('autoCompactThreshold must be less than hardLimitThreshold');
+    }
+  }
+
+  /**
+   * Subscribe to events.
+   */
+  on(listener: AutoCompactionEventListener): () => void {
+    this.listeners.push(listener);
+    return () => {
+      const idx = this.listeners.indexOf(listener);
+      if (idx >= 0) this.listeners.splice(idx, 1);
+    };
+  }
+
+  // ===========================================================================
+  // PRIVATE METHODS
+  // ===========================================================================
+
+  /**
+   * Determine which zone the current ratio falls into.
+   */
+  private determineZone(ratio: number): 'ok' | 'warning' | 'auto_compact' | 'hard_limit' {
+    if (ratio >= this.config.hardLimitThreshold) {
+      return 'hard_limit';
+    }
+    if (ratio >= this.config.autoCompactThreshold) {
+      return 'auto_compact';
+    }
+    if (ratio >= this.config.warningThreshold) {
+      return 'warning';
+    }
+    return 'ok';
+  }
+
+  /**
+   * Perform the actual compaction.
+   */
+  private async performCompaction(
+    messages: Message[],
+    currentTokens: number,
+    maxTokens: number,
+    ratio: number
+  ): Promise<CompactionCheckResult> {
+    this.emit({
+      type: 'autocompaction.triggered',
+      mode: this.config.mode,
+      currentTokens,
+    });
+
+    // Configure compactor to preserve the specified number of messages
+    // The compactor already handles preserving recent messages, but we can
+    // update its config if needed based on our preservation settings
+    const totalPreserve = this.config.preserveRecentUserMessages + this.config.preserveRecentAssistantMessages;
+    const currentCompactorConfig = this.compactor.getConfig();
+
+    // Temporarily adjust if our preserve count differs
+    const needsRestore = currentCompactorConfig.preserveRecentCount !== totalPreserve;
+    if (needsRestore) {
+      this.compactor.updateConfig({ preserveRecentCount: totalPreserve });
+    }
+
+    let result: CompactionResult;
+    try {
+      result = await this.compactor.compact(messages);
+    } finally {
+      // Restore original config
+      if (needsRestore) {
+        this.compactor.updateConfig({ preserveRecentCount: currentCompactorConfig.preserveRecentCount });
+      }
+    }
+
+    // Update cooldown
+    this.lastCompactionTime = Date.now();
+
+    const reduction = result.tokensBefore > 0
+      ? Math.round((1 - result.tokensAfter / result.tokensBefore) * 100)
+      : 0;
+
+    this.emit({
+      type: 'autocompaction.completed',
+      tokensBefore: result.tokensBefore,
+      tokensAfter: result.tokensAfter,
+      reduction,
+    });
+
+    return {
+      status: 'compacted',
+      currentTokens: result.tokensAfter,
+      maxTokens,
+      ratio: result.tokensAfter / maxTokens,
+      compactedMessages: result.preservedMessages,
+      summary: result.summary,
+    };
+  }
+
+  /**
+   * Emit an event to all listeners.
+   */
+  private emit(event: AutoCompactionEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // Ignore listener errors
+      }
+    }
+  }
+}
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+/**
+ * Create an AutoCompactionManager.
+ */
+export function createAutoCompactionManager(
+  compactor: Compactor,
+  config?: Partial<AutoCompactionConfig>
+): AutoCompactionManager {
+  return new AutoCompactionManager(compactor, config);
+}
+
+// =============================================================================
+// UTILITIES
+// =============================================================================
+
+/**
+ * Format a CompactionCheckResult for display.
+ */
+export function formatCompactionCheckResult(result: CompactionCheckResult): string {
+  const percentUsed = Math.round(result.ratio * 100);
+  const lines: string[] = [];
+
+  switch (result.status) {
+    case 'ok':
+      lines.push(`Context usage: ${percentUsed}% (${result.currentTokens.toLocaleString()} / ${result.maxTokens.toLocaleString()} tokens)`);
+      lines.push('Status: OK');
+      break;
+
+    case 'warning':
+      lines.push(`Context usage: ${percentUsed}% (${result.currentTokens.toLocaleString()} / ${result.maxTokens.toLocaleString()} tokens)`);
+      lines.push('Status: WARNING - Context usage is high');
+      lines.push('Consider compacting the conversation to free up space.');
+      break;
+
+    case 'needs_approval':
+      lines.push(`Context usage: ${percentUsed}% (${result.currentTokens.toLocaleString()} / ${result.maxTokens.toLocaleString()} tokens)`);
+      lines.push('Status: NEEDS APPROVAL');
+      lines.push('Context is nearing capacity. Approve compaction to continue.');
+      break;
+
+    case 'compacted':
+      lines.push(`Context usage: ${percentUsed}% (${result.currentTokens.toLocaleString()} / ${result.maxTokens.toLocaleString()} tokens)`);
+      lines.push('Status: COMPACTED');
+      if (result.summary) {
+        lines.push('Summary preserved: Yes');
+      }
+      break;
+
+    case 'hard_limit':
+      lines.push(`Context usage: ${percentUsed}% (${result.currentTokens.toLocaleString()} / ${result.maxTokens.toLocaleString()} tokens)`);
+      lines.push('Status: HARD LIMIT REACHED');
+      lines.push('Cannot continue - context window is too full.');
+      lines.push('Manual intervention required.');
+      break;
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Get suggested action based on check result.
+ */
+export function getSuggestedAction(result: CompactionCheckResult): string | null {
+  switch (result.status) {
+    case 'ok':
+      return null;
+    case 'warning':
+      return 'Consider running /compact to free up context space';
+    case 'needs_approval':
+      return 'Approve context compaction to continue';
+    case 'compacted':
+      return null;
+    case 'hard_limit':
+      return 'Start a new conversation or manually clear context';
+    default:
+      return null;
+  }
+}

--- a/attocode/src/integrations/file-change-tracker.ts
+++ b/attocode/src/integrations/file-change-tracker.ts
@@ -1,0 +1,754 @@
+/**
+ * File Change Tracker
+ *
+ * Tracks file changes for undo capability in agent sessions.
+ * Provides before/after content capture, diff generation, and undo functionality.
+ *
+ * @example
+ * ```typescript
+ * import Database from 'better-sqlite3';
+ * import { FileChangeTracker } from './file-change-tracker.js';
+ *
+ * const db = new Database('sessions.db');
+ * const tracker = new FileChangeTracker(db, 'session-123');
+ *
+ * // Record a file change
+ * const changeId = await tracker.recordChange({
+ *   filePath: '/path/to/file.ts',
+ *   operation: 'edit',
+ *   contentBefore: 'old content',
+ *   contentAfter: 'new content',
+ *   turnNumber: 1,
+ * });
+ *
+ * // Undo the change
+ * const result = await tracker.undoChange(changeId);
+ * ```
+ */
+
+import Database from 'better-sqlite3';
+import { writeFile, readFile, unlink } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Configuration for FileChangeTracker.
+ */
+export interface FileChangeTrackerConfig {
+  /** Whether tracking is enabled (default: true) */
+  enabled?: boolean;
+  /** Maximum bytes for full content storage (default: 50KB). Above this, store diff only. */
+  maxFullContentBytes?: number;
+}
+
+/**
+ * Represents a file change record.
+ */
+export interface FileChange {
+  /** Unique change ID */
+  id: number;
+  /** Session this change belongs to */
+  sessionId: string;
+  /** Turn number when change occurred */
+  turnNumber: number;
+  /** Path to the changed file */
+  filePath: string;
+  /** Type of operation */
+  operation: 'create' | 'write' | 'edit' | 'delete';
+  /** Content before the change (null for creates) */
+  contentBefore: string | null;
+  /** Content after the change (null for deletes) */
+  contentAfter: string | null;
+  /** Unified diff (when using diff storage mode) */
+  diffUnified: string | null;
+  /** How content is stored */
+  storageMode: 'full' | 'diff';
+  /** Bytes before change */
+  bytesBefore: number;
+  /** Bytes after change */
+  bytesAfter: number;
+  /** Whether this change has been undone */
+  isUndone: boolean;
+  /** ID of the change that undid this one */
+  undoChangeId: number | null;
+  /** Tool call ID that made this change */
+  toolCallId: string | null;
+  /** ISO timestamp of when change was recorded */
+  createdAt: string;
+}
+
+/**
+ * Result of an undo operation.
+ */
+export interface UndoResult {
+  /** Whether the undo succeeded */
+  success: boolean;
+  /** Path to the affected file */
+  filePath: string;
+  /** Human-readable message */
+  message: string;
+  /** Change ID that was undone (if successful) */
+  changeId?: number;
+}
+
+/**
+ * Summary of changes in a session.
+ */
+export interface ChangeSummary {
+  /** Total number of changes */
+  totalChanges: number;
+  /** Number of active (non-undone) changes */
+  activeChanges: number;
+  /** Number of undone changes */
+  undoneChanges: number;
+  /** Files that were modified */
+  filesModified: string[];
+  /** Changes by operation type */
+  byOperation: {
+    create: number;
+    write: number;
+    edit: number;
+    delete: number;
+  };
+}
+
+// =============================================================================
+// DIFF UTILITIES
+// =============================================================================
+
+/**
+ * Generate a simple unified diff between two strings.
+ * This is a basic implementation - for production, consider using a proper diff library.
+ */
+function generateUnifiedDiff(before: string, after: string, filePath: string): string {
+  const beforeLines = before.split('\n');
+  const afterLines = after.split('\n');
+
+  const header = [
+    `--- a/${filePath}`,
+    `+++ b/${filePath}`,
+  ];
+
+  // Simple line-by-line diff (not optimal but functional)
+  const hunks: string[] = [];
+  let i = 0;
+  let j = 0;
+
+  while (i < beforeLines.length || j < afterLines.length) {
+    // Find next difference
+    const startI = i;
+    const startJ = j;
+
+    // Skip matching lines
+    while (i < beforeLines.length && j < afterLines.length && beforeLines[i] === afterLines[j]) {
+      i++;
+      j++;
+    }
+
+    // If we've found a difference or reached the end
+    if (i < beforeLines.length || j < afterLines.length) {
+      // Determine the hunk boundaries
+      const contextBefore = Math.max(0, i - 3);
+      const hunkStart = contextBefore + 1;
+
+      // Find the extent of the difference
+      const diffStartI = i;
+      const diffStartJ = j;
+
+      // Advance through differing lines
+      while (i < beforeLines.length || j < afterLines.length) {
+        if (i < beforeLines.length && j < afterLines.length && beforeLines[i] === afterLines[j]) {
+          // Found a match - check if it's the end of the diff section
+          let matchCount = 0;
+          let tempI = i;
+          let tempJ = j;
+          while (tempI < beforeLines.length && tempJ < afterLines.length &&
+                 beforeLines[tempI] === afterLines[tempJ] && matchCount < 3) {
+            matchCount++;
+            tempI++;
+            tempJ++;
+          }
+          if (matchCount >= 3) {
+            break;
+          }
+        }
+        if (i < beforeLines.length) i++;
+        if (j < afterLines.length) j++;
+      }
+
+      // Build the hunk
+      const hunkLines: string[] = [];
+      const beforeCount = i - contextBefore;
+      const afterCount = j - (startJ + (contextBefore - startI));
+
+      hunkLines.push(`@@ -${hunkStart},${beforeCount} +${hunkStart},${afterCount} @@`);
+
+      // Add context before
+      for (let k = contextBefore; k < diffStartI; k++) {
+        hunkLines.push(` ${beforeLines[k]}`);
+      }
+
+      // Add removed lines
+      for (let k = diffStartI; k < i; k++) {
+        if (k < beforeLines.length) {
+          hunkLines.push(`-${beforeLines[k]}`);
+        }
+      }
+
+      // Add added lines
+      for (let k = diffStartJ; k < j; k++) {
+        if (k < afterLines.length) {
+          hunkLines.push(`+${afterLines[k]}`);
+        }
+      }
+
+      hunks.push(hunkLines.join('\n'));
+    }
+  }
+
+  return [...header, ...hunks].join('\n');
+}
+
+/**
+ * Apply a unified diff to restore original content.
+ * Returns the original content before the diff was applied.
+ */
+function applyReverseDiff(currentContent: string, diff: string): string {
+  // Parse diff hunks
+  const lines = diff.split('\n');
+  const resultLines = currentContent.split('\n');
+
+  let lineIndex = 0;
+  let i = 0;
+
+  // Skip header lines
+  while (i < lines.length && !lines[i].startsWith('@@')) {
+    i++;
+  }
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.startsWith('@@')) {
+      // Parse hunk header: @@ -start,count +start,count @@
+      const match = line.match(/@@ -(\d+),?\d* \+(\d+),?\d* @@/);
+      if (match) {
+        lineIndex = parseInt(match[2], 10) - 1;
+      }
+      i++;
+      continue;
+    }
+
+    if (line.startsWith('+')) {
+      // This was an addition - remove it to reverse
+      if (lineIndex < resultLines.length && resultLines[lineIndex] === line.slice(1)) {
+        resultLines.splice(lineIndex, 1);
+      }
+      i++;
+      continue;
+    }
+
+    if (line.startsWith('-')) {
+      // This was a removal - add it back to reverse
+      resultLines.splice(lineIndex, 0, line.slice(1));
+      lineIndex++;
+      i++;
+      continue;
+    }
+
+    if (line.startsWith(' ')) {
+      // Context line
+      lineIndex++;
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return resultLines.join('\n');
+}
+
+// =============================================================================
+// FILE CHANGE TRACKER
+// =============================================================================
+
+/**
+ * Tracks file changes for undo capability.
+ */
+export class FileChangeTracker {
+  private db: Database.Database;
+  private sessionId: string;
+  private config: Required<FileChangeTrackerConfig>;
+  private stmts!: {
+    insertChange: Database.Statement;
+    getChange: Database.Statement;
+    getChanges: Database.Statement;
+    getFileChanges: Database.Statement;
+    getLastFileChange: Database.Statement;
+    getTurnChanges: Database.Statement;
+    markUndone: Database.Statement;
+    getSessionSummary: Database.Statement;
+  };
+
+  constructor(db: Database.Database, sessionId: string, config?: FileChangeTrackerConfig) {
+    this.db = db;
+    this.sessionId = sessionId;
+    this.config = {
+      enabled: config?.enabled ?? true,
+      maxFullContentBytes: config?.maxFullContentBytes ?? 50 * 1024, // 50KB
+    };
+
+    this.prepareStatements();
+  }
+
+  /**
+   * Prepare SQL statements for reuse.
+   */
+  private prepareStatements(): void {
+    this.stmts = {
+      insertChange: this.db.prepare(`
+        INSERT INTO file_changes (
+          session_id, entry_id, tool_call_id, turn_number, file_path,
+          operation, content_before, content_after, diff_unified,
+          storage_mode, bytes_before, bytes_after, is_undone,
+          undo_change_id, created_at
+        )
+        VALUES (
+          @sessionId, @entryId, @toolCallId, @turnNumber, @filePath,
+          @operation, @contentBefore, @contentAfter, @diffUnified,
+          @storageMode, @bytesBefore, @bytesAfter, @isUndone,
+          @undoChangeId, @createdAt
+        )
+      `),
+
+      getChange: this.db.prepare(`
+        SELECT
+          id, session_id as sessionId, turn_number as turnNumber,
+          file_path as filePath, operation, content_before as contentBefore,
+          content_after as contentAfter, diff_unified as diffUnified,
+          storage_mode as storageMode, bytes_before as bytesBefore,
+          bytes_after as bytesAfter, is_undone as isUndone,
+          undo_change_id as undoChangeId, tool_call_id as toolCallId,
+          created_at as createdAt
+        FROM file_changes
+        WHERE id = ? AND session_id = ?
+      `),
+
+      getChanges: this.db.prepare(`
+        SELECT
+          id, session_id as sessionId, turn_number as turnNumber,
+          file_path as filePath, operation, content_before as contentBefore,
+          content_after as contentAfter, diff_unified as diffUnified,
+          storage_mode as storageMode, bytes_before as bytesBefore,
+          bytes_after as bytesAfter, is_undone as isUndone,
+          undo_change_id as undoChangeId, tool_call_id as toolCallId,
+          created_at as createdAt
+        FROM file_changes
+        WHERE session_id = ?
+        ORDER BY id ASC
+      `),
+
+      getFileChanges: this.db.prepare(`
+        SELECT
+          id, session_id as sessionId, turn_number as turnNumber,
+          file_path as filePath, operation, content_before as contentBefore,
+          content_after as contentAfter, diff_unified as diffUnified,
+          storage_mode as storageMode, bytes_before as bytesBefore,
+          bytes_after as bytesAfter, is_undone as isUndone,
+          undo_change_id as undoChangeId, tool_call_id as toolCallId,
+          created_at as createdAt
+        FROM file_changes
+        WHERE session_id = ? AND file_path = ?
+        ORDER BY id ASC
+      `),
+
+      getLastFileChange: this.db.prepare(`
+        SELECT
+          id, session_id as sessionId, turn_number as turnNumber,
+          file_path as filePath, operation, content_before as contentBefore,
+          content_after as contentAfter, diff_unified as diffUnified,
+          storage_mode as storageMode, bytes_before as bytesBefore,
+          bytes_after as bytesAfter, is_undone as isUndone,
+          undo_change_id as undoChangeId, tool_call_id as toolCallId,
+          created_at as createdAt
+        FROM file_changes
+        WHERE session_id = ? AND file_path = ? AND is_undone = 0
+        ORDER BY id DESC
+        LIMIT 1
+      `),
+
+      getTurnChanges: this.db.prepare(`
+        SELECT
+          id, session_id as sessionId, turn_number as turnNumber,
+          file_path as filePath, operation, content_before as contentBefore,
+          content_after as contentAfter, diff_unified as diffUnified,
+          storage_mode as storageMode, bytes_before as bytesBefore,
+          bytes_after as bytesAfter, is_undone as isUndone,
+          undo_change_id as undoChangeId, tool_call_id as toolCallId,
+          created_at as createdAt
+        FROM file_changes
+        WHERE session_id = ? AND turn_number = ? AND is_undone = 0
+        ORDER BY id DESC
+      `),
+
+      markUndone: this.db.prepare(`
+        UPDATE file_changes
+        SET is_undone = 1, undo_change_id = ?
+        WHERE id = ? AND session_id = ?
+      `),
+
+      getSessionSummary: this.db.prepare(`
+        SELECT
+          COUNT(*) as totalChanges,
+          SUM(CASE WHEN is_undone = 0 THEN 1 ELSE 0 END) as activeChanges,
+          SUM(CASE WHEN is_undone = 1 THEN 1 ELSE 0 END) as undoneChanges,
+          SUM(CASE WHEN operation = 'create' AND is_undone = 0 THEN 1 ELSE 0 END) as createCount,
+          SUM(CASE WHEN operation = 'write' AND is_undone = 0 THEN 1 ELSE 0 END) as writeCount,
+          SUM(CASE WHEN operation = 'edit' AND is_undone = 0 THEN 1 ELSE 0 END) as editCount,
+          SUM(CASE WHEN operation = 'delete' AND is_undone = 0 THEN 1 ELSE 0 END) as deleteCount
+        FROM file_changes
+        WHERE session_id = ?
+      `),
+    };
+  }
+
+  /**
+   * Record a file change.
+   */
+  async recordChange(params: {
+    filePath: string;
+    operation: 'create' | 'write' | 'edit' | 'delete';
+    contentBefore?: string;
+    contentAfter?: string;
+    turnNumber: number;
+    toolCallId?: string;
+  }): Promise<number> {
+    if (!this.config.enabled) {
+      return -1;
+    }
+
+    const now = new Date().toISOString();
+    const contentBefore = params.contentBefore ?? null;
+    const contentAfter = params.contentAfter ?? null;
+    const bytesBefore = contentBefore ? Buffer.byteLength(contentBefore, 'utf-8') : 0;
+    const bytesAfter = contentAfter ? Buffer.byteLength(contentAfter, 'utf-8') : 0;
+
+    // Determine storage mode
+    let storageMode: 'full' | 'diff' = 'full';
+    let diffUnified: string | null = null;
+    let storedBefore = contentBefore;
+    let storedAfter = contentAfter;
+
+    // Use diff mode for large files
+    const totalBytes = bytesBefore + bytesAfter;
+    if (totalBytes > this.config.maxFullContentBytes && contentBefore && contentAfter) {
+      storageMode = 'diff';
+      diffUnified = generateUnifiedDiff(contentBefore, contentAfter, params.filePath);
+      // In diff mode, we only store the after content (current state) and the diff
+      // to reconstruct the before content
+      storedBefore = null;
+      storedAfter = contentAfter;
+    }
+
+    const result = this.stmts.insertChange.run({
+      sessionId: this.sessionId,
+      entryId: null,
+      toolCallId: params.toolCallId ?? null,
+      turnNumber: params.turnNumber,
+      filePath: params.filePath,
+      operation: params.operation,
+      contentBefore: storedBefore,
+      contentAfter: storedAfter,
+      diffUnified,
+      storageMode,
+      bytesBefore,
+      bytesAfter,
+      isUndone: 0,
+      undoChangeId: null,
+      createdAt: now,
+    });
+
+    return result.lastInsertRowid as number;
+  }
+
+  /**
+   * Undo a specific change by ID.
+   */
+  async undoChange(changeId: number): Promise<UndoResult> {
+    const row = this.stmts.getChange.get(changeId, this.sessionId) as {
+      id: number;
+      sessionId: string;
+      turnNumber: number;
+      filePath: string;
+      operation: string;
+      contentBefore: string | null;
+      contentAfter: string | null;
+      diffUnified: string | null;
+      storageMode: string;
+      bytesBefore: number;
+      bytesAfter: number;
+      isUndone: number;
+      undoChangeId: number | null;
+      toolCallId: string | null;
+      createdAt: string;
+    } | undefined;
+
+    if (!row) {
+      return {
+        success: false,
+        filePath: '',
+        message: `Change ${changeId} not found`,
+      };
+    }
+
+    if (row.isUndone) {
+      return {
+        success: false,
+        filePath: row.filePath,
+        message: `Change ${changeId} has already been undone`,
+      };
+    }
+
+    const filePath = row.filePath;
+
+    try {
+      // Determine what content to restore
+      let contentToRestore: string | null = null;
+
+      if (row.storageMode === 'full') {
+        contentToRestore = row.contentBefore;
+      } else if (row.storageMode === 'diff' && row.diffUnified && row.contentAfter) {
+        // Reconstruct the before content from the diff
+        contentToRestore = applyReverseDiff(row.contentAfter, row.diffUnified);
+      }
+
+      // Perform the undo based on operation type
+      switch (row.operation) {
+        case 'create':
+          // Undo create = delete the file
+          if (existsSync(filePath)) {
+            await unlink(filePath);
+          }
+          break;
+
+        case 'write':
+        case 'edit':
+          // Undo write/edit = restore previous content
+          if (contentToRestore !== null) {
+            await writeFile(filePath, contentToRestore, 'utf-8');
+          } else if (row.operation === 'write') {
+            // If no previous content for a write, delete the file
+            if (existsSync(filePath)) {
+              await unlink(filePath);
+            }
+          }
+          break;
+
+        case 'delete':
+          // Undo delete = recreate the file with original content
+          if (contentToRestore !== null) {
+            await writeFile(filePath, contentToRestore, 'utf-8');
+          }
+          break;
+      }
+
+      // Mark as undone (no undo change id since this isn't creating a new change record)
+      this.stmts.markUndone.run(null, changeId, this.sessionId);
+
+      return {
+        success: true,
+        filePath,
+        message: `Successfully undid ${row.operation} on ${filePath}`,
+        changeId,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        filePath,
+        message: `Failed to undo change: ${error instanceof Error ? error.message : String(error)}`,
+        changeId,
+      };
+    }
+  }
+
+  /**
+   * Undo the last change to a specific file.
+   */
+  async undoLastChange(filePath: string): Promise<UndoResult> {
+    const row = this.stmts.getLastFileChange.get(this.sessionId, filePath) as {
+      id: number;
+    } | undefined;
+
+    if (!row) {
+      return {
+        success: false,
+        filePath,
+        message: `No undoable changes found for ${filePath}`,
+      };
+    }
+
+    return this.undoChange(row.id);
+  }
+
+  /**
+   * Undo all changes in a turn.
+   */
+  async undoTurn(turnNumber: number): Promise<UndoResult[]> {
+    const rows = this.stmts.getTurnChanges.all(this.sessionId, turnNumber) as Array<{
+      id: number;
+      filePath: string;
+    }>;
+
+    const results: UndoResult[] = [];
+
+    // Undo in reverse order (last change first)
+    for (const row of rows) {
+      const result = await this.undoChange(row.id);
+      results.push(result);
+    }
+
+    return results;
+  }
+
+  /**
+   * Get all changes for a file.
+   */
+  getFileHistory(filePath: string): FileChange[] {
+    const rows = this.stmts.getFileChanges.all(this.sessionId, filePath) as Array<{
+      id: number;
+      sessionId: string;
+      turnNumber: number;
+      filePath: string;
+      operation: string;
+      contentBefore: string | null;
+      contentAfter: string | null;
+      diffUnified: string | null;
+      storageMode: string;
+      bytesBefore: number;
+      bytesAfter: number;
+      isUndone: number;
+      undoChangeId: number | null;
+      toolCallId: string | null;
+      createdAt: string;
+    }>;
+
+    return rows.map(row => ({
+      id: row.id,
+      sessionId: row.sessionId,
+      turnNumber: row.turnNumber,
+      filePath: row.filePath,
+      operation: row.operation as 'create' | 'write' | 'edit' | 'delete',
+      contentBefore: row.contentBefore,
+      contentAfter: row.contentAfter,
+      diffUnified: row.diffUnified,
+      storageMode: row.storageMode as 'full' | 'diff',
+      bytesBefore: row.bytesBefore,
+      bytesAfter: row.bytesAfter,
+      isUndone: row.isUndone === 1,
+      undoChangeId: row.undoChangeId,
+      toolCallId: row.toolCallId,
+      createdAt: row.createdAt,
+    }));
+  }
+
+  /**
+   * Get all changes in session.
+   */
+  getChanges(options?: { filePath?: string }): FileChange[] {
+    if (options?.filePath) {
+      return this.getFileHistory(options.filePath);
+    }
+
+    const rows = this.stmts.getChanges.all(this.sessionId) as Array<{
+      id: number;
+      sessionId: string;
+      turnNumber: number;
+      filePath: string;
+      operation: string;
+      contentBefore: string | null;
+      contentAfter: string | null;
+      diffUnified: string | null;
+      storageMode: string;
+      bytesBefore: number;
+      bytesAfter: number;
+      isUndone: number;
+      undoChangeId: number | null;
+      toolCallId: string | null;
+      createdAt: string;
+    }>;
+
+    return rows.map(row => ({
+      id: row.id,
+      sessionId: row.sessionId,
+      turnNumber: row.turnNumber,
+      filePath: row.filePath,
+      operation: row.operation as 'create' | 'write' | 'edit' | 'delete',
+      contentBefore: row.contentBefore,
+      contentAfter: row.contentAfter,
+      diffUnified: row.diffUnified,
+      storageMode: row.storageMode as 'full' | 'diff',
+      bytesBefore: row.bytesBefore,
+      bytesAfter: row.bytesAfter,
+      isUndone: row.isUndone === 1,
+      undoChangeId: row.undoChangeId,
+      toolCallId: row.toolCallId,
+      createdAt: row.createdAt,
+    }));
+  }
+
+  /**
+   * Get session change summary.
+   */
+  getSessionChangeSummary(): ChangeSummary {
+    const row = this.stmts.getSessionSummary.get(this.sessionId) as {
+      totalChanges: number;
+      activeChanges: number;
+      undoneChanges: number;
+      createCount: number;
+      writeCount: number;
+      editCount: number;
+      deleteCount: number;
+    };
+
+    // Get unique file paths from active changes
+    const changes = this.getChanges();
+    const activeFiles = new Set<string>();
+    for (const change of changes) {
+      if (!change.isUndone) {
+        activeFiles.add(change.filePath);
+      }
+    }
+
+    return {
+      totalChanges: row.totalChanges || 0,
+      activeChanges: row.activeChanges || 0,
+      undoneChanges: row.undoneChanges || 0,
+      filesModified: Array.from(activeFiles),
+      byOperation: {
+        create: row.createCount || 0,
+        write: row.writeCount || 0,
+        edit: row.editCount || 0,
+        delete: row.deleteCount || 0,
+      },
+    };
+  }
+}
+
+// =============================================================================
+// FACTORY
+// =============================================================================
+
+/**
+ * Create a FileChangeTracker instance.
+ */
+export function createFileChangeTracker(
+  db: Database.Database,
+  sessionId: string,
+  config?: FileChangeTrackerConfig
+): FileChangeTracker {
+  return new FileChangeTracker(db, sessionId, config);
+}

--- a/attocode/src/integrations/planning.ts
+++ b/attocode/src/integrations/planning.ts
@@ -258,6 +258,13 @@ Return ONLY the JSON array, no other text.`;
     this.currentPlan = null;
   }
 
+  /**
+   * Load a plan from a checkpoint.
+   */
+  loadPlan(plan: AgentPlan): void {
+    this.currentPlan = { ...plan };
+  }
+
   // ===========================================================================
   // REFLECTION
   // ===========================================================================

--- a/attocode/src/integrations/thread-manager.ts
+++ b/attocode/src/integrations/thread-manager.ts
@@ -6,7 +6,7 @@
  * rollback, and state recovery.
  */
 
-import type { Message, AgentState, AgentMetrics } from '../types.js';
+import type { Message, AgentState, AgentMetrics, AgentPlan } from '../types.js';
 
 // =============================================================================
 // TYPES
@@ -48,6 +48,8 @@ export interface CheckpointState {
   messages: Message[];
   metrics: AgentMetrics;
   iteration: number;
+  plan?: AgentPlan;
+  memoryContext?: string[];
   custom?: Record<string, unknown>;
 }
 
@@ -321,6 +323,8 @@ export class ThreadManager {
         messages: thread.messages.map(m => ({ ...m })),
         metrics: options.agentState?.metrics ?? this.emptyMetrics(),
         iteration: options.agentState?.iteration ?? 0,
+        plan: options.agentState?.plan ? { ...options.agentState.plan } : undefined,
+        memoryContext: options.agentState?.memoryContext ? [...options.agentState.memoryContext] : undefined,
         custom: options.metadata,
       },
       createdAt: new Date(),

--- a/attocode/src/main.ts
+++ b/attocode/src/main.ts
@@ -63,38 +63,143 @@ import {
 // Session store type that works with both SQLite and JSONL
 type AnySessionStore = SQLiteStore | SessionStore;
 
+// =============================================================================
+// DEBUG LOGGER FOR PERSISTENCE OPERATIONS
+// =============================================================================
+
+/**
+ * Debug logger for persistence operations.
+ * Enabled via --debug flag. Shows data flow at each layer boundary.
+ */
+class PersistenceDebugger {
+  private enabled = false;
+
+  enable(): void {
+    this.enabled = true;
+    this.log('🔍 Persistence debug mode ENABLED');
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  log(message: string, data?: unknown): void {
+    if (!this.enabled) return;
+    const timestamp = new Date().toISOString().split('T')[1].slice(0, 12);
+    console.log(`[${timestamp}] 🔧 ${message}`);
+    if (data !== undefined) {
+      console.log(`    └─ ${JSON.stringify(data, null, 2).split('\n').join('\n    ')}`);
+    }
+  }
+
+  error(message: string, err: unknown): void {
+    if (!this.enabled) return;
+    const timestamp = new Date().toISOString().split('T')[1].slice(0, 12);
+    console.error(`[${timestamp}] ❌ ${message}`);
+    if (err instanceof Error) {
+      console.error(`    └─ ${err.message}`);
+      if (err.stack) {
+        console.error(`    └─ Stack: ${err.stack.split('\n').slice(1, 3).join(' → ')}`);
+      }
+    } else {
+      console.error(`    └─ ${String(err)}`);
+    }
+  }
+
+  storeType(store: AnySessionStore): string {
+    if ('saveCheckpoint' in store && typeof store.saveCheckpoint === 'function') {
+      return 'SQLiteStore';
+    }
+    return 'JSONLStore';
+  }
+}
+
+// Global debug instance - enabled via --debug flag
+const persistenceDebug = new PersistenceDebugger();
+
+/**
+ * Checkpoint data structure for full state restoration.
+ */
+interface CheckpointData {
+  id: string;
+  label?: string;
+  messages: unknown[];
+  iteration: number;
+  metrics?: unknown;
+  plan?: unknown;
+  memoryContext?: string[];
+}
+
 /**
  * Save checkpoint to session store (works with both SQLite and JSONL).
+ * Now includes plan and memoryContext for full state restoration.
  */
 function saveCheckpointToStore(
   store: AnySessionStore,
-  checkpoint: { id: string; label?: string; messages: unknown[]; iteration: number; metrics?: unknown }
+  checkpoint: CheckpointData
 ): void {
-  if ('saveCheckpoint' in store && typeof store.saveCheckpoint === 'function') {
-    // SQLite store
-    store.saveCheckpoint(
-      {
-        id: checkpoint.id,
-        label: checkpoint.label,
-        messages: checkpoint.messages,
-        iteration: checkpoint.iteration,
-        metrics: checkpoint.metrics,
-      },
-      checkpoint.label || `auto-checkpoint-${checkpoint.id}`
-    );
-  } else if ('appendEntry' in store && typeof store.appendEntry === 'function') {
-    // JSONL store - use appendEntry with checkpoint type
-    store.appendEntry({
-      type: 'checkpoint',
-      data: {
-        id: checkpoint.id,
-        label: checkpoint.label,
-        messages: checkpoint.messages,
-        iteration: checkpoint.iteration,
-        metrics: checkpoint.metrics,
-        createdAt: new Date().toISOString(),
-      },
-    });
+  const storeType = persistenceDebug.storeType(store);
+  persistenceDebug.log(`saveCheckpointToStore called`, {
+    storeType,
+    checkpointId: checkpoint.id,
+    messageCount: checkpoint.messages?.length ?? 0,
+    hasLabel: !!checkpoint.label,
+    hasPlan: !!checkpoint.plan,
+  });
+
+  try {
+    if ('saveCheckpoint' in store && typeof store.saveCheckpoint === 'function') {
+      // SQLite store - check currentSessionId
+      const sqliteStore = store as SQLiteStore;
+      const currentSessionId = sqliteStore.getCurrentSessionId();
+      persistenceDebug.log(`SQLite saveCheckpoint`, {
+        currentSessionId,
+        hasCurrentSession: !!currentSessionId,
+      });
+
+      if (!currentSessionId) {
+        persistenceDebug.error('SQLite store has no currentSessionId!', new Error('No active session'));
+      }
+
+      const ckptId = store.saveCheckpoint(
+        {
+          id: checkpoint.id,
+          label: checkpoint.label,
+          messages: checkpoint.messages,
+          iteration: checkpoint.iteration,
+          metrics: checkpoint.metrics,
+          plan: checkpoint.plan,
+          memoryContext: checkpoint.memoryContext,
+        },
+        checkpoint.label || `auto-checkpoint-${checkpoint.id}`
+      );
+      persistenceDebug.log(`SQLite checkpoint saved successfully`, { returnedId: ckptId });
+    } else if ('appendEntry' in store && typeof store.appendEntry === 'function') {
+      // JSONL store - use appendEntry with checkpoint type
+      persistenceDebug.log(`JSONL appendEntry (checkpoint type)`);
+      store.appendEntry({
+        type: 'checkpoint',
+        data: {
+          id: checkpoint.id,
+          label: checkpoint.label,
+          messages: checkpoint.messages,
+          iteration: checkpoint.iteration,
+          metrics: checkpoint.metrics,
+          plan: checkpoint.plan,
+          memoryContext: checkpoint.memoryContext,
+          createdAt: new Date().toISOString(),
+        },
+      });
+      persistenceDebug.log(`JSONL checkpoint appended successfully`);
+    } else {
+      persistenceDebug.error('No compatible save method found on store', { storeType });
+    }
+  } catch (err) {
+    persistenceDebug.error(`Failed to save checkpoint`, err);
+    // Re-throw in debug mode so the error is visible
+    if (persistenceDebug.isEnabled()) {
+      throw err;
+    }
   }
 }
 
@@ -454,6 +559,11 @@ async function startProductionREPL(
     },
     hooks: { enabled: true },
     plugins: { enabled: true },
+    // LSP integration for code intelligence and diagnostics
+    lsp: {
+      enabled: true,
+      autoDetect: true, // Auto-detect and start language servers based on file types
+    },
   });
 
   // Subscribe to events
@@ -461,11 +571,26 @@ async function startProductionREPL(
 
   // Initialize session storage (try SQLite, fall back to JSONL if native module fails)
   let sessionStore: AnySessionStore;
+  let usingSQLite = false;
+  persistenceDebug.log('Initializing session store', { baseDir: '.agent/sessions' });
   try {
     sessionStore = await createSQLiteStore({ baseDir: '.agent/sessions' });
+    usingSQLite = true;
+    persistenceDebug.log('SQLite store created successfully');
+    console.log(c('✓ SQLite session store initialized', 'green'));
+
+    // Debug: verify SQLite tables
+    if (persistenceDebug.isEnabled()) {
+      const sqliteStore = sessionStore as SQLiteStore;
+      const stats = sqliteStore.getStats();
+      persistenceDebug.log('SQLite store stats', stats);
+    }
   } catch (sqliteError) {
+    persistenceDebug.error('SQLite initialization failed', sqliteError);
     console.log(c('⚠️  SQLite unavailable, using JSONL fallback', 'yellow'));
+    console.log(c(`   Error: ${(sqliteError as Error).message}`, 'dim'));
     sessionStore = await createSessionStore({ baseDir: '.agent/sessions' });
+    persistenceDebug.log('JSONL store created as fallback');
   }
   // mcpClient was created earlier for toolResolver
   const compactor = createCompactor(adaptedProvider, {
@@ -514,7 +639,13 @@ async function startProductionREPL(
   }
 
   // Create a new session
+  persistenceDebug.log('Creating new session');
   const sessionId = await sessionStore.createSession();
+  persistenceDebug.log('Session created', {
+    sessionId,
+    storeType: persistenceDebug.storeType(sessionStore),
+    currentSessionId: usingSQLite ? (sessionStore as SQLiteStore).getCurrentSessionId() : 'N/A (JSONL)',
+  });
 
   // Welcome
   console.log(`
@@ -580,9 +711,16 @@ ${c('╚════════════════════════
         console.log(c(`\n📊 Tokens: ${metrics.inputTokens} in / ${metrics.outputTokens} out | Tools: ${metrics.toolCalls} | Duration: ${metrics.duration}ms`, 'dim'));
 
         // Auto-checkpoint after Q&A cycle (force=true for every Q&A)
+        persistenceDebug.log('Attempting auto-checkpoint');
         const checkpoint = agent.autoCheckpoint(true);
         if (checkpoint) {
           console.log(c(`💾 Auto-checkpoint: ${checkpoint.id}`, 'dim'));
+          persistenceDebug.log('Auto-checkpoint created in agent', {
+            id: checkpoint.id,
+            label: checkpoint.label,
+            messageCount: checkpoint.state.messages?.length ?? 0,
+            iteration: checkpoint.state.iteration,
+          });
 
           // Persist checkpoint to session store for cross-session recovery
           try {
@@ -592,10 +730,18 @@ ${c('╚════════════════════════
               messages: checkpoint.state.messages,
               iteration: checkpoint.state.iteration,
               metrics: checkpoint.state.metrics,
+              plan: checkpoint.state.plan,
+              memoryContext: checkpoint.state.memoryContext,
             });
-          } catch {
-            // Silently ignore persistence errors
+          } catch (err) {
+            // Log error in debug mode, otherwise silent
+            persistenceDebug.error('Failed to persist checkpoint to store', err);
+            if (persistenceDebug.isEnabled()) {
+              console.log(c(`⚠️  Checkpoint persistence failed: ${(err as Error).message}`, 'yellow'));
+            }
           }
+        } else {
+          persistenceDebug.log('No checkpoint created (autoCheckpoint returned null)');
         }
 
       } catch (error) {
@@ -767,6 +913,36 @@ ${c('Activity:', 'bold')}
   Duration:        ${metrics.duration}ms
   Est. Cost:       $${metrics.estimatedCost.toFixed(4)}
 `);
+      break;
+
+    case '/theme':
+      try {
+        const { getThemeNames, getTheme } = await import('./tui/theme/index.js');
+        const themes = getThemeNames();
+
+        if (args.length === 0) {
+          console.log(`
+${c('Available Themes:', 'bold')}
+${themes.map(t => `  ${c(t, 'cyan')}`).join('\n')}
+
+${c('Usage:', 'dim')} /theme <name>
+${c('Note:', 'dim')} Theme switching is visual in TUI mode. REPL mode uses fixed ANSI colors.
+`);
+        } else {
+          const themeName = args[0];
+          if (themes.includes(themeName)) {
+            const selectedTheme = getTheme(themeName as 'dark' | 'light' | 'high-contrast' | 'auto');
+            console.log(c(`✓ Theme set to: ${themeName}`, 'green'));
+            console.log(c(`  Primary: ${selectedTheme.colors.primary}`, 'dim'));
+            console.log(c(`  Note: Full theme support requires TUI mode`, 'dim'));
+          } else {
+            console.log(c(`Unknown theme: ${themeName}`, 'red'));
+            console.log(c(`Available: ${themes.join(', ')}`, 'dim'));
+          }
+        }
+      } catch (error) {
+        console.log(c(`Error loading themes: ${(error as Error).message}`, 'red'));
+      }
       break;
 
     case '/react':
@@ -1243,15 +1419,27 @@ ${c('Tip:', 'dim')} Use /mcp search <query> to load specific tools on-demand.
     case '/save':
       try {
         const state = agent.getState();
-        await sessionStore.appendEntry({
-          type: 'checkpoint',
-          data: {
-            messages: state.messages,
-            metadata: agent.getMetrics(),
-          },
+        const metrics = agent.getMetrics();
+        const saveCheckpointId = `ckpt-manual-${Date.now().toString(36)}`;
+
+        persistenceDebug.log('/save command - creating checkpoint', {
+          checkpointId: saveCheckpointId,
+          messageCount: state.messages?.length ?? 0,
         });
-        console.log(c(`✓ Session saved: ${sessionId}`, 'green'));
+
+        saveCheckpointToStore(sessionStore, {
+          id: saveCheckpointId,
+          label: 'manual-save',
+          messages: state.messages,
+          iteration: state.iteration,
+          metrics: metrics,
+          plan: state.plan,
+          memoryContext: state.memoryContext,
+        });
+
+        console.log(c(`✓ Session saved: ${sessionId} (checkpoint: ${saveCheckpointId})`, 'green'));
       } catch (error) {
+        persistenceDebug.error('/save command failed', error);
         console.log(c(`Error saving session: ${(error as Error).message}`, 'red'));
       }
       break;
@@ -1263,19 +1451,38 @@ ${c('Tip:', 'dim')} Use /mcp search <query> to load specific tools on-demand.
       } else {
         const loadId = args[0];
         try {
-          const entries = await sessionStore.loadSession(loadId);
-          if (entries.length === 0) {
-            console.log(c(`No entries found for session: ${loadId}`, 'yellow'));
-          } else {
-            // Find the last checkpoint
-            const checkpoint = [...entries].reverse().find(e => e.type === 'checkpoint');
-            const checkpointData = checkpoint?.data as { messages?: unknown[] } | undefined;
-            if (checkpointData?.messages) {
-              agent.loadMessages(checkpointData.messages as any);
-              console.log(c(`✓ Loaded ${checkpointData.messages.length} messages from ${loadId}`, 'green'));
-            } else {
-              console.log(c('No checkpoint found in session', 'yellow'));
+          // Try SQLite's loadLatestCheckpoint first (checkpoints are in separate table)
+          let checkpointData: CheckpointData | undefined;
+          if ('loadLatestCheckpoint' in sessionStore && typeof sessionStore.loadLatestCheckpoint === 'function') {
+            const sqliteCheckpoint = sessionStore.loadLatestCheckpoint(loadId);
+            if (sqliteCheckpoint?.state) {
+              checkpointData = sqliteCheckpoint.state as unknown as CheckpointData;
             }
+          }
+
+          // Fall back to entries-based lookup (for JSONL or if SQLite checkpoint not found)
+          if (!checkpointData) {
+            const entries = await sessionStore.loadSession(loadId);
+            if (entries.length === 0) {
+              console.log(c(`No entries found for session: ${loadId}`, 'yellow'));
+              break;
+            }
+            const checkpoint = [...entries].reverse().find(e => e.type === 'checkpoint');
+            checkpointData = checkpoint?.data as CheckpointData | undefined;
+          }
+
+          if (checkpointData?.messages) {
+            // Use loadState for full state restoration
+            agent.loadState({
+              messages: checkpointData.messages as any,
+              iteration: checkpointData.iteration,
+              metrics: checkpointData.metrics as any,
+              plan: checkpointData.plan as any,
+              memoryContext: checkpointData.memoryContext,
+            });
+            console.log(c(`✓ Loaded ${checkpointData.messages.length} messages from ${loadId}`, 'green'));
+          } else {
+            console.log(c('No checkpoint found in session', 'yellow'));
           }
         } catch (error) {
           console.log(c(`Error loading session: ${(error as Error).message}`, 'red'));
@@ -1293,26 +1500,51 @@ ${c('Tip:', 'dim')} Use /mcp search <query> to load specific tools on-demand.
           console.log(c(`   Created: ${new Date(recentSession.createdAt).toLocaleString()}`, 'dim'));
           console.log(c(`   Messages: ${recentSession.messageCount}`, 'dim'));
 
-          // loadSession may be sync (SQLite) or async (JSONL)
-          const entriesResult = sessionStore.loadSession(recentSession.id);
-          const entries = Array.isArray(entriesResult) ? entriesResult : await entriesResult;
+          // Try SQLite's loadLatestCheckpoint first (checkpoints are in separate table)
+          let resumeCheckpointData: CheckpointData | undefined;
+          if ('loadLatestCheckpoint' in sessionStore && typeof sessionStore.loadLatestCheckpoint === 'function') {
+            const sqliteCheckpoint = sessionStore.loadLatestCheckpoint(recentSession.id);
+            if (sqliteCheckpoint?.state) {
+              resumeCheckpointData = sqliteCheckpoint.state as unknown as CheckpointData;
+            }
+          }
 
-          // Find the last checkpoint
-          const checkpoint = [...entries].reverse().find(e => e.type === 'checkpoint');
-          const checkpointData = checkpoint?.data as { messages?: unknown[] } | undefined;
-          if (checkpointData?.messages) {
-            agent.loadMessages(checkpointData.messages as any);
-            console.log(c(`✓ Resumed ${checkpointData.messages.length} messages from last session`, 'green'));
-          } else {
-            // No checkpoint, try to load messages directly from entries
-            const messages = entries
-              .filter((e: { type: string }) => e.type === 'message')
-              .map((e: { data: unknown }) => e.data);
-            if (messages.length > 0) {
-              agent.loadMessages(messages as any);
-              console.log(c(`✓ Resumed ${messages.length} messages from last session`, 'green'));
+          // Fall back to entries-based lookup (for JSONL or if SQLite checkpoint not found)
+          if (!resumeCheckpointData) {
+            const entriesResult = sessionStore.loadSession(recentSession.id);
+            const entries = Array.isArray(entriesResult) ? entriesResult : await entriesResult;
+            const checkpoint = [...entries].reverse().find(e => e.type === 'checkpoint');
+            if (checkpoint?.data) {
+              resumeCheckpointData = checkpoint.data as CheckpointData;
             } else {
-              console.log(c('No messages found in last session', 'yellow'));
+              // No checkpoint, try to load messages directly from entries
+              const messages = entries
+                .filter((e: { type: string }) => e.type === 'message')
+                .map((e: { data: unknown }) => e.data);
+              if (messages.length > 0) {
+                agent.loadState({ messages: messages as any });
+                console.log(c(`✓ Resumed ${messages.length} messages from last session`, 'green'));
+              } else {
+                console.log(c('No messages found in last session', 'yellow'));
+              }
+            }
+          }
+
+          if (resumeCheckpointData?.messages) {
+            // Use loadState for full state restoration
+            agent.loadState({
+              messages: resumeCheckpointData.messages as any,
+              iteration: resumeCheckpointData.iteration,
+              metrics: resumeCheckpointData.metrics as any,
+              plan: resumeCheckpointData.plan as any,
+              memoryContext: resumeCheckpointData.memoryContext,
+            });
+            console.log(c(`✓ Resumed ${resumeCheckpointData.messages.length} messages from last session`, 'green'));
+            if (resumeCheckpointData.iteration) {
+              console.log(c(`   Iteration: ${resumeCheckpointData.iteration}`, 'dim'));
+            }
+            if (resumeCheckpointData.plan) {
+              console.log(c(`   Plan restored`, 'dim'));
             }
           }
         }
@@ -1703,6 +1935,7 @@ interface CLIArgs {
   tui: boolean | 'auto';
   theme?: 'dark' | 'light' | 'auto';
   version: boolean;
+  debug: boolean;
 }
 
 function parseArgs(): CLIArgs {
@@ -1714,6 +1947,7 @@ function parseArgs(): CLIArgs {
     trace: false,
     tui: 'auto',
     version: false,
+    debug: false,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -1724,6 +1958,8 @@ function parseArgs(): CLIArgs {
       result.version = true;
     } else if (arg === '--trace') {
       result.trace = true;
+    } else if (arg === '--debug') {
+      result.debug = true;
     } else if (arg === '--tui') {
       result.tui = true;
     } else if (arg === '--legacy' || arg === '--no-tui') {
@@ -1780,6 +2016,7 @@ ${c('INTERFACE OPTIONS:', 'bold')}
   --legacy, --no-tui      Force legacy readline mode
   --theme THEME           Color theme: dark, light, auto (default: auto)
   --trace                 Enable JSONL trace capture (saved to .traces/)
+  --debug                 Enable verbose debug logging for persistence
 
 ${c('EXAMPLES:', 'bold')}
   ${c('# Interactive mode (auto-detects TUI)', 'dim')}
@@ -1859,6 +2096,35 @@ async function startTUIMode(
       return startProductionREPL(provider, options);
     }
 
+    // CRITICAL: Initialize session storage FIRST, before any heavy dynamic imports
+    // This ensures better-sqlite3 native module loads cleanly
+    let sessionStore: AnySessionStore;
+    let usingSQLiteTUI = false;
+
+    if (persistenceDebug.isEnabled()) {
+      process.stderr.write('[DEBUG] [TUI] Initializing session store BEFORE dynamic imports...\n');
+    }
+
+    try {
+      sessionStore = await createSQLiteStore({ baseDir: '.agent/sessions' });
+      usingSQLiteTUI = true;
+
+      if (persistenceDebug.isEnabled()) {
+        const sqliteStore = sessionStore as SQLiteStore;
+        const stats = sqliteStore.getStats();
+        process.stderr.write(`[DEBUG] [TUI] ✓ SQLite store initialized! Sessions: ${stats.sessionCount}, Checkpoints: ${stats.checkpointCount}\n`);
+      }
+      console.log('✓ SQLite session store initialized');
+    } catch (sqliteError) {
+      const errMsg = (sqliteError as Error).message;
+      if (persistenceDebug.isEnabled()) {
+        process.stderr.write(`[DEBUG] [TUI] ❌ SQLite FAILED: ${errMsg}\n`);
+      }
+      console.log('⚠️  SQLite unavailable, using JSONL fallback');
+      console.log(`   Error: ${errMsg}`);
+      sessionStore = await createSessionStore({ baseDir: '.agent/sessions' });
+    }
+
     // Dynamic imports - using our modular TUI components
     const { render, Box, Text, useApp, useInput } = await import('ink');
     const React = await import('react');
@@ -1925,19 +2191,18 @@ async function startTUIMode(
       observability: trace ? { enabled: true, traceCapture: { enabled: true, outputDir: '.traces' } } : undefined,
     });
 
-    // Initialize session storage (try SQLite, fall back to JSONL if native module fails)
-    let sessionStore: AnySessionStore;
-    try {
-      sessionStore = await createSQLiteStore({ baseDir: '.agent/sessions' });
-    } catch {
-      console.log('⚠️  SQLite unavailable, using JSONL fallback');
-      sessionStore = await createSessionStore({ baseDir: '.agent/sessions' });
-    }
+    // Session store was already initialized at the top of startTUIMode
     const compactor = createCompactor(adaptedProvider, {
       tokenThreshold: 80000,
       preserveRecentCount: 10,
     });
+    persistenceDebug.log('[TUI] Creating new session');
     const currentSessionId = await sessionStore.createSession();
+    persistenceDebug.log('[TUI] Session created', {
+      sessionId: currentSessionId,
+      storeType: persistenceDebug.storeType(sessionStore),
+      currentSessionId: usingSQLiteTUI ? (sessionStore as SQLiteStore).getCurrentSessionId() : 'N/A (JSONL)',
+    });
 
     // Initial theme (will be stateful inside component)
     const initialTheme = getTheme(theme);
@@ -2022,12 +2287,27 @@ async function startTUIMode(
           case 'save':
             try {
               const agentState = agent.getState();
-              await sessionStore.appendEntry({
-                type: 'checkpoint',
-                data: { messages: agentState.messages, metadata: agent.getMetrics() },
+              const agentMetrics = agent.getMetrics();
+              const tuiSaveCheckpointId = `ckpt-manual-${Date.now().toString(36)}`;
+
+              persistenceDebug.log('[TUI] /save command - creating checkpoint', {
+                checkpointId: tuiSaveCheckpointId,
+                messageCount: agentState.messages?.length ?? 0,
               });
-              addMessage('system', `Session saved: ${currentSessionId}`);
+
+              saveCheckpointToStore(sessionStore, {
+                id: tuiSaveCheckpointId,
+                label: 'manual-save',
+                messages: agentState.messages,
+                iteration: agentState.iteration,
+                metrics: agentMetrics,
+                plan: agentState.plan,
+                memoryContext: agentState.memoryContext,
+              });
+
+              addMessage('system', `Session saved: ${currentSessionId} (checkpoint: ${tuiSaveCheckpointId})`);
             } catch (e) {
+              persistenceDebug.error('[TUI] /save command failed', e);
               addMessage('error', (e as Error).message);
             }
             return;
@@ -2038,12 +2318,34 @@ async function startTUIMode(
               return;
             }
             try {
-              const loadResult = sessionStore.loadSession(args[0]);
-              const loadEntries = Array.isArray(loadResult) ? loadResult : await loadResult;
-              const checkpoint = [...loadEntries].reverse().find((e: any) => e.type === 'checkpoint');
-              const checkpointData = checkpoint?.data as { messages?: unknown[] } | undefined;
-              if (checkpointData?.messages) {
-                agent.loadMessages(checkpointData.messages as any);
+              // Try SQLite's loadLatestCheckpoint first (checkpoints are in separate table)
+              let tuiLoadCheckpoint: CheckpointData | undefined;
+              if ('loadLatestCheckpoint' in sessionStore && typeof sessionStore.loadLatestCheckpoint === 'function') {
+                const sqliteCheckpoint = sessionStore.loadLatestCheckpoint(args[0]);
+                if (sqliteCheckpoint?.state) {
+                  tuiLoadCheckpoint = sqliteCheckpoint.state as unknown as CheckpointData;
+                }
+              }
+
+              // Fall back to entries-based lookup
+              if (!tuiLoadCheckpoint) {
+                const loadResult = sessionStore.loadSession(args[0]);
+                const loadEntries = Array.isArray(loadResult) ? loadResult : await loadResult;
+                const checkpoint = [...loadEntries].reverse().find((e: any) => e.type === 'checkpoint');
+                if (checkpoint?.data) {
+                  tuiLoadCheckpoint = checkpoint.data as CheckpointData;
+                }
+              }
+
+              if (tuiLoadCheckpoint?.messages) {
+                // Use loadState for full state restoration
+                agent.loadState({
+                  messages: tuiLoadCheckpoint.messages as any,
+                  iteration: tuiLoadCheckpoint.iteration,
+                  metrics: tuiLoadCheckpoint.metrics as any,
+                  plan: tuiLoadCheckpoint.plan as any,
+                  memoryContext: tuiLoadCheckpoint.memoryContext,
+                });
                 // Sync TUI with loaded messages
                 const loadedMsgs = agent.getState().messages;
                 const syncedLoaded = loadedMsgs.map((m, i) => ({
@@ -2053,7 +2355,7 @@ async function startTUIMode(
                   ts: new Date(),
                 }));
                 setMessages(syncedLoaded);
-                addMessage('system', `Loaded ${checkpointData.messages.length} messages from ${args[0]}`);
+                addMessage('system', `Loaded ${tuiLoadCheckpoint.messages.length} messages from ${args[0]}`);
               } else {
                 addMessage('system', 'No checkpoint found in session');
               }
@@ -2071,20 +2373,42 @@ async function startTUIMode(
               }
               addMessage('system', `📂 Found: ${recentSess.id} (${recentSess.messageCount} messages)`);
 
-              const resumeResult = sessionStore.loadSession(recentSess.id);
-              const resumeEntries = Array.isArray(resumeResult) ? resumeResult : await resumeResult;
-              const resumeCheckpoint = [...resumeEntries].reverse().find((e: any) => e.type === 'checkpoint');
-              const resumeData = resumeCheckpoint?.data as { messages?: unknown[] } | undefined;
-
-              if (resumeData?.messages) {
-                agent.loadMessages(resumeData.messages as any);
-              } else {
-                const msgs = resumeEntries
-                  .filter((e: any) => e.type === 'message')
-                  .map((e: any) => e.data);
-                if (msgs.length > 0) {
-                  agent.loadMessages(msgs as any);
+              // Try SQLite's loadLatestCheckpoint first (checkpoints are in separate table)
+              let tuiResumeCheckpoint: CheckpointData | undefined;
+              if ('loadLatestCheckpoint' in sessionStore && typeof sessionStore.loadLatestCheckpoint === 'function') {
+                const sqliteCheckpoint = sessionStore.loadLatestCheckpoint(recentSess.id);
+                if (sqliteCheckpoint?.state) {
+                  tuiResumeCheckpoint = sqliteCheckpoint.state as unknown as CheckpointData;
                 }
+              }
+
+              // Fall back to entries-based lookup
+              if (!tuiResumeCheckpoint) {
+                const resumeResult = sessionStore.loadSession(recentSess.id);
+                const resumeEntries = Array.isArray(resumeResult) ? resumeResult : await resumeResult;
+                const resumeCheckpoint = [...resumeEntries].reverse().find((e: any) => e.type === 'checkpoint');
+                if (resumeCheckpoint?.data) {
+                  tuiResumeCheckpoint = resumeCheckpoint.data as CheckpointData;
+                } else {
+                  // No checkpoint, try to load messages directly from entries
+                  const msgs = resumeEntries
+                    .filter((e: any) => e.type === 'message')
+                    .map((e: any) => e.data);
+                  if (msgs.length > 0) {
+                    agent.loadState({ messages: msgs as any });
+                  }
+                }
+              }
+
+              if (tuiResumeCheckpoint?.messages) {
+                // Use loadState for full state restoration
+                agent.loadState({
+                  messages: tuiResumeCheckpoint.messages as any,
+                  iteration: tuiResumeCheckpoint.iteration,
+                  metrics: tuiResumeCheckpoint.metrics as any,
+                  plan: tuiResumeCheckpoint.plan as any,
+                  memoryContext: tuiResumeCheckpoint.memoryContext,
+                });
               }
 
               // Sync TUI with loaded messages
@@ -2806,9 +3130,16 @@ async function startTUIMode(
           addMessage('assistant', response + metricsLine);
 
           // Auto-checkpoint after Q&A cycle (force=true for every Q&A)
+          persistenceDebug.log('[TUI] Attempting auto-checkpoint');
           const checkpoint = agent.autoCheckpoint(true);
           if (checkpoint) {
             addMessage('system', `💾 Auto-checkpoint: ${checkpoint.id}`);
+            persistenceDebug.log('[TUI] Auto-checkpoint created in agent', {
+              id: checkpoint.id,
+              label: checkpoint.label,
+              messageCount: checkpoint.state.messages?.length ?? 0,
+              iteration: checkpoint.state.iteration,
+            });
 
             // Persist checkpoint to session store for cross-session recovery
             try {
@@ -2818,10 +3149,18 @@ async function startTUIMode(
                 messages: checkpoint.state.messages,
                 iteration: checkpoint.state.iteration,
                 metrics: checkpoint.state.metrics,
+                plan: checkpoint.state.plan,
+                memoryContext: checkpoint.state.memoryContext,
               });
-            } catch {
-              // Silently ignore persistence errors
+            } catch (ckptErr) {
+              // Log error in debug mode, otherwise silent
+              persistenceDebug.error('[TUI] Failed to persist checkpoint to store', ckptErr);
+              if (persistenceDebug.isEnabled()) {
+                addMessage('system', `⚠️ Checkpoint persistence failed: ${(ckptErr as Error).message}`);
+              }
             }
+          } else {
+            persistenceDebug.log('[TUI] No checkpoint created (autoCheckpoint returned null)');
           }
         } catch (e) {
           addMessage('error', (e as Error).message);
@@ -2917,8 +3256,12 @@ async function startTUIMode(
       );
     };
 
-    // Render TUI
-    console.clear();
+    // Render TUI (don't clear in debug mode so we can see initialization messages)
+    if (!persistenceDebug.isEnabled()) {
+      console.clear();
+    } else {
+      console.log('\n--- TUI Starting (debug mode - console not cleared) ---\n');
+    }
     const instance = render(React.createElement(TUIApp));
     await instance.waitUntilExit();
     await agent.cleanup();
@@ -2938,6 +3281,11 @@ async function startTUIMode(
 
 async function main(): Promise<void> {
   const args = parseArgs();
+
+  // Enable debug mode if requested
+  if (args.debug) {
+    persistenceDebug.enable();
+  }
 
   if (args.version) {
     console.log(`attocode v${VERSION}`);

--- a/attocode/src/main.ts
+++ b/attocode/src/main.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * Attocode - A Production Coding Agent
  *

--- a/attocode/src/persistence/index.ts
+++ b/attocode/src/persistence/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Persistence Module
+ *
+ * Provides schema migration and database management utilities
+ * for SQLite-based session storage.
+ *
+ * @example
+ * ```typescript
+ * import Database from 'better-sqlite3';
+ * import { applyMigrations, needsMigration, getMigrationStatus } from './persistence/index.js';
+ *
+ * const db = new Database('sessions.db');
+ *
+ * // Check and apply pending migrations
+ * if (needsMigration(db, './migrations')) {
+ *   const result = applyMigrations(db, './migrations');
+ *   console.log(`Applied ${result.applied} migrations, now at version ${result.currentVersion}`);
+ * }
+ *
+ * // Get detailed status
+ * const status = getMigrationStatus(db, './migrations');
+ * console.log(`Current: v${status.currentVersion}, Latest: v${status.latestVersion}`);
+ * ```
+ */
+
+// Migration utilities
+export {
+  // Types
+  type MigrationFile,
+  type MigrationResult,
+  // Version management
+  getSchemaVersion,
+  setSchemaVersion,
+  // Migration loading
+  loadMigrations,
+  // Migration execution
+  needsMigration,
+  getPendingMigrations,
+  applyMigrations,
+  applyMigrationsTo,
+  getMigrationStatus,
+} from './migrator.js';

--- a/attocode/src/persistence/migrations/001_initial.sql
+++ b/attocode/src/persistence/migrations/001_initial.sql
@@ -1,0 +1,55 @@
+-- Migration: 001_initial
+-- Description: Initial schema - captures existing tables and indexes
+-- Created: 2026
+
+-- Sessions table
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,
+  name TEXT,
+  created_at TEXT NOT NULL,
+  last_active_at TEXT NOT NULL,
+  message_count INTEGER DEFAULT 0,
+  token_count INTEGER DEFAULT 0,
+  summary TEXT
+);
+
+-- Session entries table (messages, tool calls, checkpoints, etc.)
+CREATE TABLE IF NOT EXISTS entries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  timestamp TEXT NOT NULL,
+  type TEXT NOT NULL,
+  data TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+-- Tool calls table (for fast tool lookup)
+CREATE TABLE IF NOT EXISTS tool_calls (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  arguments TEXT NOT NULL,
+  status TEXT DEFAULT 'pending',
+  result TEXT,
+  error TEXT,
+  duration_ms INTEGER,
+  created_at TEXT NOT NULL,
+  completed_at TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+-- Checkpoints table (for state restoration)
+CREATE TABLE IF NOT EXISTS checkpoints (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  state_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  description TEXT,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_entries_session ON entries(session_id);
+CREATE INDEX IF NOT EXISTS idx_entries_session_type ON entries(session_id, type);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_session ON tool_calls(session_id);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_session ON checkpoints(session_id);

--- a/attocode/src/persistence/migrations/002_add_costs.sql
+++ b/attocode/src/persistence/migrations/002_add_costs.sql
@@ -1,0 +1,27 @@
+-- Migration: 002_add_costs
+-- Description: Add cost tracking columns and usage logs table
+-- Created: 2026
+
+-- Add token and cost tracking columns to sessions
+-- Note: SQLite ALTER TABLE only supports adding columns, not modifying existing ones
+ALTER TABLE sessions ADD COLUMN prompt_tokens INTEGER DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN completion_tokens INTEGER DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN cost_usd REAL DEFAULT 0.0;
+
+-- Usage logs table for detailed per-call tracking
+CREATE TABLE IF NOT EXISTS usage_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  model_id TEXT NOT NULL,
+  prompt_tokens INTEGER NOT NULL DEFAULT 0,
+  completion_tokens INTEGER NOT NULL DEFAULT 0,
+  cost_usd REAL NOT NULL DEFAULT 0.0,
+  timestamp TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+-- Index for querying usage by session
+CREATE INDEX IF NOT EXISTS idx_usage_logs_session ON usage_logs(session_id);
+
+-- Index for querying usage by timestamp (for reporting)
+CREATE INDEX IF NOT EXISTS idx_usage_logs_timestamp ON usage_logs(timestamp);

--- a/attocode/src/persistence/migrations/003_add_session_hierarchy.sql
+++ b/attocode/src/persistence/migrations/003_add_session_hierarchy.sql
@@ -1,0 +1,26 @@
+-- Migration: 003_add_session_hierarchy
+-- Description: Add session hierarchy support for parent/child sessions
+-- Created: 2026
+
+-- Add parent session reference and session type to sessions
+-- parent_session_id: Links child sessions to their parent
+-- session_type: 'main', 'subagent', 'branch', etc.
+--
+-- NOTE: SQLite's ALTER TABLE does not support adding foreign key constraints.
+-- The parent-child relationship is enforced at the application level.
+-- Enable PRAGMA foreign_keys = ON before INSERT/UPDATE to validate references.
+ALTER TABLE sessions ADD COLUMN parent_session_id TEXT;
+ALTER TABLE sessions ADD COLUMN session_type TEXT DEFAULT 'main';
+ALTER TABLE sessions ADD COLUMN summary_message_id INTEGER;
+
+-- Add is_summary flag to entries for marking summary messages
+ALTER TABLE entries ADD COLUMN is_summary INTEGER DEFAULT 0;
+
+-- Index for finding child sessions
+CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
+
+-- Index for finding sessions by type
+CREATE INDEX IF NOT EXISTS idx_sessions_type ON sessions(session_type);
+
+-- Index for finding summary entries
+CREATE INDEX IF NOT EXISTS idx_entries_summary ON entries(session_id, is_summary) WHERE is_summary = 1;

--- a/attocode/src/persistence/migrations/004_compaction_history.sql
+++ b/attocode/src/persistence/migrations/004_compaction_history.sql
@@ -1,0 +1,25 @@
+-- Migration: 004_compaction_history
+-- Description: Tracks context compaction events for session continuity
+-- Created: 2026
+
+-- Compaction history table
+-- Stores detailed records of context compaction events including:
+-- - summary: The compacted summary text
+-- - references_json: JSON array of preserved reference identifiers
+-- - tokens_before/after: Token counts for measuring compression ratio
+-- - messages_compacted: Number of messages that were compacted
+CREATE TABLE IF NOT EXISTS compaction_history (
+  id TEXT PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  summary TEXT NOT NULL,
+  references_json TEXT NOT NULL,
+  tokens_before INTEGER NOT NULL,
+  tokens_after INTEGER NOT NULL,
+  messages_compacted INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+-- Index for querying compaction history by session
+CREATE INDEX IF NOT EXISTS idx_compaction_history_session
+  ON compaction_history(session_id);

--- a/attocode/src/persistence/migrations/005_file_changes.sql
+++ b/attocode/src/persistence/migrations/005_file_changes.sql
@@ -1,0 +1,39 @@
+-- Migration: 005_file_changes
+-- Description: Tracks file changes for undo capability
+-- Created: 2026
+
+-- File changes table
+-- Stores detailed records of file operations for undo/redo capability:
+-- - operation: create, write, edit, or delete
+-- - content_before/after: Full content snapshots or null if using diff
+-- - diff_unified: Unified diff format for large files
+-- - storage_mode: 'full' or 'diff' indicating how content is stored
+-- - is_undone: Whether this change has been reverted
+-- - undo_change_id: ID of the change that undid this one (if applicable)
+CREATE TABLE IF NOT EXISTS file_changes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL,
+  entry_id INTEGER,
+  tool_call_id TEXT,
+  turn_number INTEGER NOT NULL,
+  file_path TEXT NOT NULL,
+  operation TEXT NOT NULL,
+  content_before TEXT,
+  content_after TEXT,
+  diff_unified TEXT,
+  storage_mode TEXT DEFAULT 'full',
+  bytes_before INTEGER,
+  bytes_after INTEGER,
+  is_undone INTEGER DEFAULT 0,
+  undo_change_id INTEGER,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+-- Index for querying changes by session and file path
+CREATE INDEX IF NOT EXISTS idx_file_changes_session_path
+  ON file_changes(session_id, file_path);
+
+-- Index for querying changes by session and turn number
+CREATE INDEX IF NOT EXISTS idx_file_changes_session_turn
+  ON file_changes(session_id, turn_number);

--- a/attocode/src/persistence/migrator.ts
+++ b/attocode/src/persistence/migrator.ts
@@ -1,0 +1,380 @@
+/**
+ * Schema Migrator for SQLite Database
+ *
+ * Handles versioned SQL migrations using PRAGMA user_version.
+ * Migrations are applied sequentially and tracked in the database.
+ *
+ * ## Concurrency Warning
+ *
+ * This migrator is NOT safe for concurrent access. If multiple processes
+ * attempt to run migrations simultaneously, race conditions may occur.
+ * **Recommendation:** Run migrations from a single process at startup
+ * before spawning worker processes or subagents.
+ *
+ * ## Partial Failure Recovery
+ *
+ * SQLite requires autocommit mode for ALTER TABLE statements, so each
+ * migration runs outside a transaction. If a migration fails partway:
+ * - The schema version reflects the last successful migration
+ * - The database may have partial changes from the failed migration
+ *
+ * **Recommendation:** Design migrations to be idempotent (re-runnable).
+ * Column additions already handle "duplicate column name" errors gracefully.
+ * After fixing an issue, re-run applyMigrations() to continue.
+ *
+ * @example
+ * ```typescript
+ * import Database from 'better-sqlite3';
+ * import { applyMigrations, needsMigration } from './migrator.js';
+ *
+ * const db = new Database('sessions.db');
+ * if (needsMigration(db, './migrations')) {
+ *   const result = applyMigrations(db, './migrations');
+ *   console.log(`Applied ${result.applied} migrations`);
+ * }
+ * ```
+ */
+
+import Database from 'better-sqlite3';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Represents a parsed migration file.
+ */
+export interface MigrationFile {
+  /** Migration version number (extracted from filename) */
+  version: number;
+  /** Human-readable migration name */
+  name: string;
+  /** SQL content to execute */
+  sql: string;
+}
+
+/**
+ * Result of applying migrations.
+ */
+export interface MigrationResult {
+  /** Number of migrations applied */
+  applied: number;
+  /** Current schema version after migration */
+  currentVersion: number;
+  /** List of applied migration names */
+  appliedMigrations: string[];
+}
+
+// =============================================================================
+// SCHEMA VERSION MANAGEMENT
+// =============================================================================
+
+/**
+ * Get the current schema version from the database.
+ * Uses SQLite's PRAGMA user_version.
+ *
+ * @param db - Database instance
+ * @returns Current schema version (0 if never migrated)
+ */
+export function getSchemaVersion(db: Database.Database): number {
+  const result = db.pragma('user_version', { simple: true });
+  return typeof result === 'number' ? result : 0;
+}
+
+/**
+ * Set the schema version in the database.
+ * Uses SQLite's PRAGMA user_version.
+ *
+ * @param db - Database instance
+ * @param version - Version number to set
+ */
+export function setSchemaVersion(db: Database.Database, version: number): void {
+  db.pragma(`user_version = ${version}`);
+}
+
+// =============================================================================
+// MIGRATION FILE LOADING
+// =============================================================================
+
+/**
+ * Parse a migration filename to extract version and name.
+ *
+ * @param filename - Migration filename (e.g., "001_initial.sql")
+ * @returns Parsed version and name, or null if invalid format
+ */
+function parseMigrationFilename(filename: string): { version: number; name: string } | null {
+  // Match pattern: NNN_name.sql (e.g., 001_initial.sql, 002_add_costs.sql)
+  const match = filename.match(/^(\d+)_(.+)\.sql$/);
+  if (!match) return null;
+
+  return {
+    version: parseInt(match[1], 10),
+    name: match[2],
+  };
+}
+
+/**
+ * Load all migration files from a directory.
+ * Sorts migrations by version number.
+ *
+ * @param dir - Directory containing SQL migration files
+ * @returns Array of migration files sorted by version
+ */
+export function loadMigrations(dir: string): MigrationFile[] {
+  const migrations: MigrationFile[] = [];
+
+  let files: string[];
+  try {
+    files = readdirSync(dir);
+  } catch {
+    // Directory doesn't exist or can't be read
+    return [];
+  }
+
+  for (const file of files) {
+    // Skip non-SQL files
+    if (!file.endsWith('.sql')) continue;
+
+    const parsed = parseMigrationFilename(file);
+    if (!parsed) continue;
+
+    const sql = readFileSync(join(dir, file), 'utf-8');
+
+    migrations.push({
+      version: parsed.version,
+      name: parsed.name,
+      sql,
+    });
+  }
+
+  // Sort by version number (ascending)
+  return migrations.sort((a, b) => a.version - b.version);
+}
+
+// =============================================================================
+// MIGRATION APPLICATION
+// =============================================================================
+
+/**
+ * Check if the database needs migration.
+ *
+ * @param db - Database instance
+ * @param migrationsDir - Directory containing SQL migration files
+ * @returns True if there are pending migrations
+ */
+export function needsMigration(db: Database.Database, migrationsDir: string): boolean {
+  const currentVersion = getSchemaVersion(db);
+  const migrations = loadMigrations(migrationsDir);
+
+  if (migrations.length === 0) return false;
+
+  const latestVersion = migrations[migrations.length - 1].version;
+  return currentVersion < latestVersion;
+}
+
+/**
+ * Get the list of pending migrations.
+ *
+ * @param db - Database instance
+ * @param migrationsDir - Directory containing SQL migration files
+ * @returns Array of migrations that need to be applied
+ */
+export function getPendingMigrations(db: Database.Database, migrationsDir: string): MigrationFile[] {
+  const currentVersion = getSchemaVersion(db);
+  const migrations = loadMigrations(migrationsDir);
+
+  return migrations.filter(m => m.version > currentVersion);
+}
+
+/**
+ * Strip leading comment lines from a SQL statement.
+ * Preserves the actual SQL command after comments.
+ */
+function stripLeadingComments(sql: string): string {
+  const lines = sql.split('\n');
+  let startIndex = 0;
+
+  // Skip leading blank lines and comment lines
+  while (startIndex < lines.length) {
+    const line = lines[startIndex].trim();
+    if (line === '' || line.startsWith('--')) {
+      startIndex++;
+    } else {
+      break;
+    }
+  }
+
+  return lines.slice(startIndex).join('\n').trim();
+}
+
+/**
+ * Check if a statement is only comments (no actual SQL).
+ */
+function isCommentOnly(sql: string): boolean {
+  const stripped = stripLeadingComments(sql);
+  return stripped === '' || stripped.startsWith('--');
+}
+
+/**
+ * Execute SQL statements from a migration.
+ * Handles multiple statements and makes column additions idempotent.
+ *
+ * @param db - Database instance
+ * @param sql - SQL content to execute
+ */
+function executeMigrationSql(db: Database.Database, sql: string): void {
+  // Split by semicolons
+  const rawStatements = sql.split(';');
+
+  // Process each statement: trim, strip leading comments, filter out empty/comment-only
+  const statements = rawStatements
+    .map(s => s.trim())
+    .filter(s => s.length > 0 && !isCommentOnly(s));
+
+  for (const statement of statements) {
+    try {
+      db.exec(statement);
+    } catch (err) {
+      // Check if it's a "duplicate column" error for ALTER TABLE
+      // This makes migrations idempotent for column additions
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      if (errorMessage.includes('duplicate column name')) {
+        // Column already exists, skip this statement
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Apply all pending migrations to the database.
+ * Migrations are applied in a transaction for atomicity.
+ *
+ * @param db - Database instance
+ * @param migrationsDir - Directory containing SQL migration files
+ * @returns Result containing number of applied migrations and current version
+ * @throws Error if any migration fails (transaction is rolled back)
+ */
+export function applyMigrations(db: Database.Database, migrationsDir: string): MigrationResult {
+  const currentVersion = getSchemaVersion(db);
+  const migrations = loadMigrations(migrationsDir);
+  const appliedMigrations: string[] = [];
+
+  // Filter to only pending migrations
+  const pendingMigrations = migrations.filter(m => m.version > currentVersion);
+
+  if (pendingMigrations.length === 0) {
+    return {
+      applied: 0,
+      currentVersion,
+      appliedMigrations: [],
+    };
+  }
+
+  // Apply each migration in order
+  // Note: We can't use a single transaction for ALTER TABLE in SQLite
+  // as it requires autocommit mode. We apply each migration separately.
+  for (const migration of pendingMigrations) {
+    try {
+      executeMigrationSql(db, migration.sql);
+
+      // Update schema version after successful migration
+      setSchemaVersion(db, migration.version);
+      appliedMigrations.push(migration.name);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Migration ${migration.version}_${migration.name} failed: ${errorMessage}`
+      );
+    }
+  }
+
+  const newVersion = getSchemaVersion(db);
+
+  return {
+    applied: appliedMigrations.length,
+    currentVersion: newVersion,
+    appliedMigrations,
+  };
+}
+
+/**
+ * Apply migrations up to a specific version.
+ *
+ * @param db - Database instance
+ * @param migrationsDir - Directory containing SQL migration files
+ * @param targetVersion - Maximum version to apply
+ * @returns Result containing number of applied migrations and current version
+ */
+export function applyMigrationsTo(
+  db: Database.Database,
+  migrationsDir: string,
+  targetVersion: number
+): MigrationResult {
+  const currentVersion = getSchemaVersion(db);
+  const migrations = loadMigrations(migrationsDir);
+  const appliedMigrations: string[] = [];
+
+  // Filter to migrations between current and target version
+  const pendingMigrations = migrations.filter(
+    m => m.version > currentVersion && m.version <= targetVersion
+  );
+
+  if (pendingMigrations.length === 0) {
+    return {
+      applied: 0,
+      currentVersion,
+      appliedMigrations: [],
+    };
+  }
+
+  for (const migration of pendingMigrations) {
+    try {
+      executeMigrationSql(db, migration.sql);
+
+      setSchemaVersion(db, migration.version);
+      appliedMigrations.push(migration.name);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Migration ${migration.version}_${migration.name} failed: ${errorMessage}`
+      );
+    }
+  }
+
+  const newVersion = getSchemaVersion(db);
+
+  return {
+    applied: appliedMigrations.length,
+    currentVersion: newVersion,
+    appliedMigrations,
+  };
+}
+
+/**
+ * Get migration status for the database.
+ *
+ * @param db - Database instance
+ * @param migrationsDir - Directory containing SQL migration files
+ * @returns Object containing version info and pending migrations
+ */
+export function getMigrationStatus(db: Database.Database, migrationsDir: string): {
+  currentVersion: number;
+  latestVersion: number;
+  pendingCount: number;
+  pendingMigrations: Array<{ version: number; name: string }>;
+} {
+  const currentVersion = getSchemaVersion(db);
+  const migrations = loadMigrations(migrationsDir);
+  const pending = migrations.filter(m => m.version > currentVersion);
+
+  return {
+    currentVersion,
+    latestVersion: migrations.length > 0 ? migrations[migrations.length - 1].version : 0,
+    pendingCount: pending.length,
+    pendingMigrations: pending.map(m => ({ version: m.version, name: m.name })),
+  };
+}

--- a/attocode/src/test-sqlite.ts
+++ b/attocode/src/test-sqlite.ts
@@ -1,0 +1,127 @@
+/**
+ * Quick test script to debug SQLite session persistence
+ */
+import { createSQLiteStore, SQLiteStore } from './integrations/sqlite-store.js';
+import { createSessionStore, SessionStore } from './integrations/session-store.js';
+
+async function testSQLitePersistence() {
+  console.log('=== SQLite Persistence Test ===\n');
+
+  try {
+    // 1. Create SQLite store
+    console.log('1. Creating SQLite store...');
+    const store = await createSQLiteStore({ baseDir: '.agent/sessions' });
+    console.log('   ✓ Store created');
+
+    // 2. Check current state
+    console.log('\n2. Current store stats:');
+    const stats = store.getStats();
+    console.log(`   Sessions: ${stats.sessionCount}`);
+    console.log(`   Entries: ${stats.entryCount}`);
+    console.log(`   Checkpoints: ${stats.checkpointCount}`);
+    console.log(`   DB Size: ${stats.dbSizeBytes} bytes`);
+
+    // 3. Create a new session
+    console.log('\n3. Creating new session...');
+    const sessionId = store.createSession('test-session');
+    console.log(`   Session ID: ${sessionId}`);
+    console.log(`   Current Session ID in store: ${store.getCurrentSessionId()}`);
+
+    // 4. Check if currentSessionId is set correctly
+    if (store.getCurrentSessionId() !== sessionId) {
+      console.log('   ❌ ERROR: currentSessionId mismatch!');
+    } else {
+      console.log('   ✓ currentSessionId matches');
+    }
+
+    // 5. Try to save a checkpoint
+    console.log('\n4. Saving checkpoint...');
+    try {
+      const checkpointData = {
+        id: 'test-ckpt-1',
+        label: 'test-checkpoint',
+        messages: [{ role: 'user', content: 'test' }],
+        iteration: 1,
+      };
+      const ckptId = store.saveCheckpoint(checkpointData, 'test-checkpoint');
+      console.log(`   ✓ Checkpoint saved with ID: ${ckptId}`);
+    } catch (err) {
+      console.log(`   ❌ ERROR saving checkpoint: ${(err as Error).message}`);
+      console.log(`   Stack: ${(err as Error).stack}`);
+    }
+
+    // 6. Verify checkpoint was saved
+    console.log('\n5. Verifying checkpoint...');
+    const statsAfter = store.getStats();
+    console.log(`   Checkpoints before: ${stats.checkpointCount}`);
+    console.log(`   Checkpoints after: ${statsAfter.checkpointCount}`);
+
+    if (statsAfter.checkpointCount > stats.checkpointCount) {
+      console.log('   ✓ Checkpoint count increased!');
+    } else {
+      console.log('   ❌ Checkpoint count did NOT increase!');
+    }
+
+    // 7. Try to load the checkpoint
+    console.log('\n6. Loading checkpoint...');
+    const loaded = store.loadLatestCheckpoint(sessionId);
+    if (loaded) {
+      console.log(`   ✓ Loaded checkpoint: ${loaded.id}`);
+      console.log(`   State keys: ${Object.keys(loaded.state).join(', ')}`);
+    } else {
+      console.log('   ❌ No checkpoint found for session');
+    }
+
+    // 8. List all sessions
+    console.log('\n7. Listing sessions...');
+    const sessions = store.listSessions();
+    console.log(`   Total sessions: ${sessions.length}`);
+    if (sessions.length > 0) {
+      console.log(`   Most recent: ${sessions[0].id}`);
+    }
+
+    // Cleanup
+    store.close();
+    console.log('\n=== Test Complete ===');
+
+  } catch (err) {
+    console.error('\n❌ Test failed:', (err as Error).message);
+    console.error((err as Error).stack);
+  }
+}
+
+async function testStoreTypeDetection() {
+  console.log('\n=== Store Type Detection Test ===\n');
+
+  const sqliteStore = await createSQLiteStore({ baseDir: '.agent/sessions' });
+  const jsonlStore = await createSessionStore({ baseDir: '.agent/sessions' });
+
+  console.log('SQLite store checks:');
+  console.log('  "saveCheckpoint" in store:', 'saveCheckpoint' in sqliteStore);
+  console.log('  typeof store.saveCheckpoint:', typeof sqliteStore.saveCheckpoint);
+  console.log('  "appendEntry" in store:', 'appendEntry' in sqliteStore);
+
+  console.log('\nJSONL store checks:');
+  console.log('  "saveCheckpoint" in store:', 'saveCheckpoint' in jsonlStore);
+  console.log('  typeof (store as any).saveCheckpoint:', typeof (jsonlStore as any).saveCheckpoint);
+  console.log('  "appendEntry" in store:', 'appendEntry' in jsonlStore);
+
+  // Test the actual condition used in saveCheckpointToStore
+  console.log('\n=== saveCheckpointToStore detection ===');
+  function detectStoreType(store: SQLiteStore | SessionStore): string {
+    if ('saveCheckpoint' in store && typeof store.saveCheckpoint === 'function') {
+      return 'SQLite (will use saveCheckpoint)';
+    } else if ('appendEntry' in store && typeof store.appendEntry === 'function') {
+      return 'JSONL (will use appendEntry)';
+    }
+    return 'Unknown';
+  }
+
+  console.log('SQLite store detected as:', detectStoreType(sqliteStore));
+  console.log('JSONL store detected as:', detectStoreType(jsonlStore));
+
+  sqliteStore.close();
+  await jsonlStore.cleanup();
+}
+
+testSQLitePersistence().then(() => testStoreTypeDetection());

--- a/attocode/src/tools/undo.ts
+++ b/attocode/src/tools/undo.ts
@@ -1,0 +1,172 @@
+/**
+ * Undo Tools
+ *
+ * Tools for undoing file changes and viewing file history.
+ * These tools use the FileChangeTracker to provide undo capability
+ * for file operations within an agent session.
+ *
+ * @example
+ * ```typescript
+ * import { undoTools } from './tools/undo.js';
+ *
+ * // Register undo tools with agent
+ * for (const tool of undoTools) {
+ *   registry.register(tool);
+ * }
+ * ```
+ */
+
+import { z } from 'zod';
+import type { ToolDefinition, ToolResult, DangerLevel } from './types.js';
+import type { FileChangeTracker } from '../integrations/file-change-tracker.js';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/**
+ * Context passed to tool execution that provides access to agent features.
+ */
+export interface ToolExecutionContext {
+  /** Reference to the agent (if available) */
+  agent?: {
+    getFileChangeTracker?: () => FileChangeTracker | null;
+  };
+}
+
+/**
+ * Extended tool definition that accepts execution context.
+ */
+export interface ContextAwareToolDefinition<TInput extends z.ZodTypeAny = z.ZodTypeAny> {
+  /** Unique identifier */
+  name: string;
+  /** Human-readable description (shown to LLM) */
+  description: string;
+  /** Input parameter schema */
+  parameters: TInput;
+  /** Danger level for permission checking */
+  dangerLevel: DangerLevel;
+  /** Execute the tool with context */
+  execute: (input: z.infer<TInput>, context?: ToolExecutionContext) => Promise<ToolResult>;
+}
+
+// =============================================================================
+// UNDO FILE CHANGE TOOL
+// =============================================================================
+
+/**
+ * Tool to undo the last change to a specific file.
+ */
+export const undoFileChangeTool: ContextAwareToolDefinition = {
+  name: 'undo_file_change',
+  description: 'Undo the last change to a specific file, restoring its previous content',
+  parameters: z.object({
+    path: z.string().describe('The file path to undo changes for'),
+  }),
+  dangerLevel: 'moderate',
+  execute: async (args: { path: string }, context?: ToolExecutionContext): Promise<ToolResult> => {
+    const tracker = context?.agent?.getFileChangeTracker?.();
+    if (!tracker) {
+      return { success: false, output: 'File change tracking is not enabled' };
+    }
+
+    const result = await tracker.undoLastChange(args.path);
+    return {
+      success: result.success,
+      output: result.message,
+    };
+  },
+};
+
+// =============================================================================
+// SHOW FILE HISTORY TOOL
+// =============================================================================
+
+/**
+ * Tool to show change history for a file.
+ */
+export const showFileHistoryTool: ContextAwareToolDefinition = {
+  name: 'show_file_history',
+  description: 'Show the change history for a file in this session',
+  parameters: z.object({
+    path: z.string().describe('The file path to show history for'),
+  }),
+  dangerLevel: 'safe',
+  execute: async (args: { path: string }, context?: ToolExecutionContext): Promise<ToolResult> => {
+    const tracker = context?.agent?.getFileChangeTracker?.();
+    if (!tracker) {
+      return { success: false, output: 'File change tracking is not enabled' };
+    }
+
+    const history = tracker.getFileHistory(args.path);
+    if (history.length === 0) {
+      return { success: true, output: `No changes recorded for ${args.path}` };
+    }
+
+    const formatted = history.map((change, i) =>
+      `${i + 1}. [${change.operation}] Turn ${change.turnNumber} - ${change.createdAt}` +
+      `\n   Before: ${change.bytesBefore} bytes, After: ${change.bytesAfter} bytes` +
+      (change.isUndone ? ' (UNDONE)' : '')
+    ).join('\n');
+
+    return { success: true, output: `File history for ${args.path}:\n${formatted}` };
+  },
+};
+
+// =============================================================================
+// SHOW SESSION CHANGES TOOL
+// =============================================================================
+
+/**
+ * Tool to show session change summary.
+ */
+export const showSessionChangesTool: ContextAwareToolDefinition = {
+  name: 'show_session_changes',
+  description: 'Show a summary of all file changes in this session',
+  parameters: z.object({}),
+  dangerLevel: 'safe',
+  execute: async (_args: Record<string, never>, context?: ToolExecutionContext): Promise<ToolResult> => {
+    const tracker = context?.agent?.getFileChangeTracker?.();
+    if (!tracker) {
+      return { success: false, output: 'File change tracking is not enabled' };
+    }
+
+    const summary = tracker.getSessionChangeSummary();
+    const output = [
+      `Session Change Summary:`,
+      `  Total changes: ${summary.totalChanges}`,
+      `  Files modified: ${summary.filesModified.length}`,
+      `  Creates: ${summary.byOperation.create}`,
+      `  Writes: ${summary.byOperation.write}`,
+      `  Edits: ${summary.byOperation.edit}`,
+      `  Deletes: ${summary.byOperation.delete}`,
+      `  Undone: ${summary.undoneChanges}`,
+    ].join('\n');
+
+    return { success: true, output };
+  },
+};
+
+// =============================================================================
+// EXPORTS
+// =============================================================================
+
+/**
+ * All undo-related tools.
+ *
+ * These tools require the agent to pass a ToolExecutionContext
+ * that provides access to the FileChangeTracker via
+ * context.agent.getFileChangeTracker().
+ */
+export const undoTools: ContextAwareToolDefinition[] = [
+  undoFileChangeTool,
+  showFileHistoryTool,
+  showSessionChangesTool,
+];
+
+/**
+ * Cast undo tools to standard ToolDefinition format.
+ * Use this when registering with a registry that doesn't support context.
+ * Note: The tools will return "tracking not enabled" if context is not passed.
+ */
+export const undoToolsAsStandard: ToolDefinition[] = undoTools as unknown as ToolDefinition[];

--- a/attocode/tests/core/protocol/bridge.test.ts
+++ b/attocode/tests/core/protocol/bridge.test.ts
@@ -1,0 +1,471 @@
+/**
+ * Protocol Bridge Tests
+ *
+ * Comprehensive tests for the ProtocolBridge:
+ * - Start/stop lifecycle
+ * - Operation handling and dispatch
+ * - Event emission with correlation
+ * - Error handling
+ * - Graceful shutdown
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ProtocolBridge, createProtocolBridge } from '../../../src/core/protocol/bridge.js';
+import { SubmissionQueue } from '../../../src/core/queues/submission-queue.js';
+import { EventQueue } from '../../../src/core/queues/event-queue.js';
+import type { Operation, Submission, AgentEvent, EventEnvelope } from '../../../src/core/protocol/types.js';
+
+// =============================================================================
+// TEST HELPERS
+// =============================================================================
+
+/**
+ * Creates a test operation.
+ */
+function createTestOperation(content = 'test message'): Operation {
+  return {
+    type: 'user_turn',
+    content,
+  };
+}
+
+/**
+ * Creates a test event.
+ */
+function createTestEvent(content = 'agent response', done = true): AgentEvent {
+  return {
+    type: 'agent_message',
+    content,
+    done,
+  };
+}
+
+/**
+ * Waits for a condition to be true.
+ */
+async function waitFor(
+  condition: () => boolean,
+  timeout = 1000,
+  interval = 10
+): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeout) {
+      throw new Error('Timeout waiting for condition');
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+}
+
+// =============================================================================
+// PROTOCOL BRIDGE TESTS
+// =============================================================================
+
+describe('ProtocolBridge', () => {
+  let bridge: ProtocolBridge;
+  let submissionQueue: SubmissionQueue;
+  let eventQueue: EventQueue;
+
+  beforeEach(() => {
+    bridge = new ProtocolBridge();
+    submissionQueue = new SubmissionQueue({ maxSize: 64, timeout: 1000 });
+    eventQueue = new EventQueue({ maxRecentEvents: 100 });
+  });
+
+  afterEach(async () => {
+    // Clean up - stop bridge and close queue
+    if (bridge.isRunning()) {
+      bridge.stop();
+    }
+    submissionQueue.close();
+    // Wait a bit for async cleanup
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+
+  // ===========================================================================
+  // LIFECYCLE TESTS
+  // ===========================================================================
+
+  describe('lifecycle', () => {
+    it('starts in not-running state', () => {
+      expect(bridge.isRunning()).toBe(false);
+    });
+
+    it('start() sets running state', () => {
+      bridge.start(submissionQueue, eventQueue);
+      expect(bridge.isRunning()).toBe(true);
+    });
+
+    it('stop() clears running state', () => {
+      bridge.start(submissionQueue, eventQueue);
+      bridge.stop();
+      expect(bridge.isRunning()).toBe(false);
+    });
+
+    it('throws when starting already running bridge', () => {
+      bridge.start(submissionQueue, eventQueue);
+      expect(() => bridge.start(submissionQueue, eventQueue)).toThrow(
+        'ProtocolBridge is already running'
+      );
+    });
+
+    it('can be restarted after stopping', async () => {
+      bridge.start(submissionQueue, eventQueue);
+      bridge.stop();
+      // Close queue to unblock the consume loop
+      submissionQueue.close();
+      await bridge.waitForStop();
+
+      // Create new queues for restart
+      const newSubmissionQueue = new SubmissionQueue({ maxSize: 64, timeout: 1000 });
+      const newEventQueue = new EventQueue();
+
+      expect(() => bridge.start(newSubmissionQueue, newEventQueue)).not.toThrow();
+      expect(bridge.isRunning()).toBe(true);
+
+      bridge.stop();
+      newSubmissionQueue.close();
+    });
+
+    it('stops when queue is closed', async () => {
+      bridge.start(submissionQueue, eventQueue);
+      submissionQueue.close();
+      await bridge.waitForStop();
+      expect(bridge.isRunning()).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // OPERATION HANDLING TESTS
+  // ===========================================================================
+
+  describe('operation handling', () => {
+    it('calls registered handler for each submission', async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+      bridge.onOperation(handler);
+      bridge.start(submissionQueue, eventQueue);
+
+      // Submit an operation
+      await submissionQueue.submit(createTestOperation('message 1'));
+
+      // Wait for handler to be called
+      await waitFor(() => handler.mock.calls.length >= 1);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler.mock.calls[0][0]).toMatchObject({
+        op: { type: 'user_turn', content: 'message 1' },
+      });
+    });
+
+    it('handles multiple operations in order', async () => {
+      const receivedOperations: Submission[] = [];
+      const handler = vi.fn().mockImplementation(async (sub: Submission) => {
+        receivedOperations.push(sub);
+      });
+
+      bridge.onOperation(handler);
+      bridge.start(submissionQueue, eventQueue);
+
+      // Submit multiple operations
+      await submissionQueue.submit(createTestOperation('first'));
+      await submissionQueue.submit(createTestOperation('second'));
+      await submissionQueue.submit(createTestOperation('third'));
+
+      // Wait for all handlers to be called
+      await waitFor(() => handler.mock.calls.length >= 3);
+
+      expect(handler).toHaveBeenCalledTimes(3);
+      expect(receivedOperations[0].op).toMatchObject({ content: 'first' });
+      expect(receivedOperations[1].op).toMatchObject({ content: 'second' });
+      expect(receivedOperations[2].op).toMatchObject({ content: 'third' });
+    });
+
+    it('ignores operations when no handler is registered', async () => {
+      bridge.start(submissionQueue, eventQueue);
+
+      // Submit an operation without registering a handler
+      await submissionQueue.submit(createTestOperation());
+
+      // Give it time to process
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Bridge should still be running (no crash)
+      expect(bridge.isRunning()).toBe(true);
+    });
+
+    it('replaces previous handler when registering new one', async () => {
+      const handler1 = vi.fn().mockResolvedValue(undefined);
+      const handler2 = vi.fn().mockResolvedValue(undefined);
+
+      bridge.onOperation(handler1);
+      bridge.onOperation(handler2); // Should replace handler1
+      bridge.start(submissionQueue, eventQueue);
+
+      await submissionQueue.submit(createTestOperation());
+      await waitFor(() => handler2.mock.calls.length >= 1);
+
+      expect(handler1).not.toHaveBeenCalled();
+      expect(handler2).toHaveBeenCalledTimes(1);
+    });
+
+    it('provides submission with id, timestamp, and correlationId', async () => {
+      let receivedSubmission: Submission | null = null;
+      const handler = vi.fn().mockImplementation(async (sub: Submission) => {
+        receivedSubmission = sub;
+      });
+
+      bridge.onOperation(handler);
+      bridge.start(submissionQueue, eventQueue);
+
+      await submissionQueue.submit(createTestOperation(), 'my-correlation-id');
+      await waitFor(() => receivedSubmission !== null);
+
+      expect(receivedSubmission).not.toBeNull();
+      expect(receivedSubmission!.id).toBeDefined();
+      expect(receivedSubmission!.id).toMatch(/^sub-/);
+      expect(receivedSubmission!.timestamp).toBeDefined();
+      expect(typeof receivedSubmission!.timestamp).toBe('number');
+      expect(receivedSubmission!.correlationId).toBe('my-correlation-id');
+    });
+  });
+
+  // ===========================================================================
+  // EVENT EMISSION TESTS
+  // ===========================================================================
+
+  describe('event emission', () => {
+    it('throws when emitting without starting', () => {
+      expect(() => bridge.emit('sub-0', createTestEvent())).toThrow(
+        'ProtocolBridge not started - cannot emit events'
+      );
+    });
+
+    it('emits events to the event queue', async () => {
+      bridge.start(submissionQueue, eventQueue);
+
+      const receivedEvents: EventEnvelope[] = [];
+      eventQueue.subscribe((envelope) => {
+        receivedEvents.push(envelope);
+      });
+
+      bridge.emit('sub-123', createTestEvent('hello'));
+
+      // Wait for async dispatch
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(receivedEvents.length).toBe(1);
+      expect(receivedEvents[0].submissionId).toBe('sub-123');
+      expect(receivedEvents[0].event).toMatchObject({
+        type: 'agent_message',
+        content: 'hello',
+        done: true,
+      });
+    });
+
+    it('correlates events with submission ID', async () => {
+      let capturedSubmissionId: string | null = null;
+
+      bridge.onOperation(async (sub) => {
+        capturedSubmissionId = sub.id;
+        // Emit an event correlated with this submission
+        bridge.emit(sub.id, createTestEvent('response'));
+      });
+
+      bridge.start(submissionQueue, eventQueue);
+
+      const receivedEvents: EventEnvelope[] = [];
+      eventQueue.subscribe((envelope) => {
+        receivedEvents.push(envelope);
+      });
+
+      await submissionQueue.submit(createTestOperation());
+      await waitFor(() => receivedEvents.length >= 1);
+
+      expect(receivedEvents[0].submissionId).toBe(capturedSubmissionId);
+    });
+
+    it('emits multiple events for one submission', async () => {
+      bridge.onOperation(async (sub) => {
+        // Emit streaming events
+        bridge.emit(sub.id, createTestEvent('part 1', false));
+        bridge.emit(sub.id, createTestEvent('part 2', false));
+        bridge.emit(sub.id, createTestEvent('done', true));
+      });
+
+      bridge.start(submissionQueue, eventQueue);
+
+      const receivedEvents: EventEnvelope[] = [];
+      eventQueue.subscribe((envelope) => {
+        receivedEvents.push(envelope);
+      });
+
+      const subId = await submissionQueue.submit(createTestOperation());
+      await waitFor(() => receivedEvents.length >= 3);
+
+      expect(receivedEvents.length).toBe(3);
+      expect(receivedEvents.every((e) => e.submissionId === subId)).toBe(true);
+    });
+  });
+
+  // ===========================================================================
+  // ERROR HANDLING TESTS
+  // ===========================================================================
+
+  describe('error handling', () => {
+    it('continues processing after handler error', async () => {
+      let callCount = 0;
+      const handler = vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new Error('Handler error');
+        }
+      });
+
+      bridge.onOperation(handler);
+      bridge.start(submissionQueue, eventQueue);
+
+      // Submit two operations - first will fail, second should still be processed
+      await submissionQueue.submit(createTestOperation('first'));
+      await submissionQueue.submit(createTestOperation('second'));
+
+      await waitFor(() => handler.mock.calls.length >= 2);
+
+      expect(handler).toHaveBeenCalledTimes(2);
+      expect(bridge.isRunning()).toBe(true);
+    });
+
+    it('emits error event when handler throws', async () => {
+      const handler = vi.fn().mockRejectedValue(new Error('Handler exploded'));
+
+      bridge.onOperation(handler);
+      bridge.start(submissionQueue, eventQueue);
+
+      const receivedEvents: EventEnvelope[] = [];
+      eventQueue.subscribe((envelope) => {
+        receivedEvents.push(envelope);
+      });
+
+      const subId = await submissionQueue.submit(createTestOperation());
+      await waitFor(() => receivedEvents.length >= 1);
+
+      expect(receivedEvents.length).toBe(1);
+      expect(receivedEvents[0].submissionId).toBe(subId);
+      expect(receivedEvents[0].event.type).toBe('error');
+      expect((receivedEvents[0].event as any).code).toBe('OPERATION_HANDLER_ERROR');
+      expect((receivedEvents[0].event as any).message).toContain('Handler exploded');
+      expect((receivedEvents[0].event as any).recoverable).toBe(true);
+    });
+
+    it('includes stack trace in error event', async () => {
+      const testError = new Error('Test error with stack');
+      const handler = vi.fn().mockRejectedValue(testError);
+
+      bridge.onOperation(handler);
+      bridge.start(submissionQueue, eventQueue);
+
+      const receivedEvents: EventEnvelope[] = [];
+      eventQueue.subscribe((envelope) => {
+        receivedEvents.push(envelope);
+      });
+
+      await submissionQueue.submit(createTestOperation());
+      await waitFor(() => receivedEvents.length >= 1);
+
+      const errorEvent = receivedEvents[0].event as any;
+      expect(errorEvent.stack).toBeDefined();
+      expect(errorEvent.stack).toContain('Test error with stack');
+    });
+
+    it('handles non-Error throws gracefully', async () => {
+      const handler = vi.fn().mockRejectedValue('string error');
+
+      bridge.onOperation(handler);
+      bridge.start(submissionQueue, eventQueue);
+
+      const receivedEvents: EventEnvelope[] = [];
+      eventQueue.subscribe((envelope) => {
+        receivedEvents.push(envelope);
+      });
+
+      await submissionQueue.submit(createTestOperation());
+      await waitFor(() => receivedEvents.length >= 1);
+
+      const errorEvent = receivedEvents[0].event as any;
+      expect(errorEvent.message).toContain('string error');
+      expect(errorEvent.stack).toBeUndefined();
+    });
+  });
+
+  // ===========================================================================
+  // GRACEFUL SHUTDOWN TESTS
+  // ===========================================================================
+
+  describe('graceful shutdown', () => {
+    it('completes current operation before stopping', async () => {
+      let operationCompleted = false;
+
+      bridge.onOperation(async () => {
+        // Simulate long-running operation
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        operationCompleted = true;
+      });
+
+      bridge.start(submissionQueue, eventQueue);
+      await submissionQueue.submit(createTestOperation());
+
+      // Give the handler time to start
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Stop while operation is in progress
+      bridge.stop();
+
+      // Operation should complete
+      await waitFor(() => operationCompleted, 200);
+      expect(operationCompleted).toBe(true);
+    });
+
+    it('waitForStop() resolves when bridge stops', async () => {
+      bridge.start(submissionQueue, eventQueue);
+
+      const stopPromise = bridge.waitForStop();
+
+      submissionQueue.close();
+
+      await expect(stopPromise).resolves.toBeUndefined();
+    });
+
+    it('does not process new operations after stop', async () => {
+      const handler = vi.fn().mockResolvedValue(undefined);
+
+      bridge.onOperation(handler);
+      bridge.start(submissionQueue, eventQueue);
+
+      bridge.stop();
+      // Close queue to unblock the consume loop that's waiting on take()
+      submissionQueue.close();
+      await bridge.waitForStop();
+
+      // Create a new queue and try to submit - bridge won't consume from it
+      const newQueue = new SubmissionQueue({ maxSize: 64 });
+      await newQueue.submit(createTestOperation());
+
+      // Give it time to potentially be processed (should not be)
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(handler).not.toHaveBeenCalled();
+      newQueue.close();
+    });
+  });
+
+  // ===========================================================================
+  // FACTORY FUNCTION TESTS
+  // ===========================================================================
+
+  describe('createProtocolBridge', () => {
+    it('creates a new ProtocolBridge instance', () => {
+      const bridge = createProtocolBridge();
+      expect(bridge).toBeInstanceOf(ProtocolBridge);
+      expect(bridge.isRunning()).toBe(false);
+    });
+  });
+});

--- a/attocode/tests/core/protocol/types.test.ts
+++ b/attocode/tests/core/protocol/types.test.ts
@@ -1,0 +1,669 @@
+/**
+ * Protocol Types Tests
+ *
+ * Comprehensive tests for Operation validation with Zod schemas
+ * and type guard functions for both Operations and Events.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  OperationSchema,
+  isUserTurn,
+  isInterrupt,
+  isExecApproval,
+  isCompactApproval,
+  isAgentMessage,
+  isExecApprovalRequest,
+  isCompactApprovalRequest,
+  isTaskComplete,
+  isError,
+  type Operation,
+  type OpUserTurn,
+  type OpInterrupt,
+  type OpExecApproval,
+  type OpCompactApproval,
+  type AgentEvent,
+  type EventAgentMessage,
+  type EventExecApprovalRequest,
+  type EventCompactApprovalRequest,
+  type EventTaskComplete,
+  type EventError,
+  type EventToolResult,
+} from '../../../src/core/protocol/types.js';
+
+// =============================================================================
+// OPERATION VALIDATION WITH ZOD
+// =============================================================================
+
+describe('Operation Validation with Zod', () => {
+  describe('OpUserTurn', () => {
+    it('should accept valid user_turn operation', () => {
+      const validOp = {
+        type: 'user_turn',
+        content: 'Hello, please help me with a task',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe('user_turn');
+        expect((result.data as OpUserTurn).content).toBe('Hello, please help me with a task');
+      }
+    });
+
+    it('should accept user_turn with attachments', () => {
+      const validOp = {
+        type: 'user_turn',
+        content: 'Check this image',
+        attachments: [
+          { type: 'image', path: '/path/to/image.png', mimeType: 'image/png' },
+          { type: 'file', data: 'YmFzZTY0IGNvbnRlbnQ=' },
+        ],
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const data = result.data as OpUserTurn;
+        expect(data.attachments).toHaveLength(2);
+        expect(data.attachments![0].type).toBe('image');
+        expect(data.attachments![1].type).toBe('file');
+      }
+    });
+
+    it('should reject user_turn with empty content', () => {
+      const invalidOp = {
+        type: 'user_turn',
+        content: '',
+      };
+
+      const result = OperationSchema.safeParse(invalidOp);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('empty');
+      }
+    });
+
+    it('should reject user_turn with missing content', () => {
+      const invalidOp = {
+        type: 'user_turn',
+      };
+
+      const result = OperationSchema.safeParse(invalidOp);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('OpInterrupt', () => {
+    it('should accept valid interrupt operation', () => {
+      const validOp = {
+        type: 'interrupt',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe('interrupt');
+      }
+    });
+
+    it('should accept interrupt with optional reason', () => {
+      const validOp = {
+        type: 'interrupt',
+        reason: 'User requested stop',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as OpInterrupt).reason).toBe('User requested stop');
+      }
+    });
+  });
+
+  describe('OpExecApproval', () => {
+    it('should accept valid exec_approval operation (approved)', () => {
+      const validOp = {
+        type: 'exec_approval',
+        toolCallId: 'tool_123',
+        approved: true,
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe('exec_approval');
+        expect((result.data as OpExecApproval).approved).toBe(true);
+      }
+    });
+
+    it('should accept exec_approval with persistent flag', () => {
+      const validOp = {
+        type: 'exec_approval',
+        toolCallId: 'tool_456',
+        approved: true,
+        persistent: true,
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as OpExecApproval).persistent).toBe(true);
+      }
+    });
+
+    it('should accept exec_approval when rejected', () => {
+      const validOp = {
+        type: 'exec_approval',
+        toolCallId: 'tool_789',
+        approved: false,
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as OpExecApproval).approved).toBe(false);
+      }
+    });
+
+    it('should reject exec_approval without toolCallId', () => {
+      const invalidOp = {
+        type: 'exec_approval',
+        approved: true,
+      };
+
+      const result = OperationSchema.safeParse(invalidOp);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('OpCompactApproval', () => {
+    it('should accept valid compact_approval operation', () => {
+      const validOp = {
+        type: 'compact_approval',
+        approved: true,
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.type).toBe('compact_approval');
+      }
+    });
+
+    it('should accept compact_approval with summarize strategy', () => {
+      const validOp = {
+        type: 'compact_approval',
+        approved: true,
+        strategy: 'summarize',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as OpCompactApproval).strategy).toBe('summarize');
+      }
+    });
+
+    it('should accept compact_approval with truncate strategy', () => {
+      const validOp = {
+        type: 'compact_approval',
+        approved: true,
+        strategy: 'truncate',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as OpCompactApproval).strategy).toBe('truncate');
+      }
+    });
+
+    it('should accept compact_approval with hybrid strategy', () => {
+      const validOp = {
+        type: 'compact_approval',
+        approved: true,
+        strategy: 'hybrid',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect((result.data as OpCompactApproval).strategy).toBe('hybrid');
+      }
+    });
+
+    it('should reject compact_approval with invalid strategy', () => {
+      const invalidOp = {
+        type: 'compact_approval',
+        approved: true,
+        strategy: 'invalid_strategy',
+      };
+
+      const result = OperationSchema.safeParse(invalidOp);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('OpConfigureSession', () => {
+    it('should accept valid configure_session operation', () => {
+      const validOp = {
+        type: 'configure_session',
+        config: {
+          model: 'claude-3-opus',
+          maxIterations: 50,
+          autoCompact: true,
+          approvalPolicy: 'on_request',
+        },
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept configure_session with empty config', () => {
+      const validOp = {
+        type: 'configure_session',
+        config: {},
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject configure_session with invalid approvalPolicy', () => {
+      const invalidOp = {
+        type: 'configure_session',
+        config: {
+          approvalPolicy: 'sometimes',
+        },
+      };
+
+      const result = OperationSchema.safeParse(invalidOp);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('OpSwitchSession', () => {
+    it('should accept valid switch_session operation', () => {
+      const validOp = {
+        type: 'switch_session',
+        sessionId: 'session_abc123',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('OpForkSession', () => {
+    it('should accept valid fork_session operation', () => {
+      const validOp = {
+        type: 'fork_session',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept fork_session with optional name', () => {
+      const validOp = {
+        type: 'fork_session',
+        name: 'experimental-branch',
+      };
+
+      const result = OperationSchema.safeParse(validOp);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('Unknown Operation Types', () => {
+    it('should reject unknown operation type', () => {
+      const invalidOp = {
+        type: 'unknown_operation',
+        data: 'some data',
+      };
+
+      const result = OperationSchema.safeParse(invalidOp);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject operation with missing type', () => {
+      const invalidOp = {
+        content: 'hello',
+      };
+
+      const result = OperationSchema.safeParse(invalidOp);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject null operation', () => {
+      const result = OperationSchema.safeParse(null);
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject undefined operation', () => {
+      const result = OperationSchema.safeParse(undefined);
+      expect(result.success).toBe(false);
+    });
+  });
+});
+
+// =============================================================================
+// OPERATION TYPE GUARDS
+// =============================================================================
+
+describe('Operation Type Guards', () => {
+  // Sample operations for testing
+  const userTurnOp: OpUserTurn = {
+    type: 'user_turn',
+    content: 'Hello world',
+  };
+
+  const interruptOp: OpInterrupt = {
+    type: 'interrupt',
+    reason: 'User cancelled',
+  };
+
+  const execApprovalOp: OpExecApproval = {
+    type: 'exec_approval',
+    toolCallId: 'tool_123',
+    approved: true,
+  };
+
+  const compactApprovalOp: OpCompactApproval = {
+    type: 'compact_approval',
+    approved: true,
+    strategy: 'summarize',
+  };
+
+  describe('isUserTurn', () => {
+    it('should return true for user_turn operation', () => {
+      expect(isUserTurn(userTurnOp)).toBe(true);
+    });
+
+    it('should return false for interrupt operation', () => {
+      expect(isUserTurn(interruptOp)).toBe(false);
+    });
+
+    it('should return false for exec_approval operation', () => {
+      expect(isUserTurn(execApprovalOp)).toBe(false);
+    });
+
+    it('should return false for compact_approval operation', () => {
+      expect(isUserTurn(compactApprovalOp)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const op: Operation = userTurnOp;
+      if (isUserTurn(op)) {
+        // TypeScript should know op.content exists here
+        expect(op.content).toBe('Hello world');
+      }
+    });
+  });
+
+  describe('isInterrupt', () => {
+    it('should return true for interrupt operation', () => {
+      expect(isInterrupt(interruptOp)).toBe(true);
+    });
+
+    it('should return false for user_turn operation', () => {
+      expect(isInterrupt(userTurnOp)).toBe(false);
+    });
+
+    it('should return false for exec_approval operation', () => {
+      expect(isInterrupt(execApprovalOp)).toBe(false);
+    });
+
+    it('should return false for compact_approval operation', () => {
+      expect(isInterrupt(compactApprovalOp)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const op: Operation = interruptOp;
+      if (isInterrupt(op)) {
+        // TypeScript should know op.reason exists here
+        expect(op.reason).toBe('User cancelled');
+      }
+    });
+  });
+
+  describe('isExecApproval', () => {
+    it('should return true for exec_approval operation', () => {
+      expect(isExecApproval(execApprovalOp)).toBe(true);
+    });
+
+    it('should return false for user_turn operation', () => {
+      expect(isExecApproval(userTurnOp)).toBe(false);
+    });
+
+    it('should return false for interrupt operation', () => {
+      expect(isExecApproval(interruptOp)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const op: Operation = execApprovalOp;
+      if (isExecApproval(op)) {
+        expect(op.toolCallId).toBe('tool_123');
+        expect(op.approved).toBe(true);
+      }
+    });
+  });
+
+  describe('isCompactApproval', () => {
+    it('should return true for compact_approval operation', () => {
+      expect(isCompactApproval(compactApprovalOp)).toBe(true);
+    });
+
+    it('should return false for user_turn operation', () => {
+      expect(isCompactApproval(userTurnOp)).toBe(false);
+    });
+
+    it('should return false for interrupt operation', () => {
+      expect(isCompactApproval(interruptOp)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const op: Operation = compactApprovalOp;
+      if (isCompactApproval(op)) {
+        expect(op.approved).toBe(true);
+        expect(op.strategy).toBe('summarize');
+      }
+    });
+  });
+});
+
+// =============================================================================
+// EVENT TYPE GUARDS
+// =============================================================================
+
+describe('Event Type Guards', () => {
+  // Sample events for testing
+  const agentMessageEvent: EventAgentMessage = {
+    type: 'agent_message',
+    content: 'I will help you with that task.',
+    done: false,
+    model: 'claude-3-opus',
+  };
+
+  const execApprovalRequestEvent: EventExecApprovalRequest = {
+    type: 'exec_approval_request',
+    toolCallId: 'tool_456',
+    toolName: 'bash',
+    toolArgs: { command: 'ls -la' },
+    risk: 'moderate',
+    description: 'List directory contents',
+  };
+
+  const compactApprovalRequestEvent: EventCompactApprovalRequest = {
+    type: 'compact_approval_request',
+    currentTokens: 180000,
+    maxTokens: 200000,
+    proposedStrategy: 'hybrid',
+    estimatedTokensAfter: 80000,
+    summaryPreview: 'Summary of previous conversation...',
+  };
+
+  const taskCompleteEvent: EventTaskComplete = {
+    type: 'task_complete',
+    usage: {
+      inputTokens: 1000,
+      outputTokens: 500,
+      totalTokens: 1500,
+    },
+    status: 'success',
+    durationMs: 5000,
+  };
+
+  const errorEvent: EventError = {
+    type: 'error',
+    code: 'RATE_LIMIT',
+    message: 'Rate limit exceeded',
+    recoverable: true,
+    stack: 'Error: Rate limit exceeded\n    at ...',
+  };
+
+  const toolResultEvent: EventToolResult = {
+    type: 'tool_result',
+    toolCallId: 'tool_789',
+    toolName: 'read_file',
+    result: 'file contents here',
+    durationMs: 100,
+  };
+
+  describe('isAgentMessage', () => {
+    it('should return true for agent_message event', () => {
+      expect(isAgentMessage(agentMessageEvent)).toBe(true);
+    });
+
+    it('should return false for error event', () => {
+      expect(isAgentMessage(errorEvent)).toBe(false);
+    });
+
+    it('should return false for task_complete event', () => {
+      expect(isAgentMessage(taskCompleteEvent)).toBe(false);
+    });
+
+    it('should return false for tool_result event', () => {
+      expect(isAgentMessage(toolResultEvent)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const event: AgentEvent = agentMessageEvent;
+      if (isAgentMessage(event)) {
+        expect(event.content).toBe('I will help you with that task.');
+        expect(event.done).toBe(false);
+        expect(event.model).toBe('claude-3-opus');
+      }
+    });
+  });
+
+  describe('isExecApprovalRequest', () => {
+    it('should return true for exec_approval_request event', () => {
+      expect(isExecApprovalRequest(execApprovalRequestEvent)).toBe(true);
+    });
+
+    it('should return false for agent_message event', () => {
+      expect(isExecApprovalRequest(agentMessageEvent)).toBe(false);
+    });
+
+    it('should return false for error event', () => {
+      expect(isExecApprovalRequest(errorEvent)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const event: AgentEvent = execApprovalRequestEvent;
+      if (isExecApprovalRequest(event)) {
+        expect(event.toolName).toBe('bash');
+        expect(event.risk).toBe('moderate');
+      }
+    });
+  });
+
+  describe('isCompactApprovalRequest', () => {
+    it('should return true for compact_approval_request event', () => {
+      expect(isCompactApprovalRequest(compactApprovalRequestEvent)).toBe(true);
+    });
+
+    it('should return false for agent_message event', () => {
+      expect(isCompactApprovalRequest(agentMessageEvent)).toBe(false);
+    });
+
+    it('should return false for error event', () => {
+      expect(isCompactApprovalRequest(errorEvent)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const event: AgentEvent = compactApprovalRequestEvent;
+      if (isCompactApprovalRequest(event)) {
+        expect(event.currentTokens).toBe(180000);
+        expect(event.proposedStrategy).toBe('hybrid');
+      }
+    });
+  });
+
+  describe('isTaskComplete', () => {
+    it('should return true for task_complete event', () => {
+      expect(isTaskComplete(taskCompleteEvent)).toBe(true);
+    });
+
+    it('should return false for agent_message event', () => {
+      expect(isTaskComplete(agentMessageEvent)).toBe(false);
+    });
+
+    it('should return false for error event', () => {
+      expect(isTaskComplete(errorEvent)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const event: AgentEvent = taskCompleteEvent;
+      if (isTaskComplete(event)) {
+        expect(event.status).toBe('success');
+        expect(event.durationMs).toBe(5000);
+        expect(event.usage.totalTokens).toBe(1500);
+      }
+    });
+  });
+
+  describe('isError', () => {
+    it('should return true for error event', () => {
+      expect(isError(errorEvent)).toBe(true);
+    });
+
+    it('should return false for agent_message event', () => {
+      expect(isError(agentMessageEvent)).toBe(false);
+    });
+
+    it('should return false for task_complete event', () => {
+      expect(isError(taskCompleteEvent)).toBe(false);
+    });
+
+    it('should return false for tool_result event', () => {
+      expect(isError(toolResultEvent)).toBe(false);
+    });
+
+    it('should narrow type correctly', () => {
+      const event: AgentEvent = errorEvent;
+      if (isError(event)) {
+        expect(event.code).toBe('RATE_LIMIT');
+        expect(event.message).toBe('Rate limit exceeded');
+        expect(event.recoverable).toBe(true);
+      }
+    });
+
+    it('should handle non-recoverable errors', () => {
+      const fatalError: EventError = {
+        type: 'error',
+        code: 'FATAL',
+        message: 'Unrecoverable error',
+        recoverable: false,
+      };
+
+      expect(isError(fatalError)).toBe(true);
+      if (isError(fatalError)) {
+        expect(fatalError.recoverable).toBe(false);
+      }
+    });
+  });
+});

--- a/attocode/tests/core/queues/queues.test.ts
+++ b/attocode/tests/core/queues/queues.test.ts
@@ -1,0 +1,716 @@
+/**
+ * Queue System Tests
+ *
+ * Comprehensive tests for the queue infrastructure:
+ * - AtomicCounter: Unique ID generation
+ * - SubmissionQueue: Bounded async queue with backpressure
+ * - EventQueue: Pub/sub event emitter
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  AtomicCounter,
+  globalCounter,
+  SubmissionQueue,
+  QueueTimeoutError,
+  QueueClosedError,
+  EventQueue,
+  EventTimeoutError,
+} from '../../../src/core/queues/index.js';
+import type { Operation, AgentEvent, EventAgentMessage } from '../../../src/core/protocol/types.js';
+
+// =============================================================================
+// ATOMIC COUNTER TESTS
+// =============================================================================
+
+describe('AtomicCounter', () => {
+  let counter: AtomicCounter;
+
+  beforeEach(() => {
+    counter = new AtomicCounter();
+  });
+
+  describe('unique ID generation', () => {
+    it('generates unique IDs across 1000 iterations', () => {
+      const ids = new Set<string>();
+
+      for (let i = 0; i < 1000; i++) {
+        const id = counter.next();
+        expect(ids.has(id)).toBe(false);
+        ids.add(id);
+      }
+
+      expect(ids.size).toBe(1000);
+    });
+
+    it('generates IDs with correct prefix', () => {
+      const id = counter.next();
+      expect(id.startsWith('sub-')).toBe(true);
+    });
+  });
+
+  describe('monotonically increasing', () => {
+    it('generates monotonically increasing IDs', () => {
+      const ids: string[] = [];
+
+      for (let i = 0; i < 100; i++) {
+        ids.push(counter.next());
+      }
+
+      // Parse the base36 number from each ID and verify order
+      for (let i = 1; i < ids.length; i++) {
+        const prev = parseInt(ids[i - 1].replace('sub-', ''), 36);
+        const curr = parseInt(ids[i].replace('sub-', ''), 36);
+        expect(curr).toBeGreaterThan(prev);
+      }
+    });
+
+    it('starts from 0', () => {
+      const first = counter.next();
+      expect(first).toBe('sub-0');
+    });
+
+    it('increments correctly', () => {
+      expect(counter.next()).toBe('sub-0');
+      expect(counter.next()).toBe('sub-1');
+      expect(counter.next()).toBe('sub-2');
+    });
+  });
+
+  describe('reset', () => {
+    it('reset() returns counter to 0', () => {
+      // Generate some IDs
+      counter.next();
+      counter.next();
+      counter.next();
+
+      // Reset
+      counter.reset();
+
+      // Should start from 0 again
+      expect(counter.next()).toBe('sub-0');
+    });
+
+    it('reset() accepts custom value', () => {
+      counter.reset(100n);
+      expect(counter.next()).toBe('sub-2s'); // 100 in base36
+    });
+
+    it('current() returns current value without incrementing', () => {
+      counter.next();
+      counter.next();
+      expect(counter.current()).toBe(2n);
+      expect(counter.current()).toBe(2n); // Still 2, not incremented
+    });
+  });
+
+  describe('globalCounter', () => {
+    it('globalCounter is an AtomicCounter instance', () => {
+      expect(globalCounter).toBeInstanceOf(AtomicCounter);
+    });
+
+    it('globalCounter generates unique IDs', () => {
+      // Reset to avoid interference from other tests
+      globalCounter.reset();
+      const id1 = globalCounter.next();
+      const id2 = globalCounter.next();
+      expect(id1).not.toBe(id2);
+    });
+  });
+});
+
+// =============================================================================
+// SUBMISSION QUEUE TESTS
+// =============================================================================
+
+describe('SubmissionQueue', () => {
+  let queue: SubmissionQueue;
+
+  // Helper to create a test operation
+  const createOp = (content: string): Operation => ({
+    type: 'user_turn',
+    content,
+  });
+
+  beforeEach(() => {
+    queue = new SubmissionQueue({ maxSize: 10, timeout: 100 });
+  });
+
+  describe('submit and take', () => {
+    it('submit() and take() work correctly', async () => {
+      const op = createOp('test message');
+      const submissionId = await queue.submit(op);
+
+      expect(submissionId).toMatch(/^sub-/);
+
+      const submission = await queue.take();
+      expect(submission).not.toBeNull();
+      expect(submission!.op).toEqual(op);
+      expect(submission!.id).toBe(submissionId);
+    });
+
+    it('maintains FIFO order', async () => {
+      await queue.submit(createOp('first'));
+      await queue.submit(createOp('second'));
+      await queue.submit(createOp('third'));
+
+      const first = await queue.take();
+      const second = await queue.take();
+      const third = await queue.take();
+
+      expect((first!.op as { content: string }).content).toBe('first');
+      expect((second!.op as { content: string }).content).toBe('second');
+      expect((third!.op as { content: string }).content).toBe('third');
+    });
+
+    it('stores timestamp in submission', async () => {
+      const before = Date.now();
+      await queue.submit(createOp('test'));
+      const after = Date.now();
+
+      const submission = await queue.take();
+      expect(submission!.timestamp).toBeGreaterThanOrEqual(before);
+      expect(submission!.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('stores correlationId when provided', async () => {
+      await queue.submit(createOp('test'), 'correlation-123');
+      const submission = await queue.take();
+      expect(submission!.correlationId).toBe('correlation-123');
+    });
+  });
+
+  describe('queue size limit', () => {
+    it('isFull() returns true after maxSize items', async () => {
+      const smallQueue = new SubmissionQueue({ maxSize: 3, timeout: 100 });
+
+      expect(smallQueue.isFull()).toBe(false);
+
+      await smallQueue.submit(createOp('1'));
+      await smallQueue.submit(createOp('2'));
+      await smallQueue.submit(createOp('3'));
+
+      expect(smallQueue.isFull()).toBe(true);
+      expect(smallQueue.size()).toBe(3);
+    });
+
+    it('size() returns correct count', async () => {
+      expect(queue.size()).toBe(0);
+
+      await queue.submit(createOp('1'));
+      expect(queue.size()).toBe(1);
+
+      await queue.submit(createOp('2'));
+      expect(queue.size()).toBe(2);
+
+      await queue.take();
+      expect(queue.size()).toBe(1);
+    });
+
+    it('isEmpty() returns correct value', async () => {
+      expect(queue.isEmpty()).toBe(true);
+
+      await queue.submit(createOp('test'));
+      expect(queue.isEmpty()).toBe(false);
+
+      await queue.take();
+      expect(queue.isEmpty()).toBe(true);
+    });
+  });
+
+  describe('tryTake', () => {
+    it('tryTake() returns null when empty', () => {
+      const result = queue.tryTake();
+      expect(result).toBeNull();
+    });
+
+    it('tryTake() returns item when available', async () => {
+      await queue.submit(createOp('test'));
+
+      const result = queue.tryTake();
+      expect(result).not.toBeNull();
+      expect((result!.op as { content: string }).content).toBe('test');
+    });
+
+    it('tryTake() does not block', async () => {
+      // Should return immediately
+      const start = Date.now();
+      queue.tryTake();
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeLessThan(10);
+    });
+  });
+
+  describe('async iterator', () => {
+    it('async iterator consumes all items', async () => {
+      await queue.submit(createOp('1'));
+      await queue.submit(createOp('2'));
+      await queue.submit(createOp('3'));
+
+      // Close queue after items are submitted
+      queue.close();
+
+      const items: string[] = [];
+      for await (const submission of queue) {
+        items.push((submission.op as { content: string }).content);
+      }
+
+      expect(items).toEqual(['1', '2', '3']);
+    });
+
+    it('async iterator stops when queue is closed and empty', async () => {
+      await queue.submit(createOp('only'));
+      queue.close();
+
+      const items: string[] = [];
+      for await (const submission of queue) {
+        items.push((submission.op as { content: string }).content);
+      }
+
+      expect(items).toEqual(['only']);
+    });
+
+    it('async iterator handles immediate close', async () => {
+      queue.close();
+
+      const items: string[] = [];
+      for await (const submission of queue) {
+        items.push((submission.op as { content: string }).content);
+      }
+
+      expect(items).toEqual([]);
+    });
+  });
+
+  describe('backpressure', () => {
+    it('submit blocks when queue is full', async () => {
+      const smallQueue = new SubmissionQueue({ maxSize: 2, timeout: 1000 });
+
+      // Fill the queue
+      await smallQueue.submit(createOp('1'));
+      await smallQueue.submit(createOp('2'));
+
+      // This submit should block
+      let submitResolved = false;
+      const submitPromise = smallQueue.submit(createOp('3')).then(() => {
+        submitResolved = true;
+      });
+
+      // Give it a moment - should still be blocked
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(submitResolved).toBe(false);
+
+      // Take an item - should unblock submit
+      await smallQueue.take();
+      await submitPromise;
+      expect(submitResolved).toBe(true);
+    });
+
+    it('throws QueueTimeoutError when backpressure times out', async () => {
+      const smallQueue = new SubmissionQueue({ maxSize: 1, timeout: 50 });
+
+      await smallQueue.submit(createOp('1'));
+
+      // This should timeout
+      await expect(smallQueue.submit(createOp('2'))).rejects.toThrow(
+        QueueTimeoutError
+      );
+    });
+  });
+
+  describe('close behavior', () => {
+    it('throws QueueClosedError when submitting to closed queue', async () => {
+      queue.close();
+
+      await expect(queue.submit(createOp('test'))).rejects.toThrow(
+        QueueClosedError
+      );
+    });
+
+    it('take() returns null on closed empty queue', async () => {
+      queue.close();
+
+      const result = await queue.take();
+      expect(result).toBeNull();
+    });
+
+    it('isClosed() returns correct value', () => {
+      expect(queue.isClosed()).toBe(false);
+      queue.close();
+      expect(queue.isClosed()).toBe(true);
+    });
+
+    it('close() can be called multiple times safely', () => {
+      queue.close();
+      queue.close();
+      queue.close();
+      expect(queue.isClosed()).toBe(true);
+    });
+
+    it('pending take() resolves with null when queue closes', async () => {
+      // Start a take that will block
+      const takePromise = queue.take();
+
+      // Close the queue
+      queue.close();
+
+      // Should resolve with null
+      const result = await takePromise;
+      expect(result).toBeNull();
+    });
+  });
+});
+
+// =============================================================================
+// EVENT QUEUE TESTS
+// =============================================================================
+
+describe('EventQueue', () => {
+  let eventQueue: EventQueue;
+
+  // Helper to create a test event
+  const createMessageEvent = (content: string, done = false): EventAgentMessage => ({
+    type: 'agent_message',
+    content,
+    done,
+  });
+
+  const createErrorEvent = (): AgentEvent => ({
+    type: 'error',
+    code: 'TEST_ERROR',
+    message: 'Test error message',
+    recoverable: true,
+  });
+
+  beforeEach(() => {
+    eventQueue = new EventQueue({ maxRecentEvents: 10 });
+  });
+
+  describe('emit and subscribe', () => {
+    it('emit() notifies subscribers', async () => {
+      const received: AgentEvent[] = [];
+
+      eventQueue.subscribe((envelope) => {
+        received.push(envelope.event);
+      });
+
+      eventQueue.emit('sub-1', createMessageEvent('hello'));
+
+      // Wait for async dispatch
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(received).toHaveLength(1);
+      expect((received[0] as EventAgentMessage).content).toBe('hello');
+    });
+
+    it('emit() includes submissionId in envelope', async () => {
+      let capturedSubmissionId: string | undefined;
+
+      eventQueue.subscribe((envelope) => {
+        capturedSubmissionId = envelope.submissionId;
+      });
+
+      eventQueue.emit('sub-123', createMessageEvent('test'));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(capturedSubmissionId).toBe('sub-123');
+    });
+
+    it('emit() includes timestamp in envelope', async () => {
+      let capturedTimestamp: number | undefined;
+
+      const before = Date.now();
+      eventQueue.subscribe((envelope) => {
+        capturedTimestamp = envelope.timestamp;
+      });
+
+      eventQueue.emit('sub-1', createMessageEvent('test'));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      const after = Date.now();
+
+      expect(capturedTimestamp).toBeGreaterThanOrEqual(before);
+      expect(capturedTimestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('multiple subscribers receive the same event', async () => {
+      const received1: AgentEvent[] = [];
+      const received2: AgentEvent[] = [];
+
+      eventQueue.subscribe((envelope) => received1.push(envelope.event));
+      eventQueue.subscribe((envelope) => received2.push(envelope.event));
+
+      eventQueue.emit('sub-1', createMessageEvent('shared'));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(received1).toHaveLength(1);
+      expect(received2).toHaveLength(1);
+    });
+  });
+
+  describe('typed listeners', () => {
+    it('typed listeners receive only matching event types', async () => {
+      const messageEvents: EventAgentMessage[] = [];
+      const allEvents: AgentEvent[] = [];
+
+      // Typed listener for agent_message only
+      eventQueue.on<EventAgentMessage>('agent_message', (envelope) => {
+        messageEvents.push(envelope.event);
+      });
+
+      // Global listener for all events
+      eventQueue.subscribe((envelope) => {
+        allEvents.push(envelope.event);
+      });
+
+      // Emit different event types
+      eventQueue.emit('sub-1', createMessageEvent('msg1'));
+      eventQueue.emit('sub-2', createErrorEvent());
+      eventQueue.emit('sub-3', createMessageEvent('msg2'));
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // Typed listener should only have messages
+      expect(messageEvents).toHaveLength(2);
+      expect(messageEvents[0].content).toBe('msg1');
+      expect(messageEvents[1].content).toBe('msg2');
+
+      // Global listener should have all events
+      expect(allEvents).toHaveLength(3);
+    });
+
+    it('on() returns unsubscribe function', async () => {
+      const received: EventAgentMessage[] = [];
+
+      const unsubscribe = eventQueue.on<EventAgentMessage>('agent_message', (envelope) => {
+        received.push(envelope.event);
+      });
+
+      eventQueue.emit('sub-1', createMessageEvent('before'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      unsubscribe();
+
+      eventQueue.emit('sub-2', createMessageEvent('after'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(received).toHaveLength(1);
+      expect(received[0].content).toBe('before');
+    });
+  });
+
+  describe('once', () => {
+    it('once() resolves with first matching event', async () => {
+      const promise = eventQueue.once<EventAgentMessage>('agent_message');
+
+      eventQueue.emit('sub-1', createMessageEvent('first'));
+      eventQueue.emit('sub-2', createMessageEvent('second'));
+
+      const result = await promise;
+
+      expect(result.event.content).toBe('first');
+      expect(result.submissionId).toBe('sub-1');
+    });
+
+    it('once() ignores non-matching events', async () => {
+      const promise = eventQueue.once<EventAgentMessage>('agent_message');
+
+      eventQueue.emit('sub-1', createErrorEvent());
+      eventQueue.emit('sub-2', createMessageEvent('target'));
+
+      const result = await promise;
+
+      expect(result.event.type).toBe('agent_message');
+      expect(result.event.content).toBe('target');
+    });
+
+    it('once() with timeout rejects when no event arrives', async () => {
+      const promise = eventQueue.once<EventAgentMessage>('agent_message', 50);
+
+      await expect(promise).rejects.toThrow(EventTimeoutError);
+    });
+
+    it('once() with timeout resolves if event arrives in time', async () => {
+      const promise = eventQueue.once<EventAgentMessage>('agent_message', 1000);
+
+      setTimeout(() => {
+        eventQueue.emit('sub-1', createMessageEvent('in time'));
+      }, 10);
+
+      const result = await promise;
+      expect(result.event.content).toBe('in time');
+    });
+  });
+
+  describe('getRecentEvents', () => {
+    it('getRecentEvents() returns stored events', () => {
+      eventQueue.emit('sub-1', createMessageEvent('event1'));
+      eventQueue.emit('sub-2', createMessageEvent('event2'));
+      eventQueue.emit('sub-3', createMessageEvent('event3'));
+
+      const recent = eventQueue.getRecentEvents();
+
+      expect(recent).toHaveLength(3);
+      expect((recent[0].event as EventAgentMessage).content).toBe('event1');
+      expect((recent[2].event as EventAgentMessage).content).toBe('event3');
+    });
+
+    it('getRecentEvents() respects maxRecentEvents limit', () => {
+      const smallQueue = new EventQueue({ maxRecentEvents: 3 });
+
+      for (let i = 0; i < 5; i++) {
+        smallQueue.emit(`sub-${i}`, createMessageEvent(`event${i}`));
+      }
+
+      const recent = smallQueue.getRecentEvents();
+
+      expect(recent).toHaveLength(3);
+      // Should have the last 3 events
+      expect((recent[0].event as EventAgentMessage).content).toBe('event2');
+      expect((recent[1].event as EventAgentMessage).content).toBe('event3');
+      expect((recent[2].event as EventAgentMessage).content).toBe('event4');
+    });
+
+    it('getRecentEvents(since) filters by timestamp', async () => {
+      eventQueue.emit('sub-1', createMessageEvent('before'));
+
+      // Wait a bit so timestamps differ
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const midpoint = Date.now();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      eventQueue.emit('sub-2', createMessageEvent('after'));
+
+      const recent = eventQueue.getRecentEvents(midpoint);
+
+      expect(recent).toHaveLength(1);
+      expect((recent[0].event as EventAgentMessage).content).toBe('after');
+    });
+
+    it('getEventsForSubmission() filters by submissionId', () => {
+      eventQueue.emit('sub-1', createMessageEvent('s1-e1'));
+      eventQueue.emit('sub-2', createMessageEvent('s2-e1'));
+      eventQueue.emit('sub-1', createMessageEvent('s1-e2'));
+      eventQueue.emit('sub-2', createMessageEvent('s2-e2'));
+
+      const sub1Events = eventQueue.getEventsForSubmission('sub-1');
+
+      expect(sub1Events).toHaveLength(2);
+      expect((sub1Events[0].event as EventAgentMessage).content).toBe('s1-e1');
+      expect((sub1Events[1].event as EventAgentMessage).content).toBe('s1-e2');
+    });
+  });
+
+  describe('unsubscribe', () => {
+    it('unsubscribe from global listener works correctly', async () => {
+      const received: AgentEvent[] = [];
+
+      const unsubscribe = eventQueue.subscribe((envelope) => {
+        received.push(envelope.event);
+      });
+
+      eventQueue.emit('sub-1', createMessageEvent('before'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(received).toHaveLength(1);
+
+      unsubscribe();
+
+      eventQueue.emit('sub-2', createMessageEvent('after'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(received).toHaveLength(1); // Still 1, not 2
+    });
+
+    it('unsubscribe from typed listener works correctly', async () => {
+      const received: EventAgentMessage[] = [];
+
+      const unsubscribe = eventQueue.on<EventAgentMessage>('agent_message', (envelope) => {
+        received.push(envelope.event);
+      });
+
+      eventQueue.emit('sub-1', createMessageEvent('before'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      unsubscribe();
+
+      eventQueue.emit('sub-2', createMessageEvent('after'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(received).toHaveLength(1);
+    });
+  });
+
+  describe('clear and stats', () => {
+    it('clear() removes all listeners and recent events', async () => {
+      const received: AgentEvent[] = [];
+
+      eventQueue.subscribe((envelope) => received.push(envelope.event));
+      eventQueue.emit('sub-1', createMessageEvent('test'));
+      eventQueue.emit('sub-2', createMessageEvent('test2'));
+
+      // Wait for events to be processed
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(received).toHaveLength(2);
+      expect(eventQueue.getRecentEvents()).toHaveLength(2);
+
+      // Clear should remove listeners and stored events
+      eventQueue.clear();
+
+      // Recent events should now be empty
+      expect(eventQueue.getRecentEvents()).toHaveLength(0);
+
+      // New events should not be received by old listeners (they were removed)
+      eventQueue.emit('sub-3', createMessageEvent('after clear'));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Received count should still be 2 (no new events received - listeners cleared)
+      expect(received).toHaveLength(2);
+
+      // But new events are still stored in recent events buffer
+      expect(eventQueue.getRecentEvents()).toHaveLength(1);
+    });
+
+    it('stats() returns correct statistics', () => {
+      eventQueue.subscribe(() => {});
+      eventQueue.subscribe(() => {});
+      eventQueue.on('agent_message', () => {});
+      eventQueue.on('error', () => {});
+      eventQueue.on('error', () => {});
+      eventQueue.emit('sub-1', createMessageEvent('test'));
+
+      const stats = eventQueue.stats();
+
+      expect(stats.globalListeners).toBe(2);
+      expect(stats.typedListeners).toEqual({
+        agent_message: 1,
+        error: 2,
+      });
+      expect(stats.recentEventsCount).toBe(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('listener errors do not affect other listeners', async () => {
+      const received: string[] = [];
+
+      eventQueue.subscribe(() => {
+        throw new Error('Listener error');
+      });
+
+      eventQueue.subscribe((envelope) => {
+        received.push((envelope.event as EventAgentMessage).content);
+      });
+
+      eventQueue.emit('sub-1', createMessageEvent('test'));
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Second listener should still receive the event
+      expect(received).toEqual(['test']);
+    });
+  });
+});

--- a/attocode/tests/integration/core-persistence.test.ts
+++ b/attocode/tests/integration/core-persistence.test.ts
@@ -1,0 +1,792 @@
+/**
+ * Integration Tests: Core + Persistence
+ *
+ * Verifies that all core infrastructure modules work together:
+ * - Protocol Layer (Op/Event types)
+ * - Queue System (SubmissionQueue, EventQueue)
+ * - Persistence (SQLiteStore, Migrations)
+ * - Costs (ModelRegistry, cost calculation)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import Database from 'better-sqlite3';
+
+// Import from core modules
+import { createSQLiteStore, SQLiteStore, type UsageLog } from '../../src/integrations/sqlite-store.js';
+import { SubmissionQueue, EventQueue } from '../../src/core/queues/index.js';
+import { modelRegistry, type UsageRecord } from '../../src/costs/index.js';
+import { getSchemaVersion, loadMigrations } from '../../src/persistence/migrator.js';
+import type {
+  OpUserTurn,
+  EventAgentMessage,
+  EventTaskComplete,
+  EventEnvelope,
+} from '../../src/core/protocol/types.js';
+
+describe('Core + Persistence Integration', () => {
+  let store: SQLiteStore;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'attocode-test-'));
+    store = await createSQLiteStore({ dbPath: join(tempDir, 'test.db') });
+  });
+
+  afterEach(async () => {
+    store.close();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ===========================================================================
+  // Session with Cost Tracking
+  // ===========================================================================
+
+  describe('Session with Cost Tracking', () => {
+    it('should create session and track usage costs', async () => {
+      // Create a session
+      const sessionId = store.createSession('Test Session');
+      expect(sessionId).toBeDefined();
+      expect(sessionId).toMatch(/^session-/);
+
+      // Initial usage should be zero
+      const initialUsage = store.getSessionUsage(sessionId);
+      expect(initialUsage.promptTokens).toBe(0);
+      expect(initialUsage.completionTokens).toBe(0);
+      expect(initialUsage.costUsd).toBe(0);
+
+      // Log some usage
+      const usageLog: UsageLog = {
+        sessionId,
+        modelId: 'claude-3-5-sonnet-20241022',
+        promptTokens: 1000,
+        completionTokens: 500,
+        costUsd: 0.0195,
+        timestamp: new Date().toISOString(),
+      };
+      store.logUsage(usageLog);
+
+      // Verify getSessionUsage() returns correct totals
+      const usage = store.getSessionUsage(sessionId);
+      expect(usage.promptTokens).toBe(1000);
+      expect(usage.completionTokens).toBe(500);
+      expect(usage.costUsd).toBe(0.0195);
+    });
+
+    it('should accumulate multiple usage logs', async () => {
+      const sessionId = store.createSession('Multi-Usage Session');
+
+      // Log first usage
+      store.logUsage({
+        sessionId,
+        modelId: 'claude-3-5-sonnet-20241022',
+        promptTokens: 1000,
+        completionTokens: 500,
+        costUsd: 0.0195,
+        timestamp: new Date().toISOString(),
+      });
+
+      // Log second usage
+      store.logUsage({
+        sessionId,
+        modelId: 'claude-3-5-sonnet-20241022',
+        promptTokens: 2000,
+        completionTokens: 1000,
+        costUsd: 0.039,
+        timestamp: new Date().toISOString(),
+      });
+
+      // Verify accumulated totals
+      const usage = store.getSessionUsage(sessionId);
+      expect(usage.promptTokens).toBe(3000);
+      expect(usage.completionTokens).toBe(1500);
+      expect(usage.costUsd).toBeCloseTo(0.0585, 4);
+    });
+
+    it('should calculate cost via ModelRegistry matching logged costs', async () => {
+      const sessionId = store.createSession('Cost Calculation Session');
+
+      // Create a usage record for cost calculation
+      const usageRecord: UsageRecord = {
+        modelId: 'claude-3-5-sonnet-20241022',
+        promptTokens: 1000,
+        completionTokens: 500,
+      };
+
+      // Calculate cost via ModelRegistry
+      const costBreakdown = modelRegistry.calculateCost(usageRecord);
+
+      // Log the same usage to the store
+      store.logUsage({
+        sessionId,
+        modelId: usageRecord.modelId,
+        promptTokens: usageRecord.promptTokens,
+        completionTokens: usageRecord.completionTokens,
+        costUsd: costBreakdown.totalCost,
+        timestamp: new Date().toISOString(),
+      });
+
+      // Verify costs match
+      const sessionUsage = store.getSessionUsage(sessionId);
+      expect(sessionUsage.costUsd).toBeCloseTo(costBreakdown.totalCost, 6);
+
+      // Verify cost breakdown is reasonable
+      // Claude 3.5 Sonnet: $3/M prompt, $15/M completion
+      // 1000 prompt tokens = $0.003, 500 completion = $0.0075, total = $0.0105
+      expect(costBreakdown.promptCost).toBeCloseTo(0.003, 6);
+      expect(costBreakdown.completionCost).toBeCloseTo(0.0075, 6);
+      expect(costBreakdown.totalCost).toBeCloseTo(0.0105, 6);
+    });
+
+    it('should include cost info in session metadata', async () => {
+      const sessionId = store.createSession('Metadata Cost Session');
+
+      // Log usage
+      store.logUsage({
+        sessionId,
+        modelId: 'claude-3-5-sonnet-20241022',
+        promptTokens: 5000,
+        completionTokens: 2500,
+        costUsd: 0.0525, // $0.015 + $0.0375
+        timestamp: new Date().toISOString(),
+      });
+
+      // Get session metadata
+      const metadata = store.getSessionMetadata(sessionId);
+      expect(metadata).toBeDefined();
+      expect(metadata!.promptTokens).toBe(5000);
+      expect(metadata!.completionTokens).toBe(2500);
+      expect(metadata!.costUsd).toBeCloseTo(0.0525, 4);
+    });
+  });
+
+  // ===========================================================================
+  // Parent-Child Session Hierarchy
+  // ===========================================================================
+
+  describe('Parent-Child Session Hierarchy', () => {
+    it('should create child sessions linked to parent', async () => {
+      // Create main session
+      const mainSessionId = store.createSession('Main Session');
+      expect(mainSessionId).toBeDefined();
+
+      // Create child sessions
+      const child1Id = store.createChildSession(mainSessionId, 'Child 1', 'subagent');
+      const child2Id = store.createChildSession(mainSessionId, 'Child 2', 'branch');
+
+      expect(child1Id).toBeDefined();
+      expect(child2Id).toBeDefined();
+      expect(child1Id).not.toBe(child2Id);
+
+      // Verify child metadata
+      const child1Meta = store.getSessionMetadata(child1Id);
+      expect(child1Meta).toBeDefined();
+      expect(child1Meta!.parentSessionId).toBe(mainSessionId);
+      expect(child1Meta!.sessionType).toBe('subagent');
+      expect(child1Meta!.name).toBe('Child 1');
+
+      const child2Meta = store.getSessionMetadata(child2Id);
+      expect(child2Meta).toBeDefined();
+      expect(child2Meta!.parentSessionId).toBe(mainSessionId);
+      expect(child2Meta!.sessionType).toBe('branch');
+    });
+
+    it('should return children via getChildSessions()', async () => {
+      const mainSessionId = store.createSession('Parent Session');
+
+      // Create multiple children
+      const childIds = [
+        store.createChildSession(mainSessionId, 'Task 1', 'subagent'),
+        store.createChildSession(mainSessionId, 'Task 2', 'subagent'),
+        store.createChildSession(mainSessionId, 'Task 3', 'subagent'),
+      ];
+
+      // Get children
+      const children = store.getChildSessions(mainSessionId);
+      expect(children).toHaveLength(3);
+
+      // Verify all child IDs are present
+      const returnedIds = children.map(c => c.id);
+      for (const childId of childIds) {
+        expect(returnedIds).toContain(childId);
+      }
+
+      // Verify children are sorted by creation time (ascending)
+      for (let i = 1; i < children.length; i++) {
+        expect(new Date(children[i].createdAt).getTime())
+          .toBeGreaterThanOrEqual(new Date(children[i - 1].createdAt).getTime());
+      }
+    });
+
+    it('should return empty array for session with no children', async () => {
+      const sessionId = store.createSession('Leaf Session');
+      const children = store.getChildSessions(sessionId);
+      expect(children).toEqual([]);
+    });
+
+    it('should return full hierarchy via getSessionTree()', async () => {
+      // Create a multi-level hierarchy
+      //   main
+      //   ├── child1
+      //   │   ├── grandchild1
+      //   │   └── grandchild2
+      //   └── child2
+
+      const mainId = store.createSession('Root');
+      const child1Id = store.createChildSession(mainId, 'Child 1', 'subagent');
+      const child2Id = store.createChildSession(mainId, 'Child 2', 'branch');
+      const grandchild1Id = store.createChildSession(child1Id, 'Grandchild 1', 'subagent');
+      const grandchild2Id = store.createChildSession(child1Id, 'Grandchild 2', 'subagent');
+
+      // Get full tree from root
+      const tree = store.getSessionTree(mainId);
+
+      // Should include all 5 sessions
+      expect(tree).toHaveLength(5);
+
+      // Verify all session IDs are present
+      const treeIds = tree.map(s => s.id);
+      expect(treeIds).toContain(mainId);
+      expect(treeIds).toContain(child1Id);
+      expect(treeIds).toContain(child2Id);
+      expect(treeIds).toContain(grandchild1Id);
+      expect(treeIds).toContain(grandchild2Id);
+
+      // Root should be first
+      expect(tree[0].id).toBe(mainId);
+
+      // Verify parent relationships
+      const child1 = tree.find(s => s.id === child1Id);
+      expect(child1!.parentSessionId).toBe(mainId);
+
+      const grandchild1 = tree.find(s => s.id === grandchild1Id);
+      expect(grandchild1!.parentSessionId).toBe(child1Id);
+    });
+
+    it('should return subtree when starting from non-root', async () => {
+      // Create hierarchy
+      const mainId = store.createSession('Root');
+      const child1Id = store.createChildSession(mainId, 'Child 1', 'subagent');
+      store.createChildSession(mainId, 'Child 2', 'branch');
+      const grandchildId = store.createChildSession(child1Id, 'Grandchild', 'subagent');
+
+      // Get tree from child1 (not root)
+      const subtree = store.getSessionTree(child1Id);
+
+      // Should only include child1 and its descendants
+      expect(subtree).toHaveLength(2);
+
+      const subtreeIds = subtree.map(s => s.id);
+      expect(subtreeIds).toContain(child1Id);
+      expect(subtreeIds).toContain(grandchildId);
+      expect(subtreeIds).not.toContain(mainId);
+    });
+  });
+
+  // ===========================================================================
+  // Event Queue Flow with Submissions
+  // ===========================================================================
+
+  describe('Event Queue Flow with Submissions', () => {
+    let submissionQueue: SubmissionQueue;
+    let eventQueue: EventQueue;
+
+    beforeEach(() => {
+      submissionQueue = new SubmissionQueue({ maxSize: 10 });
+      eventQueue = new EventQueue({ maxRecentEvents: 50 });
+    });
+
+    afterEach(() => {
+      submissionQueue.close();
+      eventQueue.clear();
+    });
+
+    it('should submit operation and receive via take()', async () => {
+      const op: OpUserTurn = {
+        type: 'user_turn',
+        content: 'Hello, world!',
+      };
+
+      // Submit operation
+      const submissionId = await submissionQueue.submit(op);
+      expect(submissionId).toBeDefined();
+
+      // Take submission
+      const submission = await submissionQueue.take();
+      expect(submission).not.toBeNull();
+      expect(submission!.id).toBe(submissionId);
+      expect(submission!.op).toEqual(op);
+      expect(submission!.timestamp).toBeDefined();
+    });
+
+    it('should emit events and notify listeners', async () => {
+      const receivedEnvelopes: EventEnvelope[] = [];
+
+      // Subscribe to all events
+      const unsubscribe = eventQueue.subscribe((envelope) => {
+        receivedEnvelopes.push(envelope);
+      });
+
+      // Emit events
+      const submissionId = 'test-submission-1';
+      const messageEvent: EventAgentMessage = {
+        type: 'agent_message',
+        content: 'Hello from agent',
+        done: false,
+      };
+      eventQueue.emit(submissionId, messageEvent);
+
+      const completeEvent: EventTaskComplete = {
+        type: 'task_complete',
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        status: 'success',
+        durationMs: 1000,
+      };
+      eventQueue.emit(submissionId, completeEvent);
+
+      // Wait for async dispatch
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Verify listeners received events
+      expect(receivedEnvelopes).toHaveLength(2);
+      expect(receivedEnvelopes[0].event.type).toBe('agent_message');
+      expect(receivedEnvelopes[0].submissionId).toBe(submissionId);
+      expect(receivedEnvelopes[1].event.type).toBe('task_complete');
+
+      unsubscribe();
+    });
+
+    it('should allow typed event subscriptions', async () => {
+      const messageEvents: EventEnvelope[] = [];
+      const completeEvents: EventEnvelope[] = [];
+
+      // Subscribe to specific event types
+      const unsub1 = eventQueue.on<EventAgentMessage>('agent_message', (envelope) => {
+        messageEvents.push(envelope);
+      });
+      const unsub2 = eventQueue.on<EventTaskComplete>('task_complete', (envelope) => {
+        completeEvents.push(envelope);
+      });
+
+      // Emit mixed events
+      eventQueue.emit('sub-1', { type: 'agent_message', content: 'First', done: false });
+      eventQueue.emit('sub-1', { type: 'task_complete', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }, status: 'success', durationMs: 100 });
+      eventQueue.emit('sub-1', { type: 'agent_message', content: 'Second', done: true });
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Verify typed listeners only got their events
+      expect(messageEvents).toHaveLength(2);
+      expect(completeEvents).toHaveLength(1);
+
+      unsub1();
+      unsub2();
+    });
+
+    it('should store recent events for replay', async () => {
+      const submissionId = 'replay-test';
+
+      // Emit several events
+      for (let i = 0; i < 5; i++) {
+        eventQueue.emit(submissionId, {
+          type: 'agent_message',
+          content: `Message ${i}`,
+          done: i === 4,
+        });
+      }
+
+      // Get recent events
+      const recentEvents = eventQueue.getRecentEvents();
+      expect(recentEvents).toHaveLength(5);
+
+      // Verify events are in order
+      for (let i = 0; i < 5; i++) {
+        const event = recentEvents[i].event as EventAgentMessage;
+        expect(event.content).toBe(`Message ${i}`);
+      }
+    });
+
+    it('should filter events by submission ID', async () => {
+      // Emit events for different submissions
+      eventQueue.emit('sub-A', { type: 'agent_message', content: 'A1', done: false });
+      eventQueue.emit('sub-B', { type: 'agent_message', content: 'B1', done: false });
+      eventQueue.emit('sub-A', { type: 'agent_message', content: 'A2', done: true });
+      eventQueue.emit('sub-B', { type: 'agent_message', content: 'B2', done: true });
+
+      // Get events for specific submission
+      const subAEvents = eventQueue.getEventsForSubmission('sub-A');
+      expect(subAEvents).toHaveLength(2);
+      expect((subAEvents[0].event as EventAgentMessage).content).toBe('A1');
+      expect((subAEvents[1].event as EventAgentMessage).content).toBe('A2');
+
+      const subBEvents = eventQueue.getEventsForSubmission('sub-B');
+      expect(subBEvents).toHaveLength(2);
+    });
+
+    it('should integrate full submission-event flow', async () => {
+      const receivedEvents: EventEnvelope[] = [];
+      eventQueue.subscribe((envelope) => receivedEvents.push(envelope));
+
+      // Submit a user turn
+      const op: OpUserTurn = { type: 'user_turn', content: 'Calculate 2+2' };
+      const submissionId = await submissionQueue.submit(op);
+
+      // Take and process the submission
+      const submission = await submissionQueue.take();
+      expect(submission).not.toBeNull();
+
+      // Simulate agent response - emit events for this submission
+      eventQueue.emit(submission!.id, {
+        type: 'agent_message',
+        content: 'The answer is 4',
+        done: true,
+      });
+
+      eventQueue.emit(submission!.id, {
+        type: 'task_complete',
+        usage: { inputTokens: 50, outputTokens: 10, totalTokens: 60 },
+        status: 'success',
+        durationMs: 500,
+      });
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      // Verify flow
+      expect(receivedEvents).toHaveLength(2);
+      expect(receivedEvents[0].submissionId).toBe(submissionId);
+      expect(receivedEvents[1].submissionId).toBe(submissionId);
+
+      // Verify events can be retrieved for this submission
+      const submissionEvents = eventQueue.getEventsForSubmission(submissionId);
+      expect(submissionEvents).toHaveLength(2);
+    });
+  });
+
+  // ===========================================================================
+  // Migration on Fresh Database
+  // ===========================================================================
+
+  describe('Migration on Fresh Database', () => {
+    it('should apply all migrations on fresh database', async () => {
+      // The store was already initialized with migrations in beforeEach
+      // Verify by checking schema version
+      const dbPath = join(tempDir, 'test.db');
+      const db = new Database(dbPath);
+
+      try {
+        const version = getSchemaVersion(db);
+        expect(version).toBeGreaterThanOrEqual(3); // We have 3 migrations
+      } finally {
+        db.close();
+      }
+    });
+
+    it('should have all required tables after migration', async () => {
+      const dbPath = join(tempDir, 'test.db');
+      const db = new Database(dbPath);
+
+      try {
+        // Query sqlite_master for tables
+        const tables = db.prepare(`
+          SELECT name FROM sqlite_master
+          WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+          ORDER BY name
+        `).all() as Array<{ name: string }>;
+
+        const tableNames = tables.map(t => t.name);
+
+        // Verify all expected tables exist
+        expect(tableNames).toContain('sessions');
+        expect(tableNames).toContain('entries');
+        expect(tableNames).toContain('tool_calls');
+        expect(tableNames).toContain('checkpoints');
+        expect(tableNames).toContain('usage_logs');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('should have cost tracking columns in sessions table', async () => {
+      const dbPath = join(tempDir, 'test.db');
+      const db = new Database(dbPath);
+
+      try {
+        // Get column info for sessions table
+        const columns = db.prepare('PRAGMA table_info(sessions)').all() as Array<{
+          name: string;
+          type: string;
+        }>;
+
+        const columnNames = columns.map(c => c.name);
+
+        // Verify cost tracking columns from migration 002
+        expect(columnNames).toContain('prompt_tokens');
+        expect(columnNames).toContain('completion_tokens');
+        expect(columnNames).toContain('cost_usd');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('should have hierarchy columns in sessions table', async () => {
+      const dbPath = join(tempDir, 'test.db');
+      const db = new Database(dbPath);
+
+      try {
+        // Get column info for sessions table
+        const columns = db.prepare('PRAGMA table_info(sessions)').all() as Array<{
+          name: string;
+          type: string;
+        }>;
+
+        const columnNames = columns.map(c => c.name);
+
+        // Verify hierarchy columns from migration 003
+        expect(columnNames).toContain('parent_session_id');
+        expect(columnNames).toContain('session_type');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('should have all required indexes', async () => {
+      const dbPath = join(tempDir, 'test.db');
+      const db = new Database(dbPath);
+
+      try {
+        // Get all indexes
+        const indexes = db.prepare(`
+          SELECT name FROM sqlite_master
+          WHERE type = 'index' AND name NOT LIKE 'sqlite_%'
+        `).all() as Array<{ name: string }>;
+
+        const indexNames = indexes.map(i => i.name);
+
+        // Verify key indexes exist
+        expect(indexNames).toContain('idx_entries_session');
+        expect(indexNames).toContain('idx_tool_calls_session');
+        expect(indexNames).toContain('idx_usage_logs_session');
+        expect(indexNames).toContain('idx_sessions_parent');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('should create fresh database with migrations in new temp location', async () => {
+      // Create a completely new store in a different location
+      const newTempDir = await mkdtemp(join(tmpdir(), 'attocode-fresh-'));
+
+      try {
+        const freshStore = await createSQLiteStore({
+          dbPath: join(newTempDir, 'fresh.db'),
+        });
+
+        try {
+          // Should be able to use all features
+          const sessionId = freshStore.createSession('Fresh Session');
+          expect(sessionId).toBeDefined();
+
+          // Can create child sessions
+          const childId = freshStore.createChildSession(sessionId, 'Child', 'subagent');
+          expect(childId).toBeDefined();
+
+          // Can log usage
+          freshStore.logUsage({
+            sessionId,
+            modelId: 'test-model',
+            promptTokens: 100,
+            completionTokens: 50,
+            costUsd: 0.01,
+            timestamp: new Date().toISOString(),
+          });
+
+          const usage = freshStore.getSessionUsage(sessionId);
+          expect(usage.promptTokens).toBe(100);
+        } finally {
+          freshStore.close();
+        }
+      } finally {
+        await rm(newTempDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should load migration files from persistence directory', async () => {
+      // This test verifies migration files exist and are parseable
+      const { dirname } = await import('node:path');
+      const { fileURLToPath } = await import('node:url');
+
+      const __dirname = dirname(fileURLToPath(import.meta.url));
+      const migrationsDir = join(__dirname, '../../src/persistence/migrations');
+
+      const migrations = loadMigrations(migrationsDir);
+
+      expect(migrations.length).toBeGreaterThanOrEqual(3);
+
+      // Verify migrations are sorted by version
+      for (let i = 1; i < migrations.length; i++) {
+        expect(migrations[i].version).toBeGreaterThan(migrations[i - 1].version);
+      }
+
+      // Verify expected migrations exist
+      const versions = migrations.map(m => m.version);
+      expect(versions).toContain(1);
+      expect(versions).toContain(2);
+      expect(versions).toContain(3);
+    });
+  });
+
+  // ===========================================================================
+  // Cross-Module Integration
+  // ===========================================================================
+
+  describe('Cross-Module Integration', () => {
+    it('should track costs across parent and child sessions', async () => {
+      // Create parent session
+      const parentId = store.createSession('Parent');
+
+      // Create child sessions and log usage to each
+      const childIds = [
+        store.createChildSession(parentId, 'Worker 1', 'subagent'),
+        store.createChildSession(parentId, 'Worker 2', 'subagent'),
+      ];
+
+      // Log usage to parent
+      store.logUsage({
+        sessionId: parentId,
+        modelId: 'claude-3-5-sonnet-20241022',
+        promptTokens: 1000,
+        completionTokens: 500,
+        costUsd: 0.0105,
+        timestamp: new Date().toISOString(),
+      });
+
+      // Log usage to children
+      store.logUsage({
+        sessionId: childIds[0],
+        modelId: 'claude-3-5-haiku-20241022',
+        promptTokens: 2000,
+        completionTokens: 1000,
+        costUsd: 0.0056,
+        timestamp: new Date().toISOString(),
+      });
+
+      store.logUsage({
+        sessionId: childIds[1],
+        modelId: 'claude-3-5-haiku-20241022',
+        promptTokens: 3000,
+        completionTokens: 1500,
+        costUsd: 0.0084,
+        timestamp: new Date().toISOString(),
+      });
+
+      // Get session tree and verify costs
+      const tree = store.getSessionTree(parentId);
+      expect(tree).toHaveLength(3);
+
+      // Calculate total tree cost
+      let totalCost = 0;
+      for (const session of tree) {
+        const usage = store.getSessionUsage(session.id);
+        totalCost += usage.costUsd;
+      }
+
+      expect(totalCost).toBeCloseTo(0.0105 + 0.0056 + 0.0084, 4);
+    });
+
+    it('should persist session entries and retrieve them', async () => {
+      const sessionId = store.createSession('Entry Test');
+
+      // Append various entries
+      store.appendMessage({ role: 'user', content: 'Hello' });
+      store.appendMessage({ role: 'assistant', content: 'Hi there!' });
+      store.appendToolCall({
+        id: 'tool-1',
+        name: 'read_file',
+        arguments: { path: '/test.txt' },
+      });
+      store.appendToolResult('tool-1', 'file contents here');
+
+      // Load session and verify entries
+      const entries = store.loadSession(sessionId);
+      expect(entries.length).toBeGreaterThanOrEqual(4);
+
+      // Find message entries
+      const messageEntries = entries.filter(e => e.type === 'message');
+      expect(messageEntries).toHaveLength(2);
+
+      // Verify tool call entry
+      const toolCallEntry = entries.find(e => e.type === 'tool_call');
+      expect(toolCallEntry).toBeDefined();
+      expect((toolCallEntry!.data as { name: string }).name).toBe('read_file');
+
+      // Verify tool result entry
+      const toolResultEntry = entries.find(e => e.type === 'tool_result');
+      expect(toolResultEntry).toBeDefined();
+      expect((toolResultEntry!.data as { callId: string }).callId).toBe('tool-1');
+    });
+
+    it('should handle checkpoints with session hierarchy', async () => {
+      const parentId = store.createSession('Checkpoint Parent');
+      store.setCurrentSessionId(parentId);
+
+      // Save checkpoint on parent
+      const checkpoint1Id = store.saveCheckpoint(
+        { step: 1, data: 'parent state' },
+        'Initial state'
+      );
+      expect(checkpoint1Id).toBeDefined();
+
+      // Create child and save checkpoint there
+      const childId = store.createChildSession(parentId, 'Child', 'subagent');
+      store.setCurrentSessionId(childId);
+
+      const checkpoint2Id = store.saveCheckpoint(
+        { step: 1, data: 'child state' },
+        'Child initial'
+      );
+      expect(checkpoint2Id).toBeDefined();
+
+      // Load checkpoints independently
+      const parentCheckpoint = store.loadLatestCheckpoint(parentId);
+      expect(parentCheckpoint).toBeDefined();
+      expect(parentCheckpoint!.state.data).toBe('parent state');
+
+      const childCheckpoint = store.loadLatestCheckpoint(childId);
+      expect(childCheckpoint).toBeDefined();
+      expect(childCheckpoint!.state.data).toBe('child state');
+    });
+
+    it('should calculate costs for different models correctly', async () => {
+      const sessionId = store.createSession('Multi-Model Session');
+
+      // Usage records for different models
+      const usageRecords: UsageRecord[] = [
+        { modelId: 'claude-3-5-sonnet-20241022', promptTokens: 1000, completionTokens: 500 },
+        { modelId: 'claude-3-5-haiku-20241022', promptTokens: 2000, completionTokens: 1000 },
+        { modelId: 'gpt-4o', promptTokens: 1000, completionTokens: 500 },
+      ];
+
+      let expectedTotalCost = 0;
+
+      for (const usage of usageRecords) {
+        const cost = modelRegistry.calculateCost(usage);
+        expectedTotalCost += cost.totalCost;
+
+        store.logUsage({
+          sessionId,
+          modelId: usage.modelId,
+          promptTokens: usage.promptTokens,
+          completionTokens: usage.completionTokens,
+          costUsd: cost.totalCost,
+          timestamp: new Date().toISOString(),
+        });
+      }
+
+      // Verify session total matches sum of individual costs
+      const sessionUsage = store.getSessionUsage(sessionId);
+      expect(sessionUsage.costUsd).toBeCloseTo(expectedTotalCost, 6);
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new core infrastructure layer for the `attocode` agent, focused on protocol-driven communication and queue management between the UI and agent. It adds a well-documented protocol bridge, atomic counter for submission IDs, and robust queue systems for operations and events. Additionally, it refines agent state management for easier checkpointing and restoration, and updates the package configuration for better publishing and CLI support.

**Core Infrastructure Layer:**

* Added `core` module with unified exports for protocol types, validation, type guards, and queue system in `src/core/index.ts`.
* Implemented `ProtocolBridge` in `src/core/protocol/bridge.ts` for queue-based communication between UI and agent, including operation handling, event emission, and error management.
* Added atomic counter (`AtomicCounter` and `globalCounter`) in `src/core/queues/atomic-counter.ts` for unique submission ID generation.
* Added `SubmissionQueue` and `EventQueue` systems in `src/core/queues/index.ts` and `src/core/queues/event-queue.ts`, supporting bounded operation queue (with backpressure) and unbounded event pub/sub (with typed listeners and replay buffer). [[1]](diffhunk://#diff-0a4e58b89c4235d7488a5da306a83756487dffafb1cd2877e4e61b30d1cdcda9R1-R29) [[2]](diffhunk://#diff-c33637a707fd25d7711c36a45d7d98216e0a02e29dfe14958f74bf32782924d4R1-R272)

**Agent State Management:**

* Added `getSerializableState()` and `loadState()` methods to `ProductionAgent` for serializing and restoring agent state, including messages, metrics, plan, and memory context. Marked `loadMessages()` as deprecated. [[1]](diffhunk://#diff-6c2edc71808f582d220bd4564b81f08bc94801273ae93e6852ffa46e6f04738aR1512) [[2]](diffhunk://#diff-6c2edc71808f582d220bd4564b81f08bc94801273ae93e6852ffa46e6f04738aR1526-R1603)
* Extended agent type imports to include `AgentMetrics` and `AgentPlan` for richer state handling.

**Package Configuration and CLI Support:**

* Updated `package.json` to set version to `0.1.0`, define CLI entry point (`bin.attocode`), restrict published files, and add a prepublish build step.

**Protocol Module Re-exports:**

* Added protocol module re-exports for types and schemas in `src/core/protocol/index.ts`.