### PR TITLE
feat: Add TUI approval dialog for user permission requests

### DIFF
--- a/attocode/src/tui/components/ApprovalDialog.tsx
+++ b/attocode/src/tui/components/ApprovalDialog.tsx
@@ -1,0 +1,151 @@
+/**
+ * ApprovalDialog Component
+ *
+ * Displays permission requests for dangerous tool operations in TUI mode.
+ * Supports keyboard shortcuts: Y (approve), N (deny), D (deny with reason)
+ */
+
+import { memo } from 'react';
+import { Box, Text } from 'ink';
+import type { ThemeColors } from '../types.js';
+
+export interface ApprovalRequest {
+  id: string;
+  tool: string;
+  args: Record<string, unknown>;
+  risk: 'low' | 'moderate' | 'high' | 'critical';
+  context: string;
+}
+
+export interface ApprovalDialogProps {
+  visible: boolean;
+  request: ApprovalRequest | null;
+  onApprove: () => void;
+  onDeny: (reason?: string) => void;
+  colors: ThemeColors;
+  /** Whether in "deny with reason" mode (show input prompt) */
+  denyReasonMode?: boolean;
+  /** Current deny reason being typed */
+  denyReason?: string;
+}
+
+/**
+ * Format tool arguments for display (truncated)
+ */
+function formatArgs(args: Record<string, unknown>, maxLength = 120): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return '(no arguments)';
+
+  const parts: string[] = [];
+  for (const [key, value] of entries) {
+    let valStr: string;
+    if (typeof value === 'string') {
+      valStr = value.length > 50 ? `"${value.slice(0, 47)}..."` : `"${value}"`;
+    } else if (value === null || value === undefined) {
+      valStr = String(value);
+    } else {
+      const json = JSON.stringify(value);
+      valStr = json.length > 50 ? json.slice(0, 47) + '...' : json;
+    }
+    parts.push(`${key}: ${valStr}`);
+  }
+
+  const result = parts.join(', ');
+  return result.length > maxLength ? result.slice(0, maxLength - 3) + '...' : result;
+}
+
+/**
+ * Get risk level styling
+ */
+function getRiskStyle(risk: ApprovalRequest['risk']): { color: string; icon: string } {
+  switch (risk) {
+    case 'critical':
+      return { color: '#FF4444', icon: '!!' };
+    case 'high':
+      return { color: '#FF6B6B', icon: '!' };
+    case 'moderate':
+      return { color: '#FFD700', icon: '*' };
+    case 'low':
+    default:
+      return { color: '#87CEEB', icon: '-' };
+  }
+}
+
+export const ApprovalDialog = memo(function ApprovalDialog({
+  visible,
+  request,
+  colors,
+  denyReasonMode = false,
+  denyReason = '',
+}: ApprovalDialogProps) {
+  if (!visible || !request) return null;
+
+  const riskStyle = getRiskStyle(request.risk);
+  const argsDisplay = formatArgs(request.args);
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="double"
+      borderColor={riskStyle.color}
+      paddingX={1}
+      paddingY={0}
+      marginBottom={1}
+    >
+      {/* Header */}
+      <Box gap={1}>
+        <Text color={riskStyle.color} bold>
+          [{riskStyle.icon}] APPROVAL REQUIRED
+        </Text>
+        <Text color={colors.textMuted} dimColor>
+          ({request.risk} risk)
+        </Text>
+      </Box>
+
+      {/* Tool name */}
+      <Box marginTop={1} gap={1}>
+        <Text color={colors.textMuted}>Tool:</Text>
+        <Text color="#DDA0DD" bold>{request.tool}</Text>
+      </Box>
+
+      {/* Arguments */}
+      <Box gap={1}>
+        <Text color={colors.textMuted}>Args:</Text>
+        <Text color={colors.text} wrap="truncate">{argsDisplay}</Text>
+      </Box>
+
+      {/* Context */}
+      {request.context && (
+        <Box marginTop={1}>
+          <Text color={colors.textMuted} dimColor wrap="wrap">
+            {request.context.length > 200 ? request.context.slice(0, 197) + '...' : request.context}
+          </Text>
+        </Box>
+      )}
+
+      {/* Action prompt */}
+      <Box marginTop={1} gap={2}>
+        {denyReasonMode ? (
+          <Box gap={1}>
+            <Text color={colors.warning}>Deny reason:</Text>
+            <Text color={colors.text}>{denyReason}</Text>
+            <Text color={colors.textMuted} dimColor>(Enter to confirm, Esc to cancel)</Text>
+          </Box>
+        ) : (
+          <>
+            <Text color="#98FB98" bold>[Y]</Text>
+            <Text color={colors.text}>Approve</Text>
+            <Text color={colors.textMuted}>|</Text>
+            <Text color="#FF6B6B" bold>[N]</Text>
+            <Text color={colors.text}>Deny</Text>
+            <Text color={colors.textMuted}>|</Text>
+            <Text color="#FFD700" bold>[D]</Text>
+            <Text color={colors.text}>Deny with reason</Text>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+});
+
+export default ApprovalDialog;

--- a/attocode/src/tui/components/index.ts
+++ b/attocode/src/tui/components/index.ts
@@ -12,3 +12,6 @@ export { ScrollableBox, type ScrollableBoxProps } from './ScrollableBox.js';
 export { MessageItem, type MessageItemProps, type TUIMessage } from './MessageItem.js';
 export { ToolCallItem, type ToolCallItemProps, type ToolCallDisplayItem } from './ToolCallItem.js';
 export { MemoizedInputArea, type InputAreaProps } from './InputArea.js';
+
+// Approval dialog for permission requests
+export { ApprovalDialog, type ApprovalDialogProps, type ApprovalRequest } from './ApprovalDialog.js';

--- a/attocode/src/tui/index.ts
+++ b/attocode/src/tui/index.ts
@@ -336,6 +336,9 @@ export {
   type ToolCallDisplayItem,
   MemoizedInputArea,
   type InputAreaProps,
+  ApprovalDialog,
+  type ApprovalDialogProps,
+  type ApprovalRequest as TUIApprovalRequest,
 } from './components/index.js';
 
 // Command palette


### PR DESCRIPTION
This pull request introduces a new approval dialog system for the TUI (Terminal User Interface) mode, enabling interactive, in-app human approval for tool actions that require user consent. The main changes include the creation of a TUI approval bridge for agent-to-TUI communication, integration of this bridge into the agent and TUI app, and the implementation of the approval dialog UI and keyboard handling.

**Key changes:**

### Approval Bridge and Agent Integration

* Added `createTUIApprovalBridge` in `adapters.ts`, which provides a bridge for the agent to communicate approval requests to the TUI and receive user responses. This bridge is passed to the agent's `humanInLoop.approvalHandler` in interactive mode, ensuring permission dialogs are handled in the TUI, not the console. [[1]](diffhunk://#diff-b633ccd22593b0f71943bb1095c64f05c463e2b7d248b448b54592f46a81ad83R217-R294) [[2]](diffhunk://#diff-06f527071c2ea66353b1e453a40fc1856c8cc73016bed3ee96f03968e5f29827L17-R17) [[3]](diffhunk://#diff-06f527071c2ea66353b1e453a40fc1856c8cc73016bed3ee96f03968e5f29827R162-R165) [[4]](diffhunk://#diff-06f527071c2ea66353b1e453a40fc1856c8cc73016bed3ee96f03968e5f29827L167-R184) [[5]](diffhunk://#diff-06f527071c2ea66353b1e453a40fc1856c8cc73016bed3ee96f03968e5f29827R307-R308)

### TUI App Dialog and State Management

* Integrated the approval bridge into the TUI app (`TUIApp`), adding state and handlers for pending approval requests, deny reason entry, and dialog visibility. The app now shows an `ApprovalDialog` component when approval is required, and disables input until the user responds. [[1]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR47-R48) [[2]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR464-R475) [[3]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR487-R538) [[4]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR1192-R1211) [[5]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR1315-R1337) [[6]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR1348-R1354)

### Keyboard and Input Handling

* Updated the input area (`MemoizedInputArea`) to support keyboard shortcuts for the approval dialog: 'y' to approve, 'n' to deny, 'd' to deny with a reason, and text input for the deny reason. The dialog blocks other input while active and provides smooth transitions between approval states. [[1]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR198-R205) [[2]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR226-R232) [[3]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR243-R254) [[4]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR296-R331) [[5]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdL357-R421)

### Agent Permission Flow

* Modified agent setup in TUI mode to use the new approval handler and risk thresholds, ensuring that only the TUI dialog is used for interactive permissions, and safe tools are auto-approved or never prompt. [[1]](diffhunk://#diff-06f527071c2ea66353b1e453a40fc1856c8cc73016bed3ee96f03968e5f29827L117-R122) [[2]](diffhunk://#diff-06f527071c2ea66353b1e453a40fc1856c8cc73016bed3ee96f03968e5f29827L167-R184)

### UI and Propagation

* Passed the approval bridge and relevant state/handlers through TUI app props, ensuring the dialog and input area are fully synchronized with the approval flow. [[1]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR47-R48) [[2]](diffhunk://#diff-f9f59375013f22139b7777b6e3036aa964ffd9585d5f224039ae722188811ccdR441)

These changes provide a robust, user-friendly, and fully integrated approval workflow for tool actions in the TUI, replacing the previous console-based prompt and improving both usability and reliability.