### PR TITLE
chore: release v0.1.10

### DIFF
--- a/attocode/attocode_py/CHANGELOG.md
+++ b/attocode/attocode_py/CHANGELOG.md
@@ -12,6 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `attoswarm tui` not picking up new TUI widgets when installed via `uv tool install`
 - Enabling code understanding tools of attocode to other AI coders as a skill system
 
+## [0.1.10] - 2026-03-03
+
+### Fixed
+
+- **PyPI token leak via sdist over-inclusion** — `snapshot_report.html` (pytest-textual-snapshot
+  HTML report) captured environment variables including a PyPI API token. Hatchling's sdist builder
+  couldn't resolve `.gitignore` for the nested project layout, so it included everything. Added
+  explicit `[tool.hatch.build.targets.sdist]` exclude rules for snapshot reports, session DBs,
+  trace files, recordings, and other non-source artifacts.
+
+### Security
+
+- Deleted `snapshot_report.html` containing leaked (auto-revoked) PyPI token
+- Added sdist exclusions: `*.db`, `*.jsonl`, `.attocode/traces/`, `.attocode/sessions/`,
+  `.attocode/recordings/`, `.claude/`, `.agent/`, `.traces/`, `site/`, `dist/`, `.venv/`
+
 ## [0.1.9] - 2026-03-03
 
 ### Added

--- a/attocode/attocode_py/pyproject.toml
+++ b/attocode/attocode_py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "attocode"
-version = "0.1.9"
+version = "0.1.10"
 description = "Production AI coding agent"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -79,6 +79,23 @@ Changelog = "https://github.com/eren23/attocode/blob/main/attocode_py/CHANGELOG.
 [tool.hatch.build.targets.wheel]
 packages = ["src/attocode", "src/attoswarm", "src/attocode_core"]
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "snapshot_report.html",
+    ".attocode/traces/",
+    ".attocode/sessions/",
+    ".attocode/recordings/",
+    ".claude/",
+    ".agent/",
+    ".traces/",
+    "site/",
+    "dist/",
+    ".venv/",
+    "__pycache__/",
+    "*.db",
+    "*.jsonl",
+]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
@@ -106,7 +123,7 @@ source = ["src/attocode", "src/attoswarm", "src/attocode_core"]
 omit = ["tests/*"]
 
 [tool.bumpversion]
-current_version = "0.1.9"
+current_version = "0.1.10"
 commit = false
 tag = false
 

--- a/attocode/attocode_py/src/attocode/__init__.py
+++ b/attocode/attocode_py/src/attocode/__init__.py
@@ -1,3 +1,3 @@
 """Attocode - Production AI coding agent."""
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.10
- Add sdist exclude rules in `pyproject.toml` for `.db`, `.jsonl`, `snapshot_report.html`
- Remove `snapshot_report.html` that was accidentally included in v0.1.9 sdist

## After merge
- Tag `v0.1.10` to trigger release workflow
- Yank v0.1.9 on PyPI