### PR TITLE
chore: update version to 0.1.9 and improve documentation formatting

### DIFF
--- a/attocode/attocode_py/docs/advanced-features.md
+++ b/attocode/attocode_py/docs/advanced-features.md
@@ -18,8 +18,8 @@ Plan mode switches the agent to a read-only state where file writes are intercep
 ```mermaid
 flowchart LR
     Draft[Draft Plan] --> Discuss[Discuss / Refine]
-    Discuss --> Approve[/approve]
-    Discuss --> Reject[/reject]
+    Discuss --> Approve["/approve"]
+    Discuss --> Reject["/reject"]
     Approve --> Execute[Execute Steps]
     Execute --> Complete[Done]
     Reject --> Draft

--- a/attocode/attocode_py/docs/ast-and-code-intelligence.md
+++ b/attocode/attocode_py/docs/ast-and-code-intelligence.md
@@ -28,8 +28,8 @@ flowchart TB
     end
 
     subgraph Commands["Slash Commands"]
-        Repomap[/repomap]
-        Context[/context]
+        Repomap["/repomap"]
+        Context["/context"]
     end
 
     Parser --> Service

--- a/attocode/attocode_py/docs/context-engineering.md
+++ b/attocode/attocode_py/docs/context-engineering.md
@@ -410,7 +410,7 @@ sequenceDiagram
     participant LLM as LLM Provider
 
     Loop->>AC: check(messages)
-    alt Usage > 80%
+    alt Usage above 80 percent
         AC->>LLM: Summarize progress
         LLM-->>AC: Summary
         AC->>Loop: Compacted messages

--- a/attocode/attocode_py/uv.lock
+++ b/attocode/attocode_py/uv.lock
@@ -63,7 +63,7 @@ wheels = [
 
 [[package]]
 name = "attocode"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
- Bumped version to 0.1.9 in `uv.lock`.
- Enhanced documentation by updating command syntax in flowcharts for clarity and consistency.