### PR TITLE
Release version 0.2.1 with significant enhancements and fixes

### DIFF
--- a/attocode/package-lock.json
+++ b/attocode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "attocode",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "attocode",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
@@ -1491,9 +1491,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.32",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.32.tgz",
-      "integrity": "sha512-Ez8QE4DMfhjjTsES9K2dwfV258qBui7qxUsoaixZDiTzbde4U12e1pXGNu/ECsUIOi5/zoCxAQxIhQnaUQ2VvA==",
+      "version": "20.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
+      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/attocode/package.json
+++ b/attocode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attocode",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Production AI coding agent for your terminal - multi-provider support, context management, MCP integration",
   "type": "module",
   "main": "dist/src/main.js",

--- a/attocode/src/defaults.ts
+++ b/attocode/src/defaults.ts
@@ -529,7 +529,7 @@ export const DEFAULT_PROVIDER_RESILIENCE_CONFIG: ProviderResilienceConfig = {
  */
 export function buildConfig(
   userConfig: Partial<ProductionAgentConfig>
-): Required<Omit<ProductionAgentConfig, 'provider' | 'tools' | 'toolResolver' | 'mcpToolSummaries' | 'maxContextTokens' | 'blackboard' | 'fileCache' | 'budget'>> & Pick<ProductionAgentConfig, 'provider' | 'tools' | 'toolResolver' | 'mcpToolSummaries' | 'maxContextTokens' | 'blackboard' | 'fileCache' | 'budget'> {
+): Required<Omit<ProductionAgentConfig, 'provider' | 'tools' | 'toolResolver' | 'mcpToolSummaries' | 'maxContextTokens' | 'blackboard' | 'fileCache' | 'budget' | 'agentId'>> & Pick<ProductionAgentConfig, 'provider' | 'tools' | 'toolResolver' | 'mcpToolSummaries' | 'maxContextTokens' | 'blackboard' | 'fileCache' | 'budget' | 'agentId'> {
   return {
     provider: userConfig.provider!,
     tools: userConfig.tools || [],

--- a/attocode/src/integrations/routing.ts
+++ b/attocode/src/integrations/routing.ts
@@ -11,6 +11,7 @@ import type {
   Message,
   ChatResponse,
 } from '../types.js';
+import type { MessageWithContent } from '../providers/types.js';
 
 // =============================================================================
 // MODEL CAPABILITY
@@ -307,7 +308,7 @@ export class RoutingManager {
    * Execute with fallback chain.
    */
   async executeWithFallback(
-    messages: Message[],
+    messages: (Message | MessageWithContent)[],
     context: TaskContext
   ): Promise<{ response: ChatResponse; model: string }> {
     // Build fallback chain

--- a/attocode/src/providers/adapters/openrouter.ts
+++ b/attocode/src/providers/adapters/openrouter.ts
@@ -155,6 +155,10 @@ export class OpenRouterProvider implements LLMProvider, LLMProviderWithTools {
           prompt_tokens: number;
           completion_tokens: number;
           cost?: number;
+          prompt_tokens_details?: {
+            cached_tokens?: number;
+            cache_write_tokens?: number;
+          };
         };
       };
 
@@ -178,6 +182,8 @@ export class OpenRouterProvider implements LLMProvider, LLMProviderWithTools {
         usage: {
           inputTokens: data.usage.prompt_tokens,
           outputTokens: data.usage.completion_tokens,
+          cachedTokens: data.usage.prompt_tokens_details?.cached_tokens,
+          cacheWriteTokens: data.usage.prompt_tokens_details?.cache_write_tokens,
           cost,
         },
         rateLimitInfo: this.extractRateLimitInfo(response),
@@ -333,6 +339,7 @@ export class OpenRouterProvider implements LLMProvider, LLMProviderWithTools {
           // Cache info (when using Anthropic models via OpenRouter)
           prompt_tokens_details?: {
             cached_tokens?: number;
+            cache_write_tokens?: number;
           };
         };
       };
@@ -374,7 +381,7 @@ export class OpenRouterProvider implements LLMProvider, LLMProviderWithTools {
           inputTokens: data.usage.prompt_tokens,
           outputTokens: data.usage.completion_tokens,
           cachedTokens: data.usage.prompt_tokens_details?.cached_tokens,
-          // Use actual cost from OpenRouter
+          cacheWriteTokens: data.usage.prompt_tokens_details?.cache_write_tokens,
           cost,
         },
         toolCalls,

--- a/attocode/src/providers/types.ts
+++ b/attocode/src/providers/types.ts
@@ -53,6 +53,10 @@ export interface ChatResponse {
     outputTokens: number;
     /** Tokens read from cache (for providers that support caching) */
     cachedTokens?: number;
+    /** Tokens read from prompt cache (Anthropic: cache_read_input_tokens) */
+    cacheReadTokens?: number;
+    /** Tokens written to prompt cache (Anthropic: cache_creation_input_tokens) */
+    cacheWriteTokens?: number;
     /** Actual cost from provider (when available, e.g., OpenRouter) */
     cost?: number;
   };

--- a/attocode/src/tools/bash.ts
+++ b/attocode/src/tools/bash.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import { spawn } from 'node:child_process';
 import { defineTool } from './registry.js';
 import { classifyCommand, classifyBashCommandDangerLevel } from './permission.js';
+import { coerceBoolean } from './coercion.js';
 import type { ToolResult, DangerLevel } from './types.js';
 
 // =============================================================================
@@ -151,7 +152,7 @@ export const bashTool = defineTool(
 const grepSchema = z.object({
   pattern: z.string().describe('Regex pattern to search for'),
   path: z.string().describe('File or directory to search in'),
-  recursive: z.boolean().optional().default(false).describe('Search recursively'),
+  recursive: coerceBoolean().optional().default(false).describe('Search recursively'),
 });
 
 export const grepTool = defineTool(

--- a/attocode/src/tools/coercion.ts
+++ b/attocode/src/tools/coercion.ts
@@ -1,0 +1,24 @@
+/**
+ * Type coercion utilities for tool parameter schemas.
+ *
+ * Weaker models (GLM-4, Qwen, etc.) sometimes send boolean values as strings
+ * ("true"/"false") instead of actual booleans. These helpers use z.preprocess()
+ * to coerce string representations into proper types before Zod validation.
+ */
+
+import { z } from 'zod';
+
+/**
+ * A boolean schema that accepts string "true"/"false" in addition to actual booleans.
+ * Use this instead of z.boolean() for tool parameters that may receive string values.
+ */
+export function coerceBoolean() {
+  return z.preprocess((val) => {
+    if (typeof val === 'string') {
+      const lower = val.toLowerCase().trim();
+      if (lower === 'true' || lower === '1' || lower === 'yes') return true;
+      if (lower === 'false' || lower === '0' || lower === 'no') return false;
+    }
+    return val;
+  }, z.boolean());
+}

--- a/attocode/src/tools/file.ts
+++ b/attocode/src/tools/file.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { defineTool } from './registry.js';
+import { coerceBoolean } from './coercion.js';
 import type { ToolResult } from './types.js';
 import { FileOperationError, ErrorCategory } from '../errors/index.js';
 import { generateDiff } from '../integrations/diff-utils.js';
@@ -264,7 +265,7 @@ export const editFileTool = defineTool(
 
 const listFilesSchema = z.object({
   path: z.string().optional().default('.').describe('Directory path to list'),
-  recursive: z.boolean().optional().default(false).describe('List recursively'),
+  recursive: coerceBoolean().optional().default(false).describe('List recursively'),
 });
 
 export const listFilesTool = defineTool(

--- a/attocode/src/tui/app.tsx
+++ b/attocode/src/tui/app.tsx
@@ -893,9 +893,16 @@ export function TUIApp({
 
     // Insight events - also track tokens for active agents
     if (event.type === 'insight.tokens') {
-      const e = event as { inputTokens: number; outputTokens: number; cost?: number; subagent?: string };
+      const e = event as { inputTokens: number; outputTokens: number; cacheReadTokens?: number; cacheWriteTokens?: number; cost?: number; subagent?: string };
       if (showThinking) {
-        addMessage('system', `${subagentPrefix}* ${e.inputTokens.toLocaleString()} in, ${e.outputTokens.toLocaleString()} out${e.cost ? ` $${e.cost.toFixed(6)}` : ''}`);
+        let cacheStr = '';
+        if (e.cacheReadTokens && e.cacheReadTokens > 0) {
+          cacheStr += ` [cached: ${e.cacheReadTokens.toLocaleString()}]`;
+        }
+        if (e.cacheWriteTokens && e.cacheWriteTokens > 0) {
+          cacheStr += ` [cache-write: ${e.cacheWriteTokens.toLocaleString()}]`;
+        }
+        addMessage('system', `${subagentPrefix}* ${e.inputTokens.toLocaleString()} in, ${e.outputTokens.toLocaleString()} out${cacheStr}${e.cost ? ` $${e.cost.toFixed(6)}` : ''}`);
       }
       // Update tokens for active agent if this event is from a subagent
       // IMPORTANT: Don't update tokens for agents that are timing_out/timeout/error

--- a/attocode/src/tui/event-display.ts
+++ b/attocode/src/tui/event-display.ts
@@ -58,8 +58,15 @@ export function createEventDisplay() {
 
       case 'llm.complete':
         if (event.response.usage) {
+          let cacheStr = '';
+          if (event.response.usage.cacheReadTokens && event.response.usage.cacheReadTokens > 0) {
+            cacheStr += ` [cached: ${event.response.usage.cacheReadTokens}]`;
+          }
+          if (event.response.usage.cacheWriteTokens && event.response.usage.cacheWriteTokens > 0) {
+            cacheStr += ` [cache-write: ${event.response.usage.cacheWriteTokens}]`;
+          }
           console.log(c(
-            `   Tokens: ${event.response.usage.inputTokens} in / ${event.response.usage.outputTokens} out`,
+            `   Tokens: ${event.response.usage.inputTokens} in / ${event.response.usage.outputTokens} out${cacheStr}`,
             'dim'
           ));
         }

--- a/attocode/src/types.ts
+++ b/attocode/src/types.ts
@@ -31,6 +31,7 @@ export interface ToolCall {
   id: string;
   name: string;
   arguments: Record<string, unknown>;
+  parseError?: string;
 }
 
 /**
@@ -253,6 +254,14 @@ export interface ProductionAgentConfig {
    * are available without loading full schemas.
    */
   mcpToolSummaries?: Array<{ name: string; description: string }>;
+
+  /**
+   * Unique identifier for this agent instance.
+   * Used for blackboard resource claims and tracing.
+   * Parent agents get an auto-generated ID; subagents receive one from spawnAgent().
+   * @internal Used for subagent coordination
+   */
+  agentId?: string;
 
   /**
    * Shared blackboard for subagent coordination.

--- a/attocode/tests/adapters-cache.test.ts
+++ b/attocode/tests/adapters-cache.test.ts
@@ -1,0 +1,203 @@
+/**
+ * ProviderAdapter Cache Field Passthrough Tests
+ *
+ * Verifies that ProviderAdapter correctly forwards cache-related fields
+ * (cacheReadTokens, cacheWriteTokens, cost) and handles the OpenRouter
+ * cachedTokens → cacheReadTokens fallback.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ProviderAdapter } from '../src/adapters.js';
+import type {
+  LLMProviderWithTools,
+  ChatResponseWithTools,
+} from '../src/providers/types.js';
+
+// =============================================================================
+// MOCK PROVIDER
+// =============================================================================
+
+/**
+ * Creates a mock LLMProviderWithTools that returns a controlled response.
+ */
+function createMockProvider(response: Partial<ChatResponseWithTools>): LLMProviderWithTools {
+  const fullResponse: ChatResponseWithTools = {
+    content: response.content ?? 'mock response',
+    stopReason: response.stopReason ?? 'end_turn',
+    usage: response.usage,
+    toolCalls: response.toolCalls,
+  };
+
+  return {
+    name: 'mock',
+    defaultModel: 'mock-model',
+    chat: async () => fullResponse,
+    chatWithTools: async () => fullResponse,
+    isConfigured: () => true,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('ProviderAdapter cache field passthrough', () => {
+  it('should forward cacheReadTokens and cacheWriteTokens from provider', async () => {
+    const mockProvider = createMockProvider({
+      content: 'response with cache',
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheReadTokens: 100,
+        cacheWriteTokens: 200,
+      },
+    });
+
+    const adapter = new ProviderAdapter(mockProvider);
+    const result = await adapter.chat([
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    expect(result.usage).toBeDefined();
+    expect(result.usage!.cacheReadTokens).toBe(100);
+    expect(result.usage!.cacheWriteTokens).toBe(200);
+  });
+
+  it('should fall back cachedTokens to cacheReadTokens (OpenRouter style)', async () => {
+    const mockProvider = createMockProvider({
+      content: 'openrouter response',
+      usage: {
+        inputTokens: 500,
+        outputTokens: 100,
+        cachedTokens: 150,
+      },
+    });
+
+    const adapter = new ProviderAdapter(mockProvider);
+    const result = await adapter.chat([
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    expect(result.usage).toBeDefined();
+    expect(result.usage!.cacheReadTokens).toBe(150);
+  });
+
+  it('should forward cost from provider', async () => {
+    const mockProvider = createMockProvider({
+      content: 'response with cost',
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cost: 0.05,
+      },
+    });
+
+    const adapter = new ProviderAdapter(mockProvider);
+    const result = await adapter.chat([
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    expect(result.usage).toBeDefined();
+    expect(result.usage!.cost).toBe(0.05);
+  });
+
+  it('should compute totalTokens from input + output', async () => {
+    const mockProvider = createMockProvider({
+      content: 'response',
+      usage: {
+        inputTokens: 300,
+        outputTokens: 100,
+      },
+    });
+
+    const adapter = new ProviderAdapter(mockProvider);
+    const result = await adapter.chat([
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    expect(result.usage).toBeDefined();
+    expect(result.usage!.totalTokens).toBe(400);
+  });
+
+  it('should handle undefined usage gracefully', async () => {
+    const mockProvider = createMockProvider({
+      content: 'no usage data',
+    });
+
+    const adapter = new ProviderAdapter(mockProvider);
+    const result = await adapter.chat([
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    expect(result.usage).toBeUndefined();
+  });
+
+  it('should set parseError when tool call arguments are invalid JSON', async () => {
+    const truncatedJson = '{"file_path": "/tmp/test.ts", "content": "const x = 1;\\nconst';
+    const mockProvider = createMockProvider({
+      content: '',
+      toolCalls: [{
+        id: 'call_123',
+        type: 'function' as const,
+        function: {
+          name: 'write_file',
+          arguments: truncatedJson,
+        },
+      }],
+    });
+
+    const adapter = new ProviderAdapter(mockProvider);
+    const result = await adapter.chat([
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].parseError).toBeDefined();
+    expect(result.toolCalls![0].parseError).toContain('Failed to parse arguments as JSON');
+    expect(result.toolCalls![0].parseError).toContain(truncatedJson.slice(0, 200));
+    expect(result.toolCalls![0].arguments).toEqual({});
+  });
+
+  it('should not set parseError when tool call arguments are valid JSON', async () => {
+    const validJson = '{"file_path": "/tmp/test.ts", "content": "hello"}';
+    const mockProvider = createMockProvider({
+      content: '',
+      toolCalls: [{
+        id: 'call_456',
+        type: 'function' as const,
+        function: {
+          name: 'write_file',
+          arguments: validJson,
+        },
+      }],
+    });
+
+    const adapter = new ProviderAdapter(mockProvider);
+    const result = await adapter.chat([
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].parseError).toBeUndefined();
+    expect(result.toolCalls![0].arguments).toEqual({ file_path: '/tmp/test.ts', content: 'hello' });
+  });
+
+  it('should prefer cacheReadTokens over cachedTokens when both present', async () => {
+    const mockProvider = createMockProvider({
+      content: 'both fields',
+      usage: {
+        inputTokens: 1000,
+        outputTokens: 200,
+        cacheReadTokens: 300,
+        cachedTokens: 150, // Should be ignored when cacheReadTokens is present
+      },
+    });
+
+    const adapter = new ProviderAdapter(mockProvider);
+    const result = await adapter.chat([
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    expect(result.usage!.cacheReadTokens).toBe(300);
+  });
+});

--- a/attocode/tests/parallel-tool-execution.test.ts
+++ b/attocode/tests/parallel-tool-execution.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Parallel Tool Execution Batching Tests
+ *
+ * Tests for the B1 parallel tool batching logic. Imports and tests the
+ * groupToolCallsIntoBatches algorithm and PARALLELIZABLE_TOOLS set
+ * directly from agent.ts to prevent drift.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  groupToolCallsIntoBatches,
+  PARALLELIZABLE_TOOLS,
+} from '../src/agent.js';
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('PARALLELIZABLE_TOOLS', () => {
+  it('should contain expected read-only tools', () => {
+    const expected = [
+      'read_file', 'glob', 'grep', 'list_files',
+      'search_files', 'search_code', 'get_file_info',
+    ];
+    for (const tool of expected) {
+      expect(PARALLELIZABLE_TOOLS.has(tool)).toBe(true);
+    }
+  });
+
+  it('should not contain write tools', () => {
+    expect(PARALLELIZABLE_TOOLS.has('write_file')).toBe(false);
+    expect(PARALLELIZABLE_TOOLS.has('edit_file')).toBe(false);
+    expect(PARALLELIZABLE_TOOLS.has('bash')).toBe(false);
+  });
+});
+
+describe('groupToolCallsIntoBatches', () => {
+  it('should group all-read tools into a single parallel batch', () => {
+    const toolCalls = [
+      { name: 'read_file', path: '/a.ts' },
+      { name: 'read_file', path: '/b.ts' },
+      { name: 'read_file', path: '/c.ts' },
+    ];
+
+    const batches = groupToolCallsIntoBatches(toolCalls);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(3);
+    expect(batches[0].map(t => t.name)).toEqual(['read_file', 'read_file', 'read_file']);
+  });
+
+  it('should split mixed read+write into separate batches', () => {
+    const toolCalls = [
+      { name: 'read_file', path: '/a.ts' },
+      { name: 'read_file', path: '/b.ts' },
+      { name: 'write_file', path: '/c.ts', content: 'x' },
+      { name: 'read_file', path: '/d.ts' },
+    ];
+
+    const batches = groupToolCallsIntoBatches(toolCalls);
+
+    // [read_file, read_file] → [write_file] → [read_file]
+    expect(batches).toHaveLength(3);
+    expect(batches[0]).toHaveLength(2);
+    expect(batches[0][0].name).toBe('read_file');
+    expect(batches[0][1].name).toBe('read_file');
+    expect(batches[1]).toHaveLength(1);
+    expect(batches[1][0].name).toBe('write_file');
+    expect(batches[2]).toHaveLength(1);
+    expect(batches[2][0].name).toBe('read_file');
+  });
+
+  it('should handle a single tool as a single batch of 1', () => {
+    const toolCalls = [
+      { name: 'bash', command: 'ls' },
+    ];
+
+    const batches = groupToolCallsIntoBatches(toolCalls);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(1);
+    expect(batches[0][0].name).toBe('bash');
+  });
+
+  it('should create separate batches for all-sequential tools', () => {
+    const toolCalls = [
+      { name: 'write_file', path: '/a.ts', content: 'x' },
+      { name: 'edit_file', path: '/b.ts' },
+      { name: 'bash', command: 'npm test' },
+    ];
+
+    const batches = groupToolCallsIntoBatches(toolCalls);
+
+    // Each sequential tool is in its own batch
+    expect(batches).toHaveLength(3);
+    expect(batches[0][0].name).toBe('write_file');
+    expect(batches[1][0].name).toBe('edit_file');
+    expect(batches[2][0].name).toBe('bash');
+  });
+
+  it('should preserve order within parallel batches', () => {
+    const toolCalls = [
+      { name: 'read_file', path: '/first.ts' },
+      { name: 'glob', pattern: '*.ts' },
+      { name: 'grep', pattern: 'foo' },
+      { name: 'list_files', dir: '/src' },
+    ];
+
+    const batches = groupToolCallsIntoBatches(toolCalls);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(4);
+    // Order preserved
+    expect(batches[0][0].name).toBe('read_file');
+    expect(batches[0][1].name).toBe('glob');
+    expect(batches[0][2].name).toBe('grep');
+    expect(batches[0][3].name).toBe('list_files');
+  });
+
+  it('should handle empty input', () => {
+    const batches = groupToolCallsIntoBatches([]);
+    expect(batches).toHaveLength(0);
+  });
+
+  it('should handle alternating read-write-read-write pattern', () => {
+    const toolCalls = [
+      { name: 'read_file', path: '/a.ts' },
+      { name: 'write_file', path: '/a.ts', content: 'modified' },
+      { name: 'read_file', path: '/b.ts' },
+      { name: 'edit_file', path: '/b.ts' },
+    ];
+
+    const batches = groupToolCallsIntoBatches(toolCalls);
+
+    // Each transition creates a new batch
+    expect(batches).toHaveLength(4);
+    expect(batches[0][0].name).toBe('read_file');
+    expect(batches[1][0].name).toBe('write_file');
+    expect(batches[2][0].name).toBe('read_file');
+    expect(batches[3][0].name).toBe('edit_file');
+  });
+
+  it('should group mixed parallelizable tools together', () => {
+    const toolCalls = [
+      { name: 'read_file', path: '/a.ts' },
+      { name: 'glob', pattern: '**/*.ts' },
+      { name: 'grep', pattern: 'import' },
+      { name: 'search_files', query: 'function' },
+      { name: 'get_file_info', path: '/a.ts' },
+    ];
+
+    const batches = groupToolCallsIntoBatches(toolCalls);
+
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(5);
+  });
+
+  it('should accept a custom isParallelizable predicate', () => {
+    const toolCalls = [
+      { name: 'custom_read' },
+      { name: 'custom_read' },
+      { name: 'custom_write' },
+    ];
+
+    const batches = groupToolCallsIntoBatches(
+      toolCalls,
+      (tc) => tc.name === 'custom_read',
+    );
+
+    expect(batches).toHaveLength(2);
+    expect(batches[0]).toHaveLength(2);
+    expect(batches[1]).toHaveLength(1);
+  });
+});

--- a/attocode/tests/providers/anthropic-cache.test.ts
+++ b/attocode/tests/providers/anthropic-cache.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Anthropic Cache Pipeline Tests
+ *
+ * Tests for the A1-A5 cache fixes:
+ * - prompt-caching-2024-07-31 beta header
+ * - Structured system content with cache_control passthrough
+ * - Cache usage extraction (cache_creation_input_tokens, cache_read_input_tokens)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AnthropicProvider } from '../../src/providers/adapters/anthropic.js';
+import type { MessageWithContent } from '../../src/providers/types.js';
+
+// =============================================================================
+// MOCK SETUP
+// =============================================================================
+
+const originalFetch = globalThis.fetch;
+
+function mockFetch(responseData: unknown, options: { status?: number; ok?: boolean } = {}) {
+  const { status = 200, ok = true } = options;
+  return vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: vi.fn().mockResolvedValue(responseData),
+    text: vi.fn().mockResolvedValue(JSON.stringify(responseData)),
+    headers: {
+      get: vi.fn().mockReturnValue(null),
+    },
+  });
+}
+
+function setEnvVars(vars: Record<string, string>) {
+  for (const [key, value] of Object.entries(vars)) {
+    process.env[key] = value;
+  }
+}
+
+function clearEnvVars(keys: string[]) {
+  for (const key of keys) {
+    delete process.env[key];
+  }
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('Anthropic Cache Pipeline', () => {
+  beforeEach(() => {
+    setEnvVars({ ANTHROPIC_API_KEY: 'test-key' });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearEnvVars(['ANTHROPIC_API_KEY']);
+  });
+
+  describe('prompt-caching beta header', () => {
+    const standardResponse = {
+      content: [{ type: 'text', text: 'Hello' }],
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+
+    it('chat() should send anthropic-beta: prompt-caching-2024-07-31 header', async () => {
+      const fetchMock = mockFetch(standardResponse);
+      globalThis.fetch = fetchMock;
+
+      const provider = new AnthropicProvider({ apiKey: 'test-key' });
+      await provider.chat([
+        { role: 'user', content: 'Hello' },
+      ]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['anthropic-beta']).toBe('prompt-caching-2024-07-31');
+    });
+
+    it('chatWithTools() should send anthropic-beta: prompt-caching-2024-07-31 header', async () => {
+      const fetchMock = mockFetch({
+        id: 'msg_1',
+        content: [{ type: 'text', text: 'Hello' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 5 },
+      });
+      globalThis.fetch = fetchMock;
+
+      const provider = new AnthropicProvider({ apiKey: 'test-key' });
+      await provider.chatWithTools([
+        { role: 'user', content: 'Hello' },
+      ]);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['anthropic-beta']).toBe('prompt-caching-2024-07-31');
+    });
+  });
+
+  describe('structured system content with cache_control', () => {
+    it('chatWithTools() should pass structured system content as-is', async () => {
+      const fetchMock = mockFetch({
+        id: 'msg_1',
+        content: [{ type: 'text', text: 'OK' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 100, output_tokens: 10 },
+      });
+      globalThis.fetch = fetchMock;
+
+      const structuredSystem: MessageWithContent = {
+        role: 'system',
+        content: [
+          { type: 'text', text: 'You are an assistant.' },
+          { type: 'text', text: 'Be helpful.', cache_control: { type: 'ephemeral' } },
+        ],
+      };
+
+      const provider = new AnthropicProvider({ apiKey: 'test-key' });
+      await provider.chatWithTools([
+        structuredSystem,
+        { role: 'user', content: 'Hi' },
+      ]);
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body);
+
+      // System content should be the structured array, not a flattened string
+      expect(Array.isArray(body.system)).toBe(true);
+      expect(body.system).toHaveLength(2);
+      expect(body.system[0]).toEqual({ type: 'text', text: 'You are an assistant.' });
+      expect(body.system[1]).toEqual({
+        type: 'text',
+        text: 'Be helpful.',
+        cache_control: { type: 'ephemeral' },
+      });
+    });
+
+    it('chat() should pass structured system content as-is', async () => {
+      const fetchMock = mockFetch({
+        content: [{ type: 'text', text: 'OK' }],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 100, output_tokens: 10 },
+      });
+      globalThis.fetch = fetchMock;
+
+      const structuredSystem: MessageWithContent = {
+        role: 'system',
+        content: [
+          { type: 'text', text: 'System prompt.', cache_control: { type: 'ephemeral' } },
+        ],
+      };
+
+      const provider = new AnthropicProvider({ apiKey: 'test-key' });
+      await provider.chat([
+        structuredSystem,
+        { role: 'user', content: 'Hi' },
+      ]);
+
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse(init.body);
+
+      expect(Array.isArray(body.system)).toBe(true);
+      expect(body.system[0].cache_control).toEqual({ type: 'ephemeral' });
+    });
+  });
+
+  describe('cache usage extraction', () => {
+    it('chat() should extract cache_creation and cache_read tokens', async () => {
+      const fetchMock = mockFetch({
+        content: [{ type: 'text', text: 'cached response' }],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 2000,
+          output_tokens: 100,
+          cache_creation_input_tokens: 500,
+          cache_read_input_tokens: 1200,
+        },
+      });
+      globalThis.fetch = fetchMock;
+
+      const provider = new AnthropicProvider({ apiKey: 'test-key' });
+      const result = await provider.chat([
+        { role: 'user', content: 'Hello' },
+      ]);
+
+      expect(result.usage?.cacheWriteTokens).toBe(500);
+      expect(result.usage?.cacheReadTokens).toBe(1200);
+    });
+
+    it('chatWithTools() should extract cache_creation and cache_read tokens', async () => {
+      const fetchMock = mockFetch({
+        id: 'msg_1',
+        content: [{ type: 'text', text: 'cached response' }],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 3000,
+          output_tokens: 200,
+          cache_creation_input_tokens: 800,
+          cache_read_input_tokens: 1500,
+        },
+      });
+      globalThis.fetch = fetchMock;
+
+      const provider = new AnthropicProvider({ apiKey: 'test-key' });
+      const result = await provider.chatWithTools([
+        { role: 'user', content: 'Hello' },
+      ]);
+
+      expect(result.usage?.cacheWriteTokens).toBe(800);
+      expect(result.usage?.cacheReadTokens).toBe(1500);
+    });
+
+    it('should handle missing cache fields gracefully', async () => {
+      const fetchMock = mockFetch({
+        content: [{ type: 'text', text: 'no cache' }],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+        },
+      });
+      globalThis.fetch = fetchMock;
+
+      const provider = new AnthropicProvider({ apiKey: 'test-key' });
+      const result = await provider.chat([
+        { role: 'user', content: 'Hello' },
+      ]);
+
+      expect(result.usage?.cacheWriteTokens).toBeUndefined();
+      expect(result.usage?.cacheReadTokens).toBeUndefined();
+    });
+  });
+});

--- a/attocode/tests/tools/coercion.test.ts
+++ b/attocode/tests/tools/coercion.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for coerceBoolean() from src/tools/coercion.ts.
+ *
+ * Weaker models sometimes send booleans as strings. coerceBoolean() uses
+ * z.preprocess() to handle this before Zod validation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { coerceBoolean } from '../../src/tools/coercion.js';
+
+describe('coerceBoolean', () => {
+  const schema = coerceBoolean();
+
+  describe('actual booleans pass through', () => {
+    it('should accept true', () => {
+      expect(schema.parse(true)).toBe(true);
+    });
+
+    it('should accept false', () => {
+      expect(schema.parse(false)).toBe(false);
+    });
+  });
+
+  describe('string "true"/"false" coerce to booleans', () => {
+    it('should coerce "true" to true', () => {
+      expect(schema.parse('true')).toBe(true);
+    });
+
+    it('should coerce "false" to false', () => {
+      expect(schema.parse('false')).toBe(false);
+    });
+  });
+
+  describe('case-insensitive and whitespace-tolerant', () => {
+    it('should coerce "TRUE" to true', () => {
+      expect(schema.parse('TRUE')).toBe(true);
+    });
+
+    it('should coerce "FALSE" to false', () => {
+      expect(schema.parse('FALSE')).toBe(false);
+    });
+
+    it('should coerce "True" to true', () => {
+      expect(schema.parse('True')).toBe(true);
+    });
+
+    it('should coerce " True " (with whitespace) to true', () => {
+      expect(schema.parse(' True ')).toBe(true);
+    });
+
+    it('should coerce " false " (with whitespace) to false', () => {
+      expect(schema.parse(' false ')).toBe(false);
+    });
+  });
+
+  describe('"1"/"0" and "yes"/"no" coerce correctly', () => {
+    it('should coerce "1" to true', () => {
+      expect(schema.parse('1')).toBe(true);
+    });
+
+    it('should coerce "0" to false', () => {
+      expect(schema.parse('0')).toBe(false);
+    });
+
+    it('should coerce "yes" to true', () => {
+      expect(schema.parse('yes')).toBe(true);
+    });
+
+    it('should coerce "no" to false', () => {
+      expect(schema.parse('no')).toBe(false);
+    });
+
+    it('should coerce "YES" to true', () => {
+      expect(schema.parse('YES')).toBe(true);
+    });
+
+    it('should coerce "NO" to false', () => {
+      expect(schema.parse('NO')).toBe(false);
+    });
+  });
+
+  describe('non-boolean strings fail validation', () => {
+    it('should reject "maybe"', () => {
+      expect(() => schema.parse('maybe')).toThrow();
+    });
+
+    it('should reject "2"', () => {
+      expect(() => schema.parse('2')).toThrow();
+    });
+
+    it('should reject empty string', () => {
+      expect(() => schema.parse('')).toThrow();
+    });
+  });
+
+  describe('non-string, non-boolean values fail validation', () => {
+    it('should reject number 1 (passes through to z.boolean which rejects)', () => {
+      expect(() => schema.parse(1)).toThrow();
+    });
+
+    it('should reject number 0', () => {
+      expect(() => schema.parse(0)).toThrow();
+    });
+
+    it('should reject null', () => {
+      expect(() => schema.parse(null)).toThrow();
+    });
+
+    it('should reject undefined', () => {
+      expect(() => schema.parse(undefined)).toThrow();
+    });
+
+    it('should reject object', () => {
+      expect(() => schema.parse({})).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
### Added
- Introduced parallel tool execution batching for read-only tools, improving performance by executing them concurrently.
- Implemented boolean coercion for tool parameters to handle string representations of booleans.
- Added `allowMcpTools` field in agent definitions to control access to MCP tools.
- Expanded test coverage with new test suites, adding 56 tests across various components.

### Fixed
- Resolved double budget allocation issue in parallel spawns.
- Fixed agent hang on unparseable tool call arguments, improving error handling.

### Changed
- Updated caching headers for Anthropic prompts and improved cache usage extraction in responses.
- Removed flawed `reserveBatch()` method in budget pool API, replacing it with more effective methods for managing allocations.

This release focuses on enhancing performance, error handling, and flexibility in tool execution.