### PR TITLE
chore: update version to 0.1.10 and enhance documentation

### DIFF
--- a/attocode/attocode_py/docs/ast-and-code-intelligence.md
+++ b/attocode/attocode_py/docs/ast-and-code-intelligence.md
@@ -270,12 +270,19 @@ uv tool install attocode
 # or: pip install attocode
 
 # Then install the MCP server into your tool of choice
-attocode code-intel install claude       # Claude Code (project-level)
+attocode code-intel install claude           # Claude Code (project-level)
 attocode code-intel install claude --global  # Claude Code (user-level)
-attocode code-intel install cursor       # Cursor
-attocode code-intel install windsurf     # Windsurf
-attocode code-intel install codex        # OpenAI Codex CLI
+attocode code-intel install cursor           # Cursor
+attocode code-intel install windsurf         # Windsurf
+attocode code-intel install vscode           # VS Code / GitHub Copilot
+attocode code-intel install codex            # OpenAI Codex CLI
 attocode code-intel install codex --global   # Codex (user-level)
+attocode code-intel install claude-desktop   # Claude Desktop
+attocode code-intel install cline            # Cline (VS Code extension)
+attocode code-intel install zed              # Zed (project-level)
+attocode code-intel install zed --global     # Zed (user-level)
+attocode code-intel install intellij         # IntelliJ (prints manual steps)
+attocode code-intel install opencode         # OpenCode (prints manual steps)
 ```
 
 ### Installation Targets
@@ -285,9 +292,17 @@ attocode code-intel install codex --global   # Codex (user-level)
 | Claude Code | `install claude` | Via `claude mcp add` CLI | N/A (managed) |
 | Cursor | `install cursor` | `.cursor/mcp.json` | JSON |
 | Windsurf | `install windsurf` | `.windsurf/mcp.json` | JSON |
+| VS Code | `install vscode` | `.vscode/mcp.json` | JSON |
 | Codex | `install codex` | `.codex/config.toml` | TOML |
+| Claude Desktop | `install claude-desktop` | `~/Library/.../claude_desktop_config.json` | JSON |
+| Cline | `install cline` | VS Code globalStorage `cline_mcp_settings.json` | JSON |
+| Zed | `install zed` | `.zed/settings.json` | JSON (`context_servers`) |
+| IntelliJ | `install intellij` | N/A (manual setup) | --- |
+| OpenCode | `install opencode` | N/A (manual setup) | --- |
 
-All targets support `--project <path>` to specify the project directory (defaults to `.`). Claude Code and Codex support `--global` for user-level installation.
+All targets support `--project <path>` to specify the project directory (defaults to `.`). Claude Code, Codex, and Zed support `--global` for user-level installation.
+
+> **Note:** IntelliJ and OpenCode do not support file-based MCP configuration. Running `install intellij` or `install opencode` prints step-by-step manual setup instructions instead.
 
 ### Available Tools
 

--- a/attocode/attocode_py/src/attocode/code_intel/cli.py
+++ b/attocode/attocode_py/src/attocode/code_intel/cli.py
@@ -52,14 +52,28 @@ def _print_help() -> None:
         "Usage: attocode code-intel <command>\n"
         "\n"
         "Commands:\n"
-        "  install <target>    Install MCP server (claude, cursor, windsurf, codex)\n"
-        "  uninstall <target>  Remove MCP server\n"
+        "  install <target>    Install MCP server into a coding assistant\n"
+        "  uninstall <target>  Remove MCP server from a coding assistant\n"
         "  serve               Run MCP server directly (stdio)\n"
-        "  status              Check installation status\n"
+        "  status              Check installation status across all targets\n"
+        "\n"
+        "Targets (auto-install):\n"
+        "  claude              Claude Code (via `claude mcp add` CLI)\n"
+        "  cursor              Cursor (.cursor/mcp.json)\n"
+        "  windsurf            Windsurf (.windsurf/mcp.json)\n"
+        "  vscode              VS Code / GitHub Copilot (.vscode/mcp.json)\n"
+        "  codex               OpenAI Codex CLI (.codex/config.toml)\n"
+        "  claude-desktop      Claude Desktop (platform-specific config)\n"
+        "  cline               Cline VS Code extension (globalStorage)\n"
+        "  zed                 Zed (.zed/settings.json)\n"
+        "\n"
+        "Targets (manual instructions):\n"
+        "  intellij            IntelliJ IDEA (prints setup steps)\n"
+        "  opencode            OpenCode (prints setup steps)\n"
         "\n"
         "Options:\n"
         "  --project <path>    Project directory to index (default: .)\n"
-        "  --global            Install globally (Claude only)\n"
+        "  --global            Install globally (Claude, Codex, Zed)\n"
     )
 
 
@@ -95,11 +109,11 @@ def _parse_opts(args: list[str]) -> tuple[str | None, str, str]:
 
 
 def _cmd_install(args: list[str]) -> None:
-    from attocode.code_intel.installer import install
+    from attocode.code_intel.installer import ALL_TARGETS_STR, install
 
     target, project_dir, scope = _parse_opts(args)
     if not target:
-        print("Error: specify a target (claude, cursor, windsurf, codex)", file=sys.stderr)
+        print(f"Error: specify a target ({ALL_TARGETS_STR})", file=sys.stderr)
         sys.exit(1)
 
     success = install(target, project_dir=project_dir, scope=scope)
@@ -108,11 +122,11 @@ def _cmd_install(args: list[str]) -> None:
 
 
 def _cmd_uninstall(args: list[str]) -> None:
-    from attocode.code_intel.installer import uninstall
+    from attocode.code_intel.installer import ALL_TARGETS_STR, uninstall
 
     target, project_dir, scope = _parse_opts(args)
     if not target:
-        print("Error: specify a target (claude, cursor, windsurf, codex)", file=sys.stderr)
+        print(f"Error: specify a target ({ALL_TARGETS_STR})", file=sys.stderr)
         sys.exit(1)
 
     success = uninstall(target, project_dir=project_dir, scope=scope)
@@ -141,6 +155,8 @@ def _cmd_status() -> None:
     import json
     from pathlib import Path
 
+    from attocode.code_intel.installer import _get_user_config_dir
+
     print("attocode-code-intel status:\n")
 
     # Check Claude Code
@@ -160,33 +176,20 @@ def _cmd_status() -> None:
     else:
         print("  Claude Code: CLI not found")
 
-    # Check Cursor
-    cursor_cfg = Path(".cursor/mcp.json")
-    if cursor_cfg.exists():
-        try:
-            data = json.loads(cursor_cfg.read_text())
-            if "attocode-code-intel" in data.get("mcpServers", {}):
-                print("  Cursor: installed")
-            else:
-                print("  Cursor: not installed")
-        except Exception:
-            print("  Cursor: unable to check")
-    else:
-        print("  Cursor: not installed")
-
-    # Check Windsurf
-    windsurf_cfg = Path(".windsurf/mcp.json")
-    if windsurf_cfg.exists():
-        try:
-            data = json.loads(windsurf_cfg.read_text())
-            if "attocode-code-intel" in data.get("mcpServers", {}):
-                print("  Windsurf: installed")
-            else:
-                print("  Windsurf: not installed")
-        except Exception:
-            print("  Windsurf: unable to check")
-    else:
-        print("  Windsurf: not installed")
+    # Check JSON-config targets (Cursor, Windsurf, VS Code)
+    for name, config_dir in [("Cursor", ".cursor"), ("Windsurf", ".windsurf"), ("VS Code", ".vscode")]:
+        cfg = Path(config_dir) / "mcp.json"
+        if cfg.exists():
+            try:
+                data = json.loads(cfg.read_text())
+                if "attocode-code-intel" in data.get("mcpServers", {}):
+                    print(f"  {name}: installed")
+                else:
+                    print(f"  {name}: not installed")
+            except Exception:
+                print(f"  {name}: unable to check")
+        else:
+            print(f"  {name}: not installed")
 
     # Check Codex (project-level)
     codex_cfg = Path(".codex/config.toml")
@@ -215,6 +218,59 @@ def _cmd_status() -> None:
                 print("  Codex: unable to check")
         else:
             print("  Codex: not installed")
+
+    # Check Claude Desktop
+    claude_desktop_dir = _get_user_config_dir("claude-desktop")
+    if claude_desktop_dir is not None:
+        cfg = claude_desktop_dir / "claude_desktop_config.json"
+        if cfg.exists():
+            try:
+                data = json.loads(cfg.read_text())
+                if "attocode-code-intel" in data.get("mcpServers", {}):
+                    print("  Claude Desktop: installed")
+                else:
+                    print("  Claude Desktop: not installed")
+            except Exception:
+                print("  Claude Desktop: unable to check")
+        else:
+            print("  Claude Desktop: not installed")
+    else:
+        print("  Claude Desktop: not supported on this platform")
+
+    # Check Cline
+    cline_dir = _get_user_config_dir("cline")
+    if cline_dir is not None:
+        cfg = cline_dir / "cline_mcp_settings.json"
+        if cfg.exists():
+            try:
+                data = json.loads(cfg.read_text())
+                if "attocode-code-intel" in data.get("mcpServers", {}):
+                    print("  Cline: installed")
+                else:
+                    print("  Cline: not installed")
+            except Exception:
+                print("  Cline: unable to check")
+        else:
+            print("  Cline: not installed")
+    else:
+        print("  Cline: not supported on this platform")
+
+    # Check Zed (project-level, then user-level)
+    zed_local = Path(".zed/settings.json")
+    zed_user = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "zed" / "settings.json"
+    zed_found = False
+    for zed_path, label in [(zed_local, "installed"), (zed_user, "installed (user)")]:
+        if zed_path.exists():
+            try:
+                data = json.loads(zed_path.read_text())
+                if "attocode-code-intel" in data.get("context_servers", {}):
+                    print(f"  Zed: {label}")
+                    zed_found = True
+                    break
+            except Exception:
+                pass
+    if not zed_found:
+        print("  Zed: not installed")
 
     # Check if entry point is available
     print()

--- a/attocode/attocode_py/src/attocode/code_intel/installer.py
+++ b/attocode/attocode_py/src/attocode/code_intel/installer.py
@@ -4,13 +4,19 @@ Supports:
 - Claude Code: via `claude mcp add` CLI
 - Cursor: via `.cursor/mcp.json`
 - Windsurf: via `.windsurf/mcp.json`
+- VS Code: via `.vscode/mcp.json`
 - Codex: via `.codex/config.toml`
+- Claude Desktop: via platform-specific `claude_desktop_config.json`
+- Cline: via VS Code globalStorage `cline_mcp_settings.json`
+- Zed: via `.zed/settings.json` or `~/.config/zed/settings.json`
+- IntelliJ / OpenCode: manual instructions
 """
 
 from __future__ import annotations
 
 import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -18,6 +24,25 @@ import tomllib
 from pathlib import Path
 
 import tomli_w
+
+# ---------------------------------------------------------------------------
+# Target constants
+# ---------------------------------------------------------------------------
+
+#: Targets that can be auto-installed via config file manipulation or CLI.
+AUTO_INSTALL_TARGETS: tuple[str, ...] = (
+    "claude", "cursor", "windsurf", "vscode", "codex",
+    "claude-desktop", "cline", "zed",
+)
+
+#: Targets that only support manual setup instructions.
+MANUAL_TARGETS: tuple[str, ...] = ("intellij", "opencode")
+
+#: All recognised target names.
+ALL_TARGETS: tuple[str, ...] = AUTO_INSTALL_TARGETS + MANUAL_TARGETS
+
+#: Friendly string for error messages.
+ALL_TARGETS_STR: str = ", ".join(ALL_TARGETS)
 
 
 def _find_command() -> str:
@@ -103,10 +128,10 @@ def install_json_config(
     target: str,
     project_dir: str = ".",
 ) -> bool:
-    """Install into Cursor or Windsurf via .mcp.json file.
+    """Install into Cursor, Windsurf, or VS Code via .mcp.json file.
 
     Args:
-        target: "cursor" or "windsurf".
+        target: "cursor", "windsurf", or "vscode".
         project_dir: Path to the project to index.
 
     Returns:
@@ -115,6 +140,7 @@ def install_json_config(
     config_dirs = {
         "cursor": ".cursor",
         "windsurf": ".windsurf",
+        "vscode": ".vscode",
     }
 
     config_dir = config_dirs.get(target)
@@ -166,10 +192,11 @@ def uninstall_claude(scope: str = "local") -> bool:
 
 
 def uninstall_json_config(target: str, project_dir: str = ".") -> bool:
-    """Uninstall from Cursor or Windsurf."""
+    """Uninstall from Cursor, Windsurf, or VS Code."""
     config_dirs = {
         "cursor": ".cursor",
         "windsurf": ".windsurf",
+        "vscode": ".vscode",
     }
 
     config_dir = config_dirs.get(target)
@@ -266,23 +293,377 @@ def uninstall_codex(project_dir: str = ".", scope: str = "local") -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Platform-specific config path resolver
+# ---------------------------------------------------------------------------
+
+
+def _get_user_config_dir(app: str) -> Path | None:
+    """Return the platform-specific user config directory for *app*.
+
+    Supported apps:
+      - ``"claude-desktop"`` — Claude Desktop's config dir
+      - ``"cline"``         — Cline extension globalStorage inside VS Code
+
+    Returns ``None`` for unsupported (app, platform) combinations.
+    """
+    system = platform.system()  # "Darwin", "Linux", "Windows"
+
+    if app == "claude-desktop":
+        if system == "Darwin":
+            return Path.home() / "Library" / "Application Support" / "Claude"
+        if system == "Linux":
+            return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "Claude"
+        if system == "Windows":
+            appdata = os.environ.get("APPDATA", "")
+            if appdata:
+                return Path(appdata) / "Claude"
+        return None
+
+    if app == "cline":
+        if system == "Darwin":
+            return (
+                Path.home()
+                / "Library"
+                / "Application Support"
+                / "Code"
+                / "User"
+                / "globalStorage"
+                / "saoudrizwan.claude-dev"
+            )
+        if system == "Linux":
+            return (
+                Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config"))
+                / "Code"
+                / "User"
+                / "globalStorage"
+                / "saoudrizwan.claude-dev"
+            )
+        if system == "Windows":
+            appdata = os.environ.get("APPDATA", "")
+            if appdata:
+                return (
+                    Path(appdata)
+                    / "Code"
+                    / "User"
+                    / "globalStorage"
+                    / "saoudrizwan.claude-dev"
+                )
+        return None
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Claude Desktop
+# ---------------------------------------------------------------------------
+
+
+def install_claude_desktop(project_dir: str = ".") -> bool:
+    """Install into Claude Desktop via ``claude_desktop_config.json``.
+
+    Returns True if installation succeeded.
+    """
+    config_dir = _get_user_config_dir("claude-desktop")
+    if config_dir is None:
+        print(
+            f"Error: Claude Desktop config path not supported on {platform.system()}",
+            file=sys.stderr,
+        )
+        return False
+
+    config_path = config_dir / "claude_desktop_config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict = {}
+    if config_path.exists():
+        import contextlib
+        with contextlib.suppress(json.JSONDecodeError, OSError):
+            existing = json.loads(config_path.read_text(encoding="utf-8"))
+
+    servers = existing.setdefault("mcpServers", {})
+    servers["attocode-code-intel"] = _build_server_entry(project_dir)
+
+    config_path.write_text(
+        json.dumps(existing, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Installed attocode-code-intel into {config_path}")
+    return True
+
+
+def uninstall_claude_desktop() -> bool:
+    """Uninstall from Claude Desktop."""
+    config_dir = _get_user_config_dir("claude-desktop")
+    if config_dir is None:
+        print(
+            f"Error: Claude Desktop config path not supported on {platform.system()}",
+            file=sys.stderr,
+        )
+        return False
+
+    config_path = config_dir / "claude_desktop_config.json"
+    if not config_path.exists():
+        print(f"No config found at {config_path}")
+        return True
+
+    try:
+        existing = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return True
+
+    servers = existing.get("mcpServers", {})
+    if "attocode-code-intel" in servers:
+        del servers["attocode-code-intel"]
+        config_path.write_text(
+            json.dumps(existing, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Removed attocode-code-intel from {config_path}")
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Cline (VS Code extension)
+# ---------------------------------------------------------------------------
+
+
+def install_cline(project_dir: str = ".") -> bool:
+    """Install into Cline via ``cline_mcp_settings.json``.
+
+    Returns True if installation succeeded.
+    """
+    config_dir = _get_user_config_dir("cline")
+    if config_dir is None:
+        print(
+            f"Error: Cline config path not supported on {platform.system()}",
+            file=sys.stderr,
+        )
+        return False
+
+    config_path = config_dir / "cline_mcp_settings.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict = {}
+    if config_path.exists():
+        import contextlib
+        with contextlib.suppress(json.JSONDecodeError, OSError):
+            existing = json.loads(config_path.read_text(encoding="utf-8"))
+
+    servers = existing.setdefault("mcpServers", {})
+    servers["attocode-code-intel"] = _build_server_entry(project_dir)
+
+    config_path.write_text(
+        json.dumps(existing, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Installed attocode-code-intel into {config_path}")
+    return True
+
+
+def uninstall_cline() -> bool:
+    """Uninstall from Cline."""
+    config_dir = _get_user_config_dir("cline")
+    if config_dir is None:
+        print(
+            f"Error: Cline config path not supported on {platform.system()}",
+            file=sys.stderr,
+        )
+        return False
+
+    config_path = config_dir / "cline_mcp_settings.json"
+    if not config_path.exists():
+        print(f"No config found at {config_path}")
+        return True
+
+    try:
+        existing = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return True
+
+    servers = existing.get("mcpServers", {})
+    if "attocode-code-intel" in servers:
+        del servers["attocode-code-intel"]
+        config_path.write_text(
+            json.dumps(existing, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Removed attocode-code-intel from {config_path}")
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Zed
+# ---------------------------------------------------------------------------
+
+
+def _build_zed_server_entry(project_dir: str) -> dict:
+    """Build the MCP server config dict for Zed's ``context_servers`` format.
+
+    Zed uses a nested ``{"command": {"path": ..., "args": [...]}}`` schema.
+    """
+    cmd = _find_command()
+    parts = cmd.split()
+    command = parts[0]
+    args = parts[1:] + ["--project", os.path.abspath(project_dir)]
+    return {
+        "command": {
+            "path": command,
+            "args": args,
+        },
+    }
+
+
+def install_zed(project_dir: str = ".", scope: str = "local") -> bool:
+    """Install into Zed via ``settings.json``.
+
+    Args:
+        project_dir: Path to the project to index.
+        scope: "local" writes to ``.zed/settings.json`` (project),
+               "user" writes to ``~/.config/zed/settings.json``.
+
+    Returns True if installation succeeded.
+    """
+    if scope == "user":
+        config_path = Path(
+            os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")
+        ) / "zed" / "settings.json"
+    else:
+        config_path = Path(project_dir) / ".zed" / "settings.json"
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing: dict = {}
+    if config_path.exists():
+        import contextlib
+        with contextlib.suppress(json.JSONDecodeError, OSError):
+            existing = json.loads(config_path.read_text(encoding="utf-8"))
+
+    servers = existing.setdefault("context_servers", {})
+    servers["attocode-code-intel"] = _build_zed_server_entry(project_dir)
+
+    config_path.write_text(
+        json.dumps(existing, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Installed attocode-code-intel into {config_path}")
+    return True
+
+
+def uninstall_zed(project_dir: str = ".", scope: str = "local") -> bool:
+    """Uninstall from Zed."""
+    if scope == "user":
+        config_path = Path(
+            os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")
+        ) / "zed" / "settings.json"
+    else:
+        config_path = Path(project_dir) / ".zed" / "settings.json"
+
+    if not config_path.exists():
+        print(f"No config found at {config_path}")
+        return True
+
+    try:
+        existing = json.loads(config_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return True
+
+    servers = existing.get("context_servers", {})
+    if "attocode-code-intel" in servers:
+        del servers["attocode-code-intel"]
+        config_path.write_text(
+            json.dumps(existing, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        print(f"Removed attocode-code-intel from {config_path}")
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Manual instruction targets (IntelliJ, OpenCode)
+# ---------------------------------------------------------------------------
+
+_MANUAL_INSTRUCTIONS: dict[str, str] = {
+    "intellij": (
+        "IntelliJ IDEA does not support file-based MCP configuration.\n"
+        "\n"
+        "To set up attocode-code-intel in IntelliJ:\n"
+        "  1. Open Settings > Tools > AI Assistant > MCP Servers\n"
+        "  2. Click '+' to add a new server\n"
+        "  3. Set transport to 'stdio'\n"
+        "  4. Set command to: {command}\n"
+        "  5. Set arguments to: {args}\n"
+        "  6. Click OK and restart the AI Assistant\n"
+    ),
+    "opencode": (
+        "OpenCode MCP configuration varies by version.\n"
+        "\n"
+        "To set up attocode-code-intel in OpenCode:\n"
+        "  1. Open your OpenCode config file (usually ~/.config/opencode/config.json)\n"
+        "  2. Add the following to the 'mcpServers' section:\n"
+        '     "attocode-code-intel": {{\n'
+        '       "command": "{command}",\n'
+        '       "args": {args_json}\n'
+        "     }}\n"
+        "  3. Restart OpenCode\n"
+    ),
+}
+
+
+def print_manual_instructions(target: str, project_dir: str = ".") -> bool:
+    """Print manual setup instructions for targets without file-based config.
+
+    Returns True (always succeeds — just prints instructions).
+    """
+    template = _MANUAL_INSTRUCTIONS.get(target)
+    if template is None:
+        print(f"Error: No manual instructions for '{target}'", file=sys.stderr)
+        return False
+
+    entry = _build_server_entry(project_dir)
+    print(
+        template.format(
+            command=entry["command"],
+            args=" ".join(entry["args"]),
+            args_json=json.dumps(entry["args"]),
+        )
+    )
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
 def install(target: str, project_dir: str = ".", scope: str = "local") -> bool:
     """Install into the given target.
 
     Args:
-        target: "claude", "cursor", or "windsurf".
+        target: One of :data:`ALL_TARGETS`.
         project_dir: Path to the project to index.
-        scope: For Claude: "local" or "user". Ignored for others.
+        scope: For Claude/Codex/Zed: "local" or "user". Ignored for others.
     """
     if target == "claude":
         return install_claude(project_dir, scope=scope)
-    elif target in ("cursor", "windsurf"):
+    elif target in ("cursor", "windsurf", "vscode"):
         return install_json_config(target, project_dir)
     elif target == "codex":
         return install_codex(project_dir, scope=scope)
+    elif target == "claude-desktop":
+        return install_claude_desktop(project_dir)
+    elif target == "cline":
+        return install_cline(project_dir)
+    elif target == "zed":
+        return install_zed(project_dir, scope=scope)
+    elif target in MANUAL_TARGETS:
+        return print_manual_instructions(target, project_dir)
     else:
         print(
-            f"Error: Unknown target '{target}'. Use: claude, cursor, windsurf, codex",
+            f"Error: Unknown target '{target}'. Use: {ALL_TARGETS_STR}",
             file=sys.stderr,
         )
         return False
@@ -292,13 +673,22 @@ def uninstall(target: str, project_dir: str = ".", scope: str = "local") -> bool
     """Uninstall from the given target."""
     if target == "claude":
         return uninstall_claude(scope=scope)
-    elif target in ("cursor", "windsurf"):
+    elif target in ("cursor", "windsurf", "vscode"):
         return uninstall_json_config(target, project_dir)
     elif target == "codex":
         return uninstall_codex(project_dir, scope=scope)
+    elif target == "claude-desktop":
+        return uninstall_claude_desktop()
+    elif target == "cline":
+        return uninstall_cline()
+    elif target == "zed":
+        return uninstall_zed(project_dir, scope=scope)
+    elif target in MANUAL_TARGETS:
+        print(f"Nothing to uninstall — {target} uses manual configuration.")
+        return True
     else:
         print(
-            f"Error: Unknown target '{target}'. Use: claude, cursor, windsurf, codex",
+            f"Error: Unknown target '{target}'. Use: {ALL_TARGETS_STR}",
             file=sys.stderr,
         )
         return False

--- a/attocode/attocode_py/tests/unit/test_code_intel.py
+++ b/attocode/attocode_py/tests/unit/test_code_intel.py
@@ -1071,6 +1071,281 @@ class TestInstaller:
         assert len(captured_cmds) == 1
         assert "--project" in captured_cmds[0]
 
+    # -- VS Code --
+
+    def test_install_json_vscode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_json_config
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        result = install_json_config("vscode", project_dir=str(tmp_path))
+        assert result is True
+
+        config_path = tmp_path / ".vscode" / "mcp.json"
+        assert config_path.exists()
+
+        data = json.loads(config_path.read_text())
+        assert "attocode-code-intel" in data["mcpServers"]
+        server = data["mcpServers"]["attocode-code-intel"]
+        assert "--project" in server["args"]
+
+    def test_uninstall_json_vscode(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_json_config, uninstall_json_config
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        install_json_config("vscode", project_dir=str(tmp_path))
+        result = uninstall_json_config("vscode", project_dir=str(tmp_path))
+        assert result is True
+
+        data = json.loads((tmp_path / ".vscode" / "mcp.json").read_text())
+        assert "attocode-code-intel" not in data.get("mcpServers", {})
+
+    # -- Claude Desktop --
+
+    def test_install_claude_desktop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_claude_desktop
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        monkeypatch.setattr(
+            "attocode.code_intel.installer._get_user_config_dir",
+            lambda app: tmp_path / "claude-desktop" if app == "claude-desktop" else None,
+        )
+
+        result = install_claude_desktop(project_dir=str(tmp_path))
+        assert result is True
+
+        config_path = tmp_path / "claude-desktop" / "claude_desktop_config.json"
+        assert config_path.exists()
+
+        data = json.loads(config_path.read_text())
+        assert "attocode-code-intel" in data["mcpServers"]
+
+    def test_uninstall_claude_desktop(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_claude_desktop, uninstall_claude_desktop
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        monkeypatch.setattr(
+            "attocode.code_intel.installer._get_user_config_dir",
+            lambda app: tmp_path / "claude-desktop" if app == "claude-desktop" else None,
+        )
+
+        install_claude_desktop(project_dir=str(tmp_path))
+        result = uninstall_claude_desktop()
+        assert result is True
+
+        data = json.loads(
+            (tmp_path / "claude-desktop" / "claude_desktop_config.json").read_text()
+        )
+        assert "attocode-code-intel" not in data.get("mcpServers", {})
+
+    def test_install_claude_desktop_unsupported_platform(self, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_claude_desktop
+
+        monkeypatch.setattr(
+            "attocode.code_intel.installer._get_user_config_dir",
+            lambda app: None,
+        )
+
+        result = install_claude_desktop()
+        assert result is False
+
+    # -- Cline --
+
+    def test_install_cline(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_cline
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        monkeypatch.setattr(
+            "attocode.code_intel.installer._get_user_config_dir",
+            lambda app: tmp_path / "cline" if app == "cline" else None,
+        )
+
+        result = install_cline(project_dir=str(tmp_path))
+        assert result is True
+
+        config_path = tmp_path / "cline" / "cline_mcp_settings.json"
+        assert config_path.exists()
+
+        data = json.loads(config_path.read_text())
+        assert "attocode-code-intel" in data["mcpServers"]
+
+    def test_uninstall_cline(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_cline, uninstall_cline
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        monkeypatch.setattr(
+            "attocode.code_intel.installer._get_user_config_dir",
+            lambda app: tmp_path / "cline" if app == "cline" else None,
+        )
+
+        install_cline(project_dir=str(tmp_path))
+        result = uninstall_cline()
+        assert result is True
+
+        data = json.loads(
+            (tmp_path / "cline" / "cline_mcp_settings.json").read_text()
+        )
+        assert "attocode-code-intel" not in data.get("mcpServers", {})
+
+    # -- Zed --
+
+    def test_install_zed_local(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_zed
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        result = install_zed(project_dir=str(tmp_path), scope="local")
+        assert result is True
+
+        config_path = tmp_path / ".zed" / "settings.json"
+        assert config_path.exists()
+
+        data = json.loads(config_path.read_text())
+        assert "attocode-code-intel" in data["context_servers"]
+        entry = data["context_servers"]["attocode-code-intel"]
+        assert "command" in entry
+        assert "path" in entry["command"]
+        assert "args" in entry["command"]
+
+    def test_install_zed_user(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_zed
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+        result = install_zed(project_dir=str(tmp_path), scope="user")
+        assert result is True
+
+        config_path = tmp_path / "xdg" / "zed" / "settings.json"
+        assert config_path.exists()
+
+        data = json.loads(config_path.read_text())
+        assert "attocode-code-intel" in data["context_servers"]
+
+    def test_uninstall_zed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_zed, uninstall_zed
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        install_zed(project_dir=str(tmp_path), scope="local")
+        result = uninstall_zed(project_dir=str(tmp_path), scope="local")
+        assert result is True
+
+        data = json.loads((tmp_path / ".zed" / "settings.json").read_text())
+        assert "attocode-code-intel" not in data.get("context_servers", {})
+
+    def test_install_zed_merges_existing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import install_zed
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        # Pre-existing settings
+        zed_dir = tmp_path / ".zed"
+        zed_dir.mkdir()
+        existing = {
+            "theme": "One Dark",
+            "context_servers": {"other-server": {"command": {"path": "other"}}},
+        }
+        (zed_dir / "settings.json").write_text(json.dumps(existing))
+
+        install_zed(project_dir=str(tmp_path), scope="local")
+
+        data = json.loads((zed_dir / "settings.json").read_text())
+        assert data["theme"] == "One Dark"
+        assert "other-server" in data["context_servers"]
+        assert "attocode-code-intel" in data["context_servers"]
+
+    # -- IntelliJ / OpenCode (manual instructions) --
+
+    def test_print_manual_instructions_intellij(self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import print_manual_instructions
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        result = print_manual_instructions("intellij")
+        assert result is True
+
+        captured = capsys.readouterr()
+        assert "IntelliJ" in captured.out
+        assert "MCP Servers" in captured.out
+
+    def test_print_manual_instructions_opencode(self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch):
+        from attocode.code_intel.installer import print_manual_instructions
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        result = print_manual_instructions("opencode")
+        assert result is True
+
+        captured = capsys.readouterr()
+        assert "OpenCode" in captured.out
+        assert "mcpServers" in captured.out
+
+    def test_install_dispatch_intellij(self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch):
+        """install('intellij') should print instructions, not fail."""
+        from attocode.code_intel.installer import install
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        result = install("intellij")
+        assert result is True
+
+        captured = capsys.readouterr()
+        assert "IntelliJ" in captured.out
+
+    def test_uninstall_dispatch_manual_target(self, capsys: pytest.CaptureFixture[str]):
+        """uninstall('intellij') should succeed with a message."""
+        from attocode.code_intel.installer import uninstall
+
+        result = uninstall("intellij")
+        assert result is True
+
+        captured = capsys.readouterr()
+        assert "manual" in captured.out.lower()
+
+    # -- _get_user_config_dir --
+
+    def test_get_user_config_dir_claude_desktop_darwin(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        from attocode.code_intel.installer import _get_user_config_dir
+
+        monkeypatch.setattr("attocode.code_intel.installer.platform.system", lambda: "Darwin")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        result = _get_user_config_dir("claude-desktop")
+        assert result is not None
+        assert "Application Support" in str(result)
+        assert "Claude" in str(result)
+
+    def test_get_user_config_dir_claude_desktop_linux(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        from attocode.code_intel.installer import _get_user_config_dir
+
+        monkeypatch.setattr("attocode.code_intel.installer.platform.system", lambda: "Linux")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        result = _get_user_config_dir("claude-desktop")
+        assert result is not None
+        assert ".config" in str(result)
+        assert "Claude" in str(result)
+
+    def test_get_user_config_dir_cline_darwin(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        from attocode.code_intel.installer import _get_user_config_dir
+
+        monkeypatch.setattr("attocode.code_intel.installer.platform.system", lambda: "Darwin")
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+        result = _get_user_config_dir("cline")
+        assert result is not None
+        assert "globalStorage" in str(result)
+        assert "saoudrizwan.claude-dev" in str(result)
+
+    def test_get_user_config_dir_unknown_app(self):
+        from attocode.code_intel.installer import _get_user_config_dir
+
+        result = _get_user_config_dir("unknown-app")
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # CLI dispatch
@@ -1097,6 +1372,20 @@ class TestCLIDispatch:
         dispatch_code_intel(["status"])
         captured = capsys.readouterr()
         assert "attocode-code-intel status" in captured.out
+
+    def test_status_shows_all_targets(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Status output should mention all supported targets."""
+        from attocode.code_intel.cli import dispatch_code_intel
+
+        monkeypatch.setattr("shutil.which", lambda x: None)
+
+        dispatch_code_intel(["status"])
+        captured = capsys.readouterr()
+        for target_name in ["Claude Code", "Cursor", "Windsurf", "VS Code", "Codex",
+                            "Claude Desktop", "Cline", "Zed"]:
+            assert target_name in captured.out, f"Missing '{target_name}' in status output"
 
     def test_dispatch_unknown(self):
         from attocode.code_intel.cli import dispatch_code_intel

--- a/attocode/attocode_py/uv.lock
+++ b/attocode/attocode_py/uv.lock
@@ -63,7 +63,7 @@ wheels = [
 
 [[package]]
 name = "attocode"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
- Bumped version to 0.1.10 in `uv.lock`.
- Updated installation documentation to include new targets: VS Code, Claude Desktop, Cline, and Zed.
- Improved command help output to reflect all available installation targets and their configurations.
- Added tests for new installation and uninstallation functionalities for VS Code, Claude Desktop, Cline, and Zed.