### PR TITLE
chore: release version 0.1.11

### DIFF
--- a/attocode/attocode_py/CHANGELOG.md
+++ b/attocode/attocode_py/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `attoswarm tui` not picking up new TUI widgets when installed via `uv tool install`
 - Enabling code understanding tools of attocode to other AI coders as a skill system
 
+## [0.1.11] - 2026-03-03
+
+### Added
+
+- **6 new IDE integration targets for code-intel MCP server** — `attocode code-intel install`
+  now supports 10 targets (up from 4):
+  - **VS Code / GitHub Copilot** (`vscode`) — writes `.vscode/mcp.json`
+  - **Claude Desktop** (`claude-desktop`) — writes `claude_desktop_config.json` at
+    platform-specific path (macOS, Linux, Windows)
+  - **Cline** (`cline`) — writes `cline_mcp_settings.json` in VS Code globalStorage
+  - **Zed** (`zed`) — writes `.zed/settings.json` with Zed's `context_servers` format;
+    supports `--global` for user-level install
+  - **IntelliJ IDEA** (`intellij`) — prints step-by-step manual setup instructions
+  - **OpenCode** (`opencode`) — prints step-by-step manual setup instructions
+- **Platform-aware config resolver** — `_get_user_config_dir()` resolves correct config
+  paths for Claude Desktop and Cline across macOS, Linux, and Windows
+- **Target constants** — `AUTO_INSTALL_TARGETS`, `MANUAL_TARGETS`, `ALL_TARGETS` exported
+  from installer module for programmatic use
+- **Expanded `code-intel status`** — now checks all 8 auto-install targets (was 4)
+
 ## [0.1.10] - 2026-03-03
 
 ### Fixed

--- a/attocode/attocode_py/pyproject.toml
+++ b/attocode/attocode_py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "attocode"
-version = "0.1.10"
+version = "0.1.11"
 description = "Production AI coding agent"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -123,7 +123,7 @@ source = ["src/attocode", "src/attoswarm", "src/attocode_core"]
 omit = ["tests/*"]
 
 [tool.bumpversion]
-current_version = "0.1.10"
+current_version = "0.1.11"
 commit = false
 tag = false
 

--- a/attocode/attocode_py/src/attocode/__init__.py
+++ b/attocode/attocode_py/src/attocode/__init__.py
@@ -1,3 +1,3 @@
 """Attocode - Production AI coding agent."""
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/attocode/attocode_py/uv.lock
+++ b/attocode/attocode_py/uv.lock
@@ -63,7 +63,7 @@ wheels = [
 
 [[package]]
 name = "attocode"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
- Bumped version to 0.1.11 in `pyproject.toml`, `__init__.py`, and `uv.lock`.
- Updated `CHANGELOG.md` to include 6 new IDE integration targets for the code-intel MCP server, expanding support from 4 to 10 targets.
- Added platform-aware config resolver for improved configuration handling across different operating systems.
- Enhanced `code-intel status` to check all 8 auto-install targets.