### PR TITLE
ci: add Python release workflow

### DIFF
--- a/.github/workflows/release-py.yml
+++ b/.github/workflows/release-py.yml
@@ -1,0 +1,51 @@
+name: Release Python to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: attocode/attocode_py
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: pip install --upgrade pip hatchling build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: attocode/attocode_py/dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Add `release-py.yml` to repo root `.github/workflows/`
- The existing `release.yml` inside `attocode/attocode_py/.github/` was never triggered by GitHub Actions

## Next
After merge, delete and re-push `v0.1.10` tag to trigger the release.