### PR TITLE
Add Code Intel HTTP API support and enhance CLI options

### DIFF
--- a/docker/code-intel/Dockerfile
+++ b/docker/code-intel/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install git for repo cloning (Phase 2)
+RUN apt-get update && apt-get install -y --no-install-recommends git curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy project files
+COPY pyproject.toml .
+COPY src/ src/
+
+# Install with code-intel extras
+RUN pip install --no-cache-dir ".[code-intel]"
+
+# Default port
+EXPOSE 8080
+
+# Run HTTP server
+ENV ATTOCODE_HOST=0.0.0.0
+ENV ATTOCODE_PORT=8080
+
+CMD ["attocode-code-intel", "serve", "--transport", "http", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker/code-intel/README.md
+++ b/docker/code-intel/README.md
@@ -1,0 +1,55 @@
+# Code Intelligence Docker Setup
+
+Docker packaging for the Attocode Code Intelligence HTTP API server.
+
+## Quick Start
+
+```bash
+# Analyze the current directory
+docker-compose up --build
+
+# Analyze a specific project
+PROJECT_DIR=/path/to/repo docker-compose up --build
+
+# With authentication
+PROJECT_DIR=/path/to/repo ATTOCODE_API_KEY=my-secret docker-compose up --build
+```
+
+The server starts at `http://localhost:8080`. Open `http://localhost:8080/docs` for Swagger UI.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROJECT_DIR` | `.` (host-side) | Path to the project to analyze |
+| `ATTOCODE_API_KEY` | (empty) | API key for bearer token auth (empty = no auth) |
+| `ATTOCODE_PORT` | `8080` | Port to expose on the host |
+
+Inside the container, `ATTOCODE_HOST` is set to `0.0.0.0` and `ATTOCODE_PROJECT_DIR` is `/project`.
+
+## Volume Mounts
+
+- **`$PROJECT_DIR:/project:ro`** --- Your source code, mounted read-only. The server cannot modify your files.
+- **`code-intel-cache:/project/.attocode/cache`** --- Named volume for persistent SQLite databases (AST graph, embeddings, memory). Survives container restarts.
+
+## Building Manually
+
+```bash
+# From the repository root
+docker build -f docker/code-intel/Dockerfile -t attocode-code-intel .
+
+# Run
+docker run -p 8080:8080 \
+  -v /path/to/repo:/project:ro \
+  -e ATTOCODE_API_KEY=optional-key \
+  attocode-code-intel
+```
+
+## What's Included
+
+- Python 3.12 slim base image
+- Git (for future repo cloning support)
+- Attocode with `[code-intel]` extras (FastAPI, uvicorn, etc.)
+- Runs `attocode-code-intel serve --transport http` as the entrypoint
+
+For full API documentation, see [Code Intel HTTP API](../../docs/code-intel-http-api.md).

--- a/docker/code-intel/docker-compose.yml
+++ b/docker/code-intel/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.8"
+
+services:
+  code-intel:
+    build:
+      context: ../..
+      dockerfile: docker/code-intel/Dockerfile
+    ports:
+      - "${ATTOCODE_PORT:-8080}:8080"
+    environment:
+      - ATTOCODE_PROJECT_DIR=/project
+      - ATTOCODE_API_KEY=${ATTOCODE_API_KEY:-}
+      - ATTOCODE_HOST=0.0.0.0
+      - ATTOCODE_PORT=8080
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    volumes:
+      # Mount a local project to analyze (read-only)
+      - ${PROJECT_DIR:-.}:/project:ro
+      # Writable volume for SQLite cache (graph.db, embeddings.db, memory.db)
+      - code-intel-cache:/project/.attocode/cache
+
+volumes:
+  code-intel-cache:

--- a/docs/ast-and-code-intelligence.md
+++ b/docs/ast-and-code-intelligence.md
@@ -306,21 +306,70 @@ All targets support `--project <path>` to specify the project directory (default
 
 ### Available Tools
 
-The MCP server exposes 11 tools:
+The MCP server exposes 27 tools across 6 categories:
+
+#### Orientation
 
 | Tool | Parameters | Description |
 |------|-----------|-------------|
+| `bootstrap` | `task_hint`, `max_tokens` | All-in-one codebase orientation (summary + map + conventions + search) |
+| `project_summary` | `max_tokens` | High-level project overview (languages, structure, entry points) |
 | `repo_map` | `include_symbols`, `max_tokens` | Token-budgeted file tree with top-level symbols |
+| `explore_codebase` | `path`, `max_items`, `importance_threshold` | Hierarchical drill-down navigation |
+| `hotspots` | `top_n` | Risk/complexity analysis with percentile-ranked hotspots |
+| `conventions` | `sample_size`, `path` | Code style and convention detection (naming, typing, patterns) |
+
+#### Symbol Lookup
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
 | `symbols` | `path` | List all symbols (functions, classes, methods) in a file |
 | `search_symbols` | `name` | Fuzzy symbol search across the entire codebase |
-| `dependencies` | `path` | Show what a file imports from and what imports it |
-| `impact_analysis` | `changed_files` | Transitive impact set via BFS on reverse dependency graph |
 | `cross_references` | `symbol_name` | Find where a symbol is defined and all its usage sites |
 | `file_analysis` | `path` | Detailed single-file analysis: chunks, imports, exports |
+
+#### Dependencies & Graph
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `dependencies` | `path` | Show what a file imports from and what imports it |
 | `dependency_graph` | `start_file`, `depth` | Dependency graph radiating outward from a file |
-| `project_summary` | --- | High-level project overview (languages, structure, entry points) |
-| `hotspots` | --- | Risk/complexity analysis with percentile-ranked hotspots |
-| `conventions` | --- | Code style and convention detection (naming, typing, patterns) |
+| `graph_query` | `file`, `edge_type`, `direction`, `depth` | BFS traversal with typed edges and direction control |
+| `find_related` | `file`, `top_k` | Find structurally similar files (Jaccard + 2-hop) |
+| `community_detection` | `min_community_size`, `max_communities` | Connected-component clustering of the import graph |
+| `impact_analysis` | `changed_files` | Transitive impact set via BFS on reverse dependency graph |
+| `relevant_context` | `files`, `depth`, `max_tokens`, `include_symbols` | Subgraph capsule --- file + neighbors with symbols |
+
+#### Search & Security
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `semantic_search` | `query`, `top_k`, `file_filter` | Natural language code search (vector + keyword RRF) |
+| `security_scan` | `mode`, `path` | Secret detection, anti-patterns, dependency issues |
+
+#### LSP
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `lsp_definition` | `file`, `line`, `col` | Type-resolved go-to-definition |
+| `lsp_references` | `file`, `line`, `col`, `include_declaration` | All references with type awareness |
+| `lsp_hover` | `file`, `line`, `col` | Type signature + documentation |
+| `lsp_diagnostics` | `file` | Errors and warnings from language server |
+
+#### Memory & Recall
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `recall` | `query`, `scope`, `max_results` | Retrieve relevant project learnings |
+| `record_learning` | `type`, `description`, `details`, `scope`, `confidence` | Record patterns/conventions/gotchas |
+| `learning_feedback` | `learning_id`, `helpful` | Mark learning as helpful/unhelpful |
+| `list_learnings` | `status`, `type`, `scope` | Browse all stored learnings |
+
+#### Index Maintenance
+
+| Tool | Parameters | Description |
+|------|-----------|-------------|
+| `notify_file_changed` | `files` | Trigger index update for changed files |
 
 ### CLI Reference
 
@@ -366,8 +415,33 @@ python -m attocode.code_intel.server --project /path/to/repo
 
 The server uses stdio transport and speaks the MCP protocol. Any MCP client can connect to it.
 
+## HTTP API
+
+The same 27 tools are also available as a REST API over HTTP, supporting multi-project management, bearer token authentication, and interactive Swagger/ReDoc docs.
+
+```bash
+# Start the HTTP server
+attocode code-intel serve --transport http --project /path/to/repo
+
+# Open http://localhost:8080/docs for Swagger UI
+```
+
+For the full endpoint reference, authentication setup, Docker deployment, and client examples, see the dedicated **[Code Intel HTTP API](code-intel-http-api.md)** page.
+
+## Docker Deployment
+
+A Docker setup is provided in `docker/code-intel/` for containerized deployment of the HTTP API:
+
+```bash
+cd docker/code-intel
+PROJECT_DIR=/path/to/repo docker-compose up --build
+```
+
+Your source code is mounted read-only; cache databases persist in a named volume. See **[Code Intel HTTP API --- Docker Deployment](code-intel-http-api.md#docker-deployment)** for details.
+
 ## Related Pages
 
+- [Code Intel HTTP API](code-intel-http-api.md) --- REST endpoints, auth, Docker, client examples
 - [Context Engineering](context-engineering.md) --- How context blocks and code context work together
 - [Architecture](ARCHITECTURE.md) --- Overall system design
 - [Extending Attocode](extending.md) --- Adding custom tools

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -51,6 +51,42 @@ attocode --resume abc123
 attocode --non-interactive "List all TODO comments"
 ```
 
+## Code Intelligence Server
+
+The `code-intel serve` subcommand starts the MCP or HTTP server for code intelligence tools.
+
+```bash
+attocode code-intel serve [options]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--transport <type>` | `stdio` | Transport protocol: `stdio`, `sse`, or `http` |
+| `--project <path>` | `.` | Project directory to index |
+| `--host <addr>` | `127.0.0.1` | Server bind address (for `sse` and `http` transports) |
+| `--port <num>` | `8080` | Server port (for `sse` and `http` transports) |
+
+### Transport Modes
+
+| Transport | Protocol | Use Case |
+|-----------|----------|----------|
+| `stdio` | MCP over stdin/stdout | AI coding assistants (Claude Code, Cursor, etc.) |
+| `sse` | MCP over Server-Sent Events | Remote MCP clients |
+| `http` | REST API (FastAPI) | Custom integrations, CI pipelines, multi-project |
+
+```bash
+# Default: MCP over stdio
+attocode code-intel serve --project /path/to/repo
+
+# HTTP REST API
+attocode code-intel serve --transport http --project /path/to/repo
+
+# SSE transport on custom port
+attocode code-intel serve --transport sse --host 0.0.0.0 --port 9090
+```
+
+The HTTP transport serves interactive API docs at `/docs` (Swagger) and `/redoc`. See [Code Intel HTTP API](code-intel-http-api.md) for the full endpoint reference.
+
 ## Keyboard Shortcuts
 
 | Key | Action |

--- a/docs/code-intel-http-api.md
+++ b/docs/code-intel-http-api.md
@@ -1,0 +1,357 @@
+# Code Intelligence HTTP API
+
+The HTTP API exposes all 27 code intelligence tools as REST endpoints, backed by the same analysis engine as the MCP server. It supports multi-project management, bearer token auth, and interactive API docs.
+
+## Quick Start
+
+### Option 1: CLI
+
+```bash
+# Install attocode
+uv tool install attocode
+# or: pip install 'attocode[code-intel]'
+
+# Start the HTTP server for a project
+attocode code-intel serve --transport http --project /path/to/repo
+```
+
+The server starts at `http://127.0.0.1:8080`. Open `http://127.0.0.1:8080/docs` for interactive Swagger UI.
+
+### Option 2: Docker
+
+```bash
+cd docker/code-intel
+
+# Point PROJECT_DIR to the repo you want to analyze
+PROJECT_DIR=/path/to/repo docker-compose up
+```
+
+See [Docker Deployment](#docker-deployment) for details.
+
+### Option 3: Programmatic
+
+```python
+from attocode.code_intel.api.app import create_app
+from attocode.code_intel.config import CodeIntelConfig
+
+config = CodeIntelConfig(project_dir="/path/to/repo", host="0.0.0.0", port=8080)
+app = create_app(config)
+
+# Run with uvicorn
+import uvicorn
+uvicorn.run(app, host=config.host, port=config.port)
+```
+
+---
+
+## Authentication
+
+Authentication is controlled by the `ATTOCODE_API_KEY` environment variable.
+
+| `ATTOCODE_API_KEY` | Behavior |
+|---------------------|----------|
+| Not set (empty) | **Open mode** --- all requests are allowed without auth |
+| Set to a value | **Auth required** --- every request must include `Authorization: Bearer <key>` |
+
+The auth middleware accepts both `Bearer <key>` and the raw key in the `Authorization` header.
+
+```bash
+# Start with auth
+ATTOCODE_API_KEY=my-secret-key attocode code-intel serve --transport http
+
+# Authenticated request
+curl -H "Authorization: Bearer my-secret-key" http://localhost:8080/api/v1/projects
+```
+
+---
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ATTOCODE_PROJECT_DIR` | `""` | Default project directory to index on startup |
+| `ATTOCODE_HOST` | `127.0.0.1` | Server bind address |
+| `ATTOCODE_PORT` | `8080` | Server port |
+| `ATTOCODE_API_KEY` | `""` | API key for bearer auth (empty = open mode) |
+| `ATTOCODE_CORS_ORIGINS` | `*` | Comma-separated allowed CORS origins |
+| `ATTOCODE_LOG_LEVEL` | `info` | Log level (`debug`, `info`, `warning`, `error`) |
+
+---
+
+## Endpoint Reference
+
+All project-scoped endpoints use the pattern `/api/v1/projects/{project_id}/...`. Register a project first to obtain a `project_id`.
+
+### Health
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/health` | Basic health check |
+| `GET` | `/ready` | Readiness probe (checks for registered projects) |
+
+```bash
+curl http://localhost:8080/health
+# {"status": "ok"}
+```
+
+### Projects
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/projects` | Register a project |
+| `GET` | `/api/v1/projects` | List all registered projects |
+| `GET` | `/api/v1/projects/{id}` | Get project details |
+| `POST` | `/api/v1/projects/{id}/reindex` | Trigger full reindex |
+
+```bash
+# Register a project
+curl -X POST http://localhost:8080/api/v1/projects \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/path/to/repo", "name": "my-project"}'
+# {"id": "a1b2c3d4", "name": "my-project", "path": "/path/to/repo", "status": "ready", ...}
+
+# List projects
+curl http://localhost:8080/api/v1/projects
+```
+
+### Analysis
+
+| Method | Path | Parameters | Description |
+|--------|------|-----------|-------------|
+| `GET` | `/{id}/map` | `include_symbols`, `max_tokens` | Token-budgeted repository map |
+| `GET` | `/{id}/summary` | `max_tokens` | High-level project overview |
+| `POST` | `/{id}/bootstrap` | `task_hint`, `max_tokens` | All-in-one codebase orientation |
+| `GET` | `/{id}/symbols` | `path` (required) | List symbols in a file |
+| `GET` | `/{id}/search-symbols` | `name` (required) | Fuzzy symbol search |
+| `GET` | `/{id}/dependencies` | `path` (required) | File dependencies (forward/reverse) |
+| `GET` | `/{id}/impact` | `files` (required, repeatable) | Transitive impact analysis |
+| `GET` | `/{id}/cross-refs` | `symbol` (required) | Symbol cross-references |
+| `GET` | `/{id}/file-analysis` | `path` (required) | Detailed single-file analysis |
+| `POST` | `/{id}/dependency-graph` | `start_file`, `depth` | Dependency graph from a starting file |
+| `GET` | `/{id}/hotspots` | `top_n` | Risk/complexity hotspots |
+| `GET` | `/{id}/conventions` | `sample_size`, `path` | Coding conventions detection |
+| `POST` | `/{id}/explore` | `path`, `max_items`, `importance_threshold` | Hierarchical directory drill-down |
+| `POST` | `/{id}/security-scan` | `mode`, `path` | Security analysis |
+| `POST` | `/{id}/notify` | `files` | Notify about changed files |
+
+> All paths above are relative to `/api/v1/projects`. For example, `/{id}/map` means `/api/v1/projects/{project_id}/map`.
+
+```bash
+# Get repo map
+curl "http://localhost:8080/api/v1/projects/a1b2c3d4/map?max_tokens=6000"
+
+# Bootstrap orientation
+curl -X POST http://localhost:8080/api/v1/projects/a1b2c3d4/bootstrap \
+  -H "Content-Type: application/json" \
+  -d '{"task_hint": "fix auth bug", "max_tokens": 8000}'
+
+# Impact analysis
+curl "http://localhost:8080/api/v1/projects/a1b2c3d4/impact?files=src/auth.py&files=src/config.py"
+```
+
+### Search
+
+| Method | Path | Parameters | Description |
+|--------|------|-----------|-------------|
+| `POST` | `/{id}/search` | `query`, `top_k`, `file_filter` | Semantic search (vector + keyword RRF) |
+
+```bash
+curl -X POST http://localhost:8080/api/v1/projects/a1b2c3d4/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "authentication middleware", "top_k": 10}'
+```
+
+### Graph
+
+| Method | Path | Parameters | Description |
+|--------|------|-----------|-------------|
+| `POST` | `/{id}/graph/query` | `file`, `edge_type`, `direction`, `depth` | BFS traversal over dependency edges |
+| `POST` | `/{id}/graph/related` | `file`, `top_k` | Find structurally related files |
+| `GET` | `/{id}/graph/communities` | `min_community_size`, `max_communities` | Detect file communities |
+| `POST` | `/{id}/graph/context` | `files`, `depth`, `max_tokens`, `include_symbols` | Subgraph capsule with neighbors |
+
+```bash
+# BFS traversal
+curl -X POST http://localhost:8080/api/v1/projects/a1b2c3d4/graph/query \
+  -H "Content-Type: application/json" \
+  -d '{"file": "src/core/loop.py", "edge_type": "IMPORTS", "direction": "outbound", "depth": 2}'
+
+# Relevant context for a set of files
+curl -X POST http://localhost:8080/api/v1/projects/a1b2c3d4/graph/context \
+  -H "Content-Type: application/json" \
+  -d '{"files": ["src/auth.py"], "depth": 1, "max_tokens": 4000}'
+```
+
+### Learning
+
+| Method | Path | Parameters | Description |
+|--------|------|-----------|-------------|
+| `POST` | `/{id}/learnings` | `type`, `description`, `details`, `scope`, `confidence` | Record a learning |
+| `GET` | `/{id}/learnings/recall` | `query` (required), `scope`, `max_results` | Recall relevant learnings |
+| `POST` | `/{id}/learnings/{learning_id}/feedback` | `helpful` | Mark learning as helpful/unhelpful |
+| `GET` | `/{id}/learnings` | `status`, `type`, `scope` | List all learnings |
+
+> All paths above are relative to `/api/v1/projects`.
+
+```bash
+# Record a learning
+curl -X POST http://localhost:8080/api/v1/projects/a1b2c3d4/learnings \
+  -H "Content-Type: application/json" \
+  -d '{"type": "gotcha", "description": "Config module is lazy-loaded", "scope": "src/config/"}'
+
+# Recall learnings
+curl "http://localhost:8080/api/v1/projects/a1b2c3d4/learnings/recall?query=config+loading"
+```
+
+### LSP
+
+| Method | Path | Parameters | Description |
+|--------|------|-----------|-------------|
+| `POST` | `/{id}/lsp/definition` | `file`, `line`, `col` | Go-to-definition |
+| `POST` | `/{id}/lsp/references` | `file`, `line`, `col`, `include_declaration` | Find all references |
+| `POST` | `/{id}/lsp/hover` | `file`, `line`, `col` | Hover info (type + docs) |
+| `GET` | `/{id}/lsp/diagnostics` | `file` (required) | Errors and warnings |
+
+> All paths above are relative to `/api/v1/projects`.
+
+```bash
+# Go-to-definition
+curl -X POST http://localhost:8080/api/v1/projects/a1b2c3d4/lsp/definition \
+  -H "Content-Type: application/json" \
+  -d '{"file": "src/auth.py", "line": 42, "col": 10}'
+
+# Get diagnostics
+curl "http://localhost:8080/api/v1/projects/a1b2c3d4/lsp/diagnostics?file=src/auth.py"
+```
+
+---
+
+## Docker Deployment
+
+The `docker/code-intel/` directory contains a ready-to-use Docker setup.
+
+### Build and Run
+
+```bash
+cd docker/code-intel
+
+# Analyze the current directory
+docker-compose up --build
+
+# Analyze a specific project
+PROJECT_DIR=/path/to/repo docker-compose up --build
+
+# With authentication
+PROJECT_DIR=/path/to/repo ATTOCODE_API_KEY=secret docker-compose up --build
+```
+
+### Volume Mounts
+
+| Mount | Container Path | Mode | Purpose |
+|-------|---------------|------|---------|
+| `$PROJECT_DIR` (or `.`) | `/project` | Read-only | Source code to analyze |
+| `code-intel-cache` named volume | `/project/.attocode/cache` | Read-write | SQLite databases (graph.db, embeddings.db, memory.db) |
+
+The read-only mount ensures the server cannot modify your source code. The named volume persists cache data across container restarts.
+
+### Customizing the Port
+
+```bash
+ATTOCODE_PORT=9090 docker-compose up
+```
+
+---
+
+## OpenAPI Docs
+
+When the HTTP server is running, interactive API docs are available at:
+
+- **Swagger UI**: `http://localhost:8080/docs`
+- **ReDoc**: `http://localhost:8080/redoc`
+
+These are auto-generated from the route definitions and Pydantic models.
+
+---
+
+## Client Examples
+
+### Python (httpx)
+
+```python
+import httpx
+
+BASE = "http://localhost:8080/api/v1"
+HEADERS = {"Authorization": "Bearer my-key"}  # omit if no auth
+
+# Register project
+r = httpx.post(f"{BASE}/projects", json={"path": "/my/repo"}, headers=HEADERS)
+project_id = r.json()["id"]
+
+# Get repo map
+r = httpx.get(f"{BASE}/projects/{project_id}/map?max_tokens=6000", headers=HEADERS)
+print(r.json()["result"])
+
+# Semantic search
+r = httpx.post(
+    f"{BASE}/projects/{project_id}/search",
+    json={"query": "error handling", "top_k": 5},
+    headers=HEADERS,
+)
+print(r.json()["result"])
+```
+
+### JavaScript (fetch)
+
+```javascript
+const BASE = "http://localhost:8080/api/v1";
+const headers = {
+  "Content-Type": "application/json",
+  Authorization: "Bearer my-key", // omit if no auth
+};
+
+// Register project
+const res = await fetch(`${BASE}/projects`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({ path: "/my/repo" }),
+});
+const { id: projectId } = await res.json();
+
+// Get repo map
+const mapRes = await fetch(
+  `${BASE}/projects/${projectId}/map?max_tokens=6000`,
+  { headers }
+);
+const { result } = await mapRes.json();
+console.log(result);
+```
+
+### curl
+
+```bash
+# Full workflow: register + analyze
+PROJECT_ID=$(curl -s -X POST http://localhost:8080/api/v1/projects \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/my/repo"}' | jq -r '.id')
+
+curl "http://localhost:8080/api/v1/projects/$PROJECT_ID/summary"
+curl "http://localhost:8080/api/v1/projects/$PROJECT_ID/hotspots?top_n=10"
+```
+
+---
+
+## Differences from MCP
+
+| Aspect | MCP (stdio/SSE) | HTTP API |
+|--------|-----------------|----------|
+| Project selection | `ATTOCODE_PROJECT_DIR` env var at server start | Project IDs in URL path (`/projects/{id}/...`) |
+| Multi-project | One project per server instance | Multiple projects via `/projects` endpoint |
+| Authentication | None (local transport) | `Authorization: Bearer <key>` header |
+| Transport | stdio or SSE | HTTP REST (JSON) |
+| Auto-discovery | Registered in MCP client config | Swagger UI at `/docs`, ReDoc at `/redoc` |
+| Tool invocation | MCP `tools/call` protocol | Standard HTTP methods (GET/POST) |
+| Client compatibility | MCP-compatible clients only | Any HTTP client |
+
+The same 27 analysis tools are available through both transports. Choose MCP for AI coding assistants with built-in MCP support; choose HTTP for custom integrations, CI pipelines, or multi-project scenarios.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - Sessions & Persistence: sessions-guide.md
       - Context Engineering: context-engineering.md
       - AST & Code Intelligence: ast-and-code-intelligence.md
+      - Code Intel HTTP API: code-intel-http-api.md
       - Advanced Features: advanced-features.md
   - Guides:
       - Providers: PROVIDERS.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,11 @@ tree-sitter = [
 watch = ["watchfiles>=1.0"]
 semantic = ["sentence-transformers>=3.0"]
 semantic-nomic = ["sentence-transformers>=3.0", "einops"]
-code-intel = []  # mcp moved to required deps (entry point always registered)
+code-intel = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.34",
+    "python-multipart>=0.0.18",
+]
 docs = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",
@@ -113,7 +117,7 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks integration tests",
+    "integration: tests that use real services (not mocked)",
     "live_swarm: opt-in live backend swarm smoke tests",
 ]
 

--- a/src/attocode/code_intel/GUIDELINES.md
+++ b/src/attocode/code_intel/GUIDELINES.md
@@ -2,6 +2,11 @@
 
 > **27 tools** for deep codebase understanding. This guide helps AI agents use them
 > efficiently, minimizing token usage while maximizing insight.
+>
+> These tools are available via MCP (stdio/SSE) **and** as a REST API over HTTP.
+> The HTTP API supports multi-project management, bearer token auth, and interactive
+> docs at `/docs`. Start the HTTP server with:
+> `attocode code-intel serve --transport http --project /path/to/repo`
 
 ---
 

--- a/src/attocode/code_intel/api/__init__.py
+++ b/src/attocode/code_intel/api/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI HTTP API for Attocode Code Intelligence."""

--- a/src/attocode/code_intel/api/app.py
+++ b/src/attocode/code_intel/api/app.py
@@ -1,0 +1,64 @@
+"""FastAPI application factory for Attocode Code Intelligence."""
+
+from __future__ import annotations
+
+import logging
+
+from attocode.code_intel.config import CodeIntelConfig
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(config: CodeIntelConfig | None = None) -> "FastAPI":
+    """Create and configure the FastAPI application.
+
+    Args:
+        config: Service configuration. If None, reads from environment.
+    """
+    from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
+
+    from attocode.code_intel.api import deps
+    from attocode.code_intel.api.middleware import RequestLoggingMiddleware
+    from attocode.code_intel.api.routes import analysis, graph, health, learning, lsp, projects, search
+
+    if config is None:
+        config = CodeIntelConfig.from_env()
+
+    # Initialize DI
+    deps.configure(config)
+
+    app = FastAPI(
+        title="Attocode Code Intelligence",
+        description=(
+            "Code intelligence service with AST parsing, dependency graphs, "
+            "semantic search, impact analysis, and more. "
+            "All 27 MCP tools exposed as HTTP endpoints."
+        ),
+        version="0.1.0",
+        docs_url="/docs",
+        redoc_url="/redoc",
+    )
+
+    # Middleware — credentials=True is invalid with origins=["*"] per CORS spec
+    allow_creds = "*" not in config.cors_origins
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=config.cors_origins,
+        allow_credentials=allow_creds,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    app.add_middleware(RequestLoggingMiddleware)
+
+    # Routes
+    app.include_router(health.router)
+    app.include_router(projects.router)
+    app.include_router(analysis.router)
+    app.include_router(search.router)
+    app.include_router(graph.router)
+    app.include_router(learning.router)
+    app.include_router(lsp.router)
+
+    logger.info("FastAPI app created for %s", config.project_dir or "(no project)")
+    return app

--- a/src/attocode/code_intel/api/auth.py
+++ b/src/attocode/code_intel/api/auth.py
@@ -1,0 +1,23 @@
+"""API key authentication middleware."""
+
+from __future__ import annotations
+
+from fastapi import Header, HTTPException
+
+from attocode.code_intel.api.deps import get_config
+
+
+async def verify_api_key(authorization: str | None = Header(None)) -> None:
+    """Verify the API key if one is configured.
+
+    If ATTOCODE_API_KEY is not set, all requests are allowed (local mode).
+    """
+    config = get_config()
+    if not config.api_key:
+        return  # No auth configured = open access (local mode)
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+    # Accept "Bearer <key>" or raw key
+    token = authorization.removeprefix("Bearer ").strip()
+    if token != config.api_key:
+        raise HTTPException(status_code=401, detail="Invalid API key")

--- a/src/attocode/code_intel/api/deps.py
+++ b/src/attocode/code_intel/api/deps.py
@@ -1,0 +1,81 @@
+"""Dependency injection for the HTTP API."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+
+from attocode.code_intel.config import CodeIntelConfig
+from attocode.code_intel.service import CodeIntelService
+
+logger = logging.getLogger(__name__)
+
+# Module-level singletons set during app startup
+_config: CodeIntelConfig | None = None
+_services: dict[str, CodeIntelService] = {}
+_default_project_id: str = ""
+
+
+def configure(config: CodeIntelConfig) -> None:
+    """Initialize the DI container with a config. Called once at app startup."""
+    global _config, _default_project_id
+    if _config is not None:
+        logger.warning("configure() called more than once; overwriting previous config")
+    _config = config
+    if config.project_dir:
+        svc = CodeIntelService.get_instance(config.project_dir, config)
+        _default_project_id = "default"
+        _services["default"] = svc
+
+
+def reset() -> None:
+    """Reset all state. For test isolation only."""
+    global _config, _default_project_id
+    _config = None
+    _services.clear()
+    _default_project_id = ""
+
+
+def get_config() -> CodeIntelConfig:
+    """Return the active config."""
+    if _config is None:
+        return CodeIntelConfig.from_env()
+    return _config
+
+
+def get_service(project_id: str = "") -> CodeIntelService:
+    """Return the CodeIntelService for a project.
+
+    For Phase 1, only a single project is supported (the default).
+    Multi-project support comes in Phase 2.
+    """
+    pid = project_id or _default_project_id
+    if pid not in _services:
+        raise ValueError(f"Project '{pid}' not found. Register it first via POST /api/v1/projects")
+    return _services[pid]
+
+
+def get_service_or_404(project_id: str) -> CodeIntelService:
+    """Return the service for a project or raise HTTP 404."""
+    try:
+        return get_service(project_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail=f"Project '{project_id}' not found")
+
+
+def register_project(project_id: str, path: str, name: str = "") -> CodeIntelService:
+    """Register a new project and return its service instance."""
+    svc = CodeIntelService.get_instance(path, _config)
+    _services[project_id] = svc
+    return svc
+
+
+def list_projects() -> dict[str, CodeIntelService]:
+    """Return all registered projects."""
+    return dict(_services)
+
+
+def get_default_project_id() -> str:
+    """Return the default project ID."""
+    return _default_project_id

--- a/src/attocode/code_intel/api/middleware.py
+++ b/src/attocode/code_intel/api/middleware.py
@@ -1,0 +1,29 @@
+"""Middleware for CORS, request logging, and rate limiting."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Log request method, path, status, and duration."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        start = time.monotonic()
+        response = await call_next(request)
+        duration_ms = (time.monotonic() - start) * 1000
+        logger.info(
+            "%s %s → %d (%.1fms)",
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration_ms,
+        )
+        return response

--- a/src/attocode/code_intel/api/models.py
+++ b/src/attocode/code_intel/api/models.py
@@ -1,0 +1,146 @@
+"""Pydantic request/response models for the HTTP API."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+# ------------------------------------------------------------------
+# Common
+# ------------------------------------------------------------------
+
+
+class ErrorResponse(BaseModel):
+    detail: str
+
+
+# ------------------------------------------------------------------
+# Projects
+# ------------------------------------------------------------------
+
+
+class ProjectRegister(BaseModel):
+    path: str = Field(..., description="Local path to the project directory")
+    name: str = Field("", description="Optional human-readable name (auto-detected if empty)")
+
+
+class ProjectInfo(BaseModel):
+    id: str
+    name: str
+    path: str
+    status: str
+    file_count: int = 0
+    symbol_count: int = 0
+
+
+class ProjectListResponse(BaseModel):
+    projects: list[ProjectInfo]
+
+
+# ------------------------------------------------------------------
+# Analysis
+# ------------------------------------------------------------------
+
+
+class DependencyGraphRequest(BaseModel):
+    start_file: str
+    depth: int = 2
+
+
+class GraphQueryRequest(BaseModel):
+    file: str
+    edge_type: str = "IMPORTS"
+    direction: str = "outbound"
+    depth: int = 2
+
+
+class FindRelatedRequest(BaseModel):
+    file: str
+    top_k: int = 10
+
+
+class RelevantContextRequest(BaseModel):
+    files: list[str]
+    depth: int = 1
+    max_tokens: int = 4000
+    include_symbols: bool = True
+
+
+class BootstrapRequest(BaseModel):
+    task_hint: str = ""
+    max_tokens: int = 8000
+
+
+class ExploreRequest(BaseModel):
+    path: str = ""
+    max_items: int = 30
+    importance_threshold: float = 0.3
+
+
+class SecurityScanRequest(BaseModel):
+    mode: str = "full"
+    path: str = ""
+
+
+# ------------------------------------------------------------------
+# Search
+# ------------------------------------------------------------------
+
+
+class SemanticSearchRequest(BaseModel):
+    query: str
+    top_k: int = 10
+    file_filter: str = ""
+
+
+# ------------------------------------------------------------------
+# Learning
+# ------------------------------------------------------------------
+
+
+class RecordLearningRequest(BaseModel):
+    type: str
+    description: str
+    details: str = ""
+    scope: str = ""
+    confidence: float = 0.7
+
+
+class LearningFeedbackRequest(BaseModel):
+    helpful: bool
+
+
+# ------------------------------------------------------------------
+# LSP
+# ------------------------------------------------------------------
+
+
+class LSPPositionRequest(BaseModel):
+    file: str
+    line: int
+    col: int = 0
+
+
+class LSPReferencesRequest(BaseModel):
+    file: str
+    line: int
+    col: int = 0
+    include_declaration: bool = True
+
+
+# ------------------------------------------------------------------
+# Notifications
+# ------------------------------------------------------------------
+
+
+class NotifyFilesRequest(BaseModel):
+    files: list[str]
+
+
+# ------------------------------------------------------------------
+# Generic text result
+# ------------------------------------------------------------------
+
+
+class TextResult(BaseModel):
+    result: str

--- a/src/attocode/code_intel/api/routes/__init__.py
+++ b/src/attocode/code_intel/api/routes/__init__.py
@@ -1,0 +1,1 @@
+"""API route modules."""

--- a/src/attocode/code_intel/api/routes/analysis.py
+++ b/src/attocode/code_intel/api/routes/analysis.py
@@ -1,0 +1,133 @@
+"""Code analysis endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from attocode.code_intel.api.auth import verify_api_key
+from attocode.code_intel.api.deps import get_service_or_404
+from attocode.code_intel.api.models import (
+    BootstrapRequest,
+    DependencyGraphRequest,
+    ExploreRequest,
+    NotifyFilesRequest,
+    SecurityScanRequest,
+    TextResult,
+)
+
+router = APIRouter(
+    prefix="/api/v1/projects/{project_id}",
+    tags=["analysis"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+
+@router.get("/map", response_model=TextResult)
+async def repo_map(
+    project_id: str,
+    include_symbols: bool = True,
+    max_tokens: int = 6000,
+) -> TextResult:
+    """Get token-budgeted repository map."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.repo_map(include_symbols=include_symbols, max_tokens=max_tokens))
+
+
+@router.get("/summary", response_model=TextResult)
+async def project_summary(project_id: str, max_tokens: int = 4000) -> TextResult:
+    """Get high-level project overview."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.project_summary(max_tokens=max_tokens))
+
+
+@router.post("/bootstrap", response_model=TextResult)
+async def bootstrap(project_id: str, req: BootstrapRequest) -> TextResult:
+    """All-in-one codebase orientation."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.bootstrap(task_hint=req.task_hint, max_tokens=req.max_tokens))
+
+
+@router.get("/symbols", response_model=TextResult)
+async def symbols(project_id: str, path: str = Query(...)) -> TextResult:
+    """List symbols in a file."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.symbols(path))
+
+
+@router.get("/search-symbols", response_model=TextResult)
+async def search_symbols(project_id: str, name: str = Query(...)) -> TextResult:
+    """Fuzzy symbol search across project."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.search_symbols(name))
+
+
+@router.get("/dependencies", response_model=TextResult)
+async def dependencies(project_id: str, path: str = Query(...)) -> TextResult:
+    """File dependencies (forward/reverse)."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.dependencies(path))
+
+
+@router.get("/impact", response_model=TextResult)
+async def impact_analysis(project_id: str, files: list[str] = Query(..., description="Changed file paths")) -> TextResult:
+    """Transitive impact analysis."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.impact_analysis(files))
+
+
+@router.get("/cross-refs", response_model=TextResult)
+async def cross_references(project_id: str, symbol: str = Query(...)) -> TextResult:
+    """Symbol cross-references."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.cross_references(symbol))
+
+
+@router.get("/file-analysis", response_model=TextResult)
+async def file_analysis(project_id: str, path: str = Query(...)) -> TextResult:
+    """Detailed single-file analysis."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.file_analysis(path))
+
+
+@router.post("/dependency-graph", response_model=TextResult)
+async def dependency_graph(project_id: str, req: DependencyGraphRequest) -> TextResult:
+    """Dependency graph from a starting file."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.dependency_graph(req.start_file, depth=req.depth))
+
+
+@router.get("/hotspots", response_model=TextResult)
+async def hotspots(project_id: str, top_n: int = 15) -> TextResult:
+    """Risk/complexity analysis."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.hotspots(top_n=top_n))
+
+
+@router.get("/conventions", response_model=TextResult)
+async def conventions(project_id: str, sample_size: int = 50, path: str = "") -> TextResult:
+    """Coding conventions."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.conventions(sample_size=sample_size, path=path))
+
+
+@router.post("/explore", response_model=TextResult)
+async def explore(project_id: str, req: ExploreRequest) -> TextResult:
+    """Hierarchical drill-down navigation."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.explore_codebase(
+        path=req.path, max_items=req.max_items, importance_threshold=req.importance_threshold,
+    ))
+
+
+@router.post("/security-scan", response_model=TextResult)
+async def security_scan(project_id: str, req: SecurityScanRequest) -> TextResult:
+    """Security analysis."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.security_scan(mode=req.mode, path=req.path))
+
+
+@router.post("/notify", response_model=TextResult)
+async def notify_files(project_id: str, req: NotifyFilesRequest) -> TextResult:
+    """Notify about changed files."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.notify_file_changed(req.files))

--- a/src/attocode/code_intel/api/routes/graph.py
+++ b/src/attocode/code_intel/api/routes/graph.py
@@ -1,0 +1,59 @@
+"""Graph query endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from attocode.code_intel.api.auth import verify_api_key
+from attocode.code_intel.api.deps import get_service_or_404
+from attocode.code_intel.api.models import (
+    FindRelatedRequest,
+    GraphQueryRequest,
+    RelevantContextRequest,
+    TextResult,
+)
+
+router = APIRouter(
+    prefix="/api/v1/projects/{project_id}/graph",
+    tags=["graph"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+
+@router.post("/query", response_model=TextResult)
+async def graph_query(project_id: str, req: GraphQueryRequest) -> TextResult:
+    """BFS traversal over dependency edges."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.graph_query(
+        file=req.file, edge_type=req.edge_type, direction=req.direction, depth=req.depth,
+    ))
+
+
+@router.post("/related", response_model=TextResult)
+async def find_related(project_id: str, req: FindRelatedRequest) -> TextResult:
+    """Find structurally related files."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.find_related(file=req.file, top_k=req.top_k))
+
+
+@router.get("/communities", response_model=TextResult)
+async def community_detection(
+    project_id: str,
+    min_community_size: int = 3,
+    max_communities: int = 20,
+) -> TextResult:
+    """Detect file communities."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.community_detection(
+        min_community_size=min_community_size, max_communities=max_communities,
+    ))
+
+
+@router.post("/context", response_model=TextResult)
+async def relevant_context(project_id: str, req: RelevantContextRequest) -> TextResult:
+    """Get subgraph capsule for files with neighbors."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.relevant_context(
+        files=req.files, depth=req.depth, max_tokens=req.max_tokens,
+        include_symbols=req.include_symbols,
+    ))

--- a/src/attocode/code_intel/api/routes/health.py
+++ b/src/attocode/code_intel/api/routes/health.py
@@ -1,0 +1,24 @@
+"""Health check endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+async def health() -> dict:
+    """Basic health check."""
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def ready() -> dict:
+    """Readiness probe — checks that at least one project is registered."""
+    from attocode.code_intel.api.deps import list_projects
+
+    projects = list_projects()
+    if not projects:
+        return {"status": "not_ready", "reason": "no projects registered"}
+    return {"status": "ready", "projects": len(projects)}

--- a/src/attocode/code_intel/api/routes/learning.py
+++ b/src/attocode/code_intel/api/routes/learning.py
@@ -1,0 +1,60 @@
+"""Learning/memory endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from attocode.code_intel.api.auth import verify_api_key
+from attocode.code_intel.api.deps import get_service_or_404
+from attocode.code_intel.api.models import (
+    LearningFeedbackRequest,
+    RecordLearningRequest,
+    TextResult,
+)
+
+router = APIRouter(
+    prefix="/api/v1",
+    tags=["learning"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+
+@router.post("/projects/{project_id}/learnings", response_model=TextResult)
+async def record_learning(project_id: str, req: RecordLearningRequest) -> TextResult:
+    """Record a new learning."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.record_learning(
+        type=req.type, description=req.description,
+        details=req.details, scope=req.scope, confidence=req.confidence,
+    ))
+
+
+@router.get("/projects/{project_id}/learnings/recall", response_model=TextResult)
+async def recall(
+    project_id: str,
+    query: str = Query(...),
+    scope: str = "",
+    max_results: int = 10,
+) -> TextResult:
+    """Recall relevant learnings."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.recall(query=query, scope=scope, max_results=max_results))
+
+
+@router.post("/projects/{project_id}/learnings/{learning_id}/feedback", response_model=TextResult)
+async def learning_feedback(project_id: str, learning_id: int, req: LearningFeedbackRequest) -> TextResult:
+    """Mark a learning as helpful/unhelpful."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.learning_feedback(learning_id=learning_id, helpful=req.helpful))
+
+
+@router.get("/projects/{project_id}/learnings", response_model=TextResult)
+async def list_learnings(
+    project_id: str,
+    status: str = "active",
+    type: str = "",
+    scope: str = "",
+) -> TextResult:
+    """List all learnings."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.list_learnings(status=status, type=type, scope=scope))

--- a/src/attocode/code_intel/api/routes/lsp.py
+++ b/src/attocode/code_intel/api/routes/lsp.py
@@ -1,0 +1,46 @@
+"""LSP proxy endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from attocode.code_intel.api.auth import verify_api_key
+from attocode.code_intel.api.deps import get_service_or_404
+from attocode.code_intel.api.models import LSPPositionRequest, LSPReferencesRequest, TextResult
+
+router = APIRouter(
+    prefix="/api/v1/projects/{project_id}/lsp",
+    tags=["lsp"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+
+@router.post("/definition", response_model=TextResult)
+async def lsp_definition(project_id: str, req: LSPPositionRequest) -> TextResult:
+    """Go-to-definition via LSP."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=await svc.lsp_definition(file=req.file, line=req.line, col=req.col))
+
+
+@router.post("/references", response_model=TextResult)
+async def lsp_references(project_id: str, req: LSPReferencesRequest) -> TextResult:
+    """Find references via LSP."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=await svc.lsp_references(
+        file=req.file, line=req.line, col=req.col,
+        include_declaration=req.include_declaration,
+    ))
+
+
+@router.post("/hover", response_model=TextResult)
+async def lsp_hover(project_id: str, req: LSPPositionRequest) -> TextResult:
+    """Hover info via LSP."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=await svc.lsp_hover(file=req.file, line=req.line, col=req.col))
+
+
+@router.get("/diagnostics", response_model=TextResult)
+async def lsp_diagnostics(project_id: str, file: str = Query(...)) -> TextResult:
+    """Diagnostics from LSP."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.lsp_diagnostics(file=file))

--- a/src/attocode/code_intel/api/routes/projects.py
+++ b/src/attocode/code_intel/api/routes/projects.py
@@ -1,0 +1,101 @@
+"""Project management endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from attocode.code_intel.api.auth import verify_api_key
+from attocode.code_intel.api.deps import (
+    get_config,
+    get_service_or_404,
+    list_projects,
+    register_project,
+)
+from attocode.code_intel.api.models import ProjectInfo, ProjectListResponse, ProjectRegister, TextResult
+
+router = APIRouter(prefix="/api/v1/projects", tags=["projects"], dependencies=[Depends(verify_api_key)])
+
+# Serializes reindex operations so concurrent requests don't corrupt state
+_reindex_lock = asyncio.Lock()
+
+# System directories that should never be registered as projects
+_BLOCKED_PREFIXES = ("/etc", "/var", "/usr", "/sys", "/proc", "/dev")
+
+
+@router.post("", response_model=ProjectInfo)
+async def create_project(req: ProjectRegister) -> ProjectInfo:
+    """Register a project (local path)."""
+    abs_path = os.path.abspath(req.path)
+    if not os.path.isdir(abs_path):
+        raise HTTPException(status_code=400, detail=f"Directory not found: {abs_path}")
+
+    # Block system directories when API key auth is active
+    config = get_config()
+    if config.api_key:
+        for prefix in _BLOCKED_PREFIXES:
+            if abs_path == prefix or abs_path.startswith(prefix + "/"):
+                raise HTTPException(status_code=400, detail=f"Cannot register system directory: {abs_path}")
+
+    # Idempotent: return existing project if same path already registered
+    for pid, svc in list_projects().items():
+        if svc.project_dir == abs_path:
+            return ProjectInfo(
+                id=pid,
+                name=req.name or os.path.basename(abs_path),
+                path=abs_path,
+                status="ready",
+            )
+
+    project_id = str(uuid.uuid4())[:8]
+    name = req.name or os.path.basename(abs_path)
+    register_project(project_id, abs_path, name)
+
+    return ProjectInfo(
+        id=project_id,
+        name=name,
+        path=abs_path,
+        status="ready",
+    )
+
+
+@router.get("", response_model=ProjectListResponse)
+async def get_projects() -> ProjectListResponse:
+    """List all registered projects."""
+    projects = list_projects()
+    items = []
+    for pid, svc in projects.items():
+        items.append(ProjectInfo(
+            id=pid,
+            name=os.path.basename(svc.project_dir),
+            path=svc.project_dir,
+            status="ready",
+        ))
+    return ProjectListResponse(projects=items)
+
+
+@router.get("/{project_id}", response_model=ProjectInfo)
+async def get_project(project_id: str) -> ProjectInfo:
+    """Get project details."""
+    svc = get_service_or_404(project_id)
+    return ProjectInfo(
+        id=project_id,
+        name=os.path.basename(svc.project_dir),
+        path=svc.project_dir,
+        status="ready",
+    )
+
+
+@router.post("/{project_id}/reindex", response_model=TextResult)
+async def reindex_project(project_id: str) -> TextResult:
+    """Trigger a full reindex of the project."""
+    svc = get_service_or_404(project_id)
+    async with _reindex_lock:
+        svc._ast_service = None
+        svc._context_mgr = None
+        svc._get_ast_service()
+        svc._get_context_mgr()
+    return TextResult(result="Reindex complete")

--- a/src/attocode/code_intel/api/routes/search.py
+++ b/src/attocode/code_intel/api/routes/search.py
@@ -1,0 +1,24 @@
+"""Search endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from attocode.code_intel.api.auth import verify_api_key
+from attocode.code_intel.api.deps import get_service_or_404
+from attocode.code_intel.api.models import SemanticSearchRequest, TextResult
+
+router = APIRouter(
+    prefix="/api/v1/projects/{project_id}",
+    tags=["search"],
+    dependencies=[Depends(verify_api_key)],
+)
+
+
+@router.post("/search", response_model=TextResult)
+async def semantic_search(project_id: str, req: SemanticSearchRequest) -> TextResult:
+    """Semantic search (vector + keyword RRF)."""
+    svc = get_service_or_404(project_id)
+    return TextResult(result=svc.semantic_search(
+        query=req.query, top_k=req.top_k, file_filter=req.file_filter,
+    ))

--- a/src/attocode/code_intel/cli.py
+++ b/src/attocode/code_intel/cli.py
@@ -80,9 +80,9 @@ def _print_help() -> None:
         "  --hooks             Also install PostToolUse hooks (Claude Code)\n"
         "\n"
         "Serve options:\n"
-        "  --transport <type>  Transport protocol: stdio (default) or sse\n"
-        "  --host <addr>       SSE host address (default: 127.0.0.1)\n"
-        "  --port <num>        SSE port number (default: 8080)\n"
+        "  --transport <type>  Transport protocol: stdio (default), sse, or http\n"
+        "  --host <addr>       Server host address (default: 127.0.0.1)\n"
+        "  --port <num>        Server port number (default: 8080)\n"
         "\n"
         "Notify options:\n"
         "  --file <path>       File that changed (repeatable)\n"
@@ -198,10 +198,37 @@ def _cmd_serve(args: list[str], *, debug: bool = False) -> None:
 
     abs_dir = os.path.abspath(project_dir)
     print(f"Starting attocode-code-intel server for {abs_dir} (transport={transport})", file=sys.stderr)
-    if transport == "sse":
+    if transport == "http":
+        _serve_http(abs_dir, host=host, port=port, debug=debug)
+    elif transport == "sse":
         mcp.run(transport="sse", host=host, port=port)
     else:
         mcp.run(transport="stdio")
+
+
+def _serve_http(project_dir: str, *, host: str, port: int, debug: bool) -> None:
+    """Start the FastAPI HTTP server."""
+    try:
+        import uvicorn
+    except ImportError:
+        print(
+            "Error: uvicorn not installed. Install with: pip install 'attocode[code-intel]'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    from attocode.code_intel.api.app import create_app
+    from attocode.code_intel.config import CodeIntelConfig
+
+    config = CodeIntelConfig(
+        project_dir=project_dir,
+        host=host,
+        port=port,
+        api_key=os.environ.get("ATTOCODE_API_KEY", ""),
+        log_level="debug" if debug else "info",
+    )
+    app = create_app(config)
+    uvicorn.run(app, host=host, port=port, log_level=config.log_level)
 
 
 def _cmd_status() -> None:

--- a/src/attocode/code_intel/config.py
+++ b/src/attocode/code_intel/config.py
@@ -1,0 +1,30 @@
+"""Configuration for the code intelligence service."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class CodeIntelConfig:
+    """Configuration for the CodeIntelService."""
+
+    project_dir: str = ""
+    host: str = "127.0.0.1"
+    port: int = 8080
+    api_key: str = ""
+    cors_origins: list[str] = field(default_factory=lambda: ["*"])
+    log_level: str = "info"
+
+    @classmethod
+    def from_env(cls) -> CodeIntelConfig:
+        """Build config from environment variables."""
+        return cls(
+            project_dir=os.environ.get("ATTOCODE_PROJECT_DIR", ""),
+            host=os.environ.get("ATTOCODE_HOST", "127.0.0.1"),
+            port=int(os.environ.get("ATTOCODE_PORT", "8080")),
+            api_key=os.environ.get("ATTOCODE_API_KEY", ""),
+            cors_origins=os.environ.get("ATTOCODE_CORS_ORIGINS", "*").split(","),
+            log_level=os.environ.get("ATTOCODE_LOG_LEVEL", "info"),
+        )

--- a/src/attocode/code_intel/server.py
+++ b/src/attocode/code_intel/server.py
@@ -1999,7 +1999,7 @@ async def lsp_hover(file: str, line: int, col: int = 0) -> str:
 
 
 @mcp.tool()
-async def lsp_diagnostics(file: str) -> str:
+def lsp_diagnostics(file: str) -> str:
     """Get errors and warnings from the language server for a file.
 
     Args:
@@ -2614,7 +2614,11 @@ def main() -> None:
 
     logger.info("Starting attocode-code-intel for %s (transport=%s)", project_dir, transport)
     try:
-        if transport == "sse":
+        if transport == "http":
+            from attocode.code_intel.cli import _serve_http
+
+            _serve_http(project_dir, host=host, port=port, debug=False)
+        elif transport == "sse":
             mcp.run(transport="sse", host=host, port=port)
         else:
             mcp.run(transport="stdio")

--- a/src/attocode/code_intel/service.py
+++ b/src/attocode/code_intel/service.py
@@ -1,0 +1,1075 @@
+"""Unified code intelligence service.
+
+Used by both the MCP server (server.py) and HTTP API (api/app.py) as a
+single source of truth for all 27 tool operations.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections import Counter, deque
+from pathlib import Path
+
+from attocode.code_intel.config import CodeIntelConfig
+
+logger = logging.getLogger(__name__)
+
+# Registry of service instances by project_dir
+_instances: dict[str, CodeIntelService] = {}
+_instances_lock = threading.Lock()
+
+
+class CodeIntelService:
+    """Unified code intelligence service wrapping all tool operations."""
+
+    def __init__(self, project_dir: str, config: CodeIntelConfig | None = None) -> None:
+        self._project_dir = os.path.abspath(project_dir)
+        self._config = config or CodeIntelConfig(project_dir=self._project_dir)
+
+        # Lazy singletons
+        self._init_lock = threading.Lock()
+        self._ast_service = None
+        self._context_mgr = None
+        self._code_analyzer = None
+        self._lsp_manager = None
+        self._explorer = None
+        self._security_scanner = None
+        self._semantic_search = None
+        self._memory_store = None
+
+    @classmethod
+    def get_instance(cls, project_dir: str, config: CodeIntelConfig | None = None) -> CodeIntelService:
+        """Get or create a service instance for the given project directory."""
+        abs_dir = os.path.abspath(project_dir)
+        if abs_dir not in _instances:
+            with _instances_lock:
+                if abs_dir not in _instances:
+                    _instances[abs_dir] = cls(abs_dir, config)
+        return _instances[abs_dir]
+
+    @classmethod
+    def _reset_instances(cls) -> None:
+        """Clear all cached instances. For test isolation only."""
+        with _instances_lock:
+            _instances.clear()
+
+    @property
+    def project_dir(self) -> str:
+        return self._project_dir
+
+    # ------------------------------------------------------------------
+    # Lazy initializers
+    # ------------------------------------------------------------------
+
+    def _get_ast_service(self):
+        if self._ast_service is None:
+            with self._init_lock:
+                if self._ast_service is None:
+                    from attocode.integrations.context.ast_service import ASTService
+
+                    svc = ASTService.get_instance(self._project_dir)
+                    if not svc.initialized:
+                        logger.info("Initializing ASTService for %s...", self._project_dir)
+                        svc.initialize()
+                        logger.info(
+                            "ASTService ready: %d files indexed",
+                            len(svc._ast_cache),
+                        )
+                    self._ast_service = svc
+        return self._ast_service
+
+    def _get_context_mgr(self):
+        if self._context_mgr is None:
+            with self._init_lock:
+                if self._context_mgr is None:
+                    from attocode.integrations.context.codebase_context import CodebaseContextManager
+
+                    mgr = CodebaseContextManager(root_dir=self._project_dir)
+                    mgr.discover_files()
+                    self._context_mgr = mgr
+        return self._context_mgr
+
+    def _get_code_analyzer(self):
+        if self._code_analyzer is None:
+            with self._init_lock:
+                if self._code_analyzer is None:
+                    from attocode.integrations.context.code_analyzer import CodeAnalyzer
+
+                    self._code_analyzer = CodeAnalyzer()
+        return self._code_analyzer
+
+    def _get_lsp_manager(self):
+        if self._lsp_manager is None:
+            with self._init_lock:
+                if self._lsp_manager is None:
+                    from attocode.integrations.lsp.client import LSPConfig, LSPManager
+
+                    config = LSPConfig(
+                        enabled=True,
+                        root_uri=f"file://{self._project_dir}",
+                    )
+                    self._lsp_manager = LSPManager(config=config)
+        return self._lsp_manager
+
+    def _get_explorer(self):
+        if self._explorer is None:
+            # Initialize deps outside the lock to avoid reentrant deadlock
+            ctx = self._get_context_mgr()
+            ast_svc = self._get_ast_service()
+            with self._init_lock:
+                if self._explorer is None:
+                    from attocode.integrations.context.hierarchical_explorer import HierarchicalExplorer
+
+                    self._explorer = HierarchicalExplorer(ctx, ast_service=ast_svc)
+        return self._explorer
+
+    def _get_security_scanner(self):
+        if self._security_scanner is None:
+            with self._init_lock:
+                if self._security_scanner is None:
+                    from attocode.integrations.security.scanner import SecurityScanner
+
+                    self._security_scanner = SecurityScanner(root_dir=self._project_dir)
+        return self._security_scanner
+
+    def _get_semantic_search(self):
+        if self._semantic_search is None:
+            with self._init_lock:
+                if self._semantic_search is None:
+                    from attocode.integrations.context.semantic_search import SemanticSearchManager
+
+                    self._semantic_search = SemanticSearchManager(root_dir=self._project_dir)
+        return self._semantic_search
+
+    def _get_memory_store(self):
+        if self._memory_store is None:
+            with self._init_lock:
+                if self._memory_store is None:
+                    from attocode.integrations.context.memory_store import MemoryStore
+
+                    self._memory_store = MemoryStore(self._project_dir)
+        return self._memory_store
+
+    # ------------------------------------------------------------------
+    # Tool operations — same signatures as server.py tool functions
+    # ------------------------------------------------------------------
+
+    def repo_map(self, *, include_symbols: bool = True, max_tokens: int = 6000) -> str:
+        ctx = self._get_context_mgr()
+        repo = ctx.get_repo_map(include_symbols=include_symbols, max_tokens=max_tokens)
+        lines = [repo.tree, ""]
+        lines.append(
+            f"({repo.total_files} files, {repo.total_lines:,} lines, "
+            f"{len(repo.languages)} languages)"
+        )
+        return "\n".join(lines)
+
+    def symbols(self, path: str) -> str:
+        svc = self._get_ast_service()
+        locs = svc.get_file_symbols(path)
+        if not locs:
+            return f"No symbols found in {path}"
+        lines = [f"Symbols in {path}:"]
+        for loc in sorted(locs, key=lambda s: s.start_line):
+            lines.append(f"  {loc.kind} {loc.qualified_name}  (L{loc.start_line}-{loc.end_line})")
+        return "\n".join(lines)
+
+    def search_symbols(self, name: str) -> str:
+        svc = self._get_ast_service()
+        locs = svc.find_symbol(name)
+        if not locs:
+            return f"No definitions found for '{name}'"
+        lines = [f"Definitions of '{name}':"]
+        for loc in locs:
+            lines.append(
+                f"  {loc.kind} {loc.qualified_name}  "
+                f"in {loc.file_path}:{loc.start_line}-{loc.end_line}"
+            )
+        return "\n".join(lines)
+
+    def dependencies(self, path: str) -> str:
+        svc = self._get_ast_service()
+        deps = svc.get_dependencies(path)
+        dependents = svc.get_dependents(path)
+        lines = [f"Dependencies for {path}:"]
+        lines.append(f"\n  Imports from ({len(deps)} files):")
+        if deps:
+            for d in sorted(deps):
+                lines.append(f"    {d}")
+        else:
+            lines.append("    (none)")
+        lines.append(f"\n  Imported by ({len(dependents)} files):")
+        if dependents:
+            for d in sorted(dependents):
+                lines.append(f"    {d}")
+        else:
+            lines.append("    (none)")
+        return "\n".join(lines)
+
+    def impact_analysis(self, changed_files: list[str]) -> str:
+        svc = self._get_ast_service()
+        impacted = svc.get_impact(changed_files)
+        if not impacted:
+            return f"No other files are impacted by changes to {', '.join(changed_files)}"
+        lines = [f"Impact analysis for {', '.join(changed_files)}:"]
+        lines.append(f"\n  {len(impacted)} files affected:")
+        for f in sorted(impacted):
+            lines.append(f"    {f}")
+        return "\n".join(lines)
+
+    def cross_references(self, symbol_name: str) -> str:
+        svc = self._get_ast_service()
+        definitions = svc.find_symbol(symbol_name)
+        references = svc.get_callers(symbol_name)
+        lines = [f"Cross-references for '{symbol_name}':"]
+        lines.append(f"\n  Definitions ({len(definitions)}):")
+        if definitions:
+            for loc in definitions:
+                lines.append(
+                    f"    {loc.kind} {loc.qualified_name}  "
+                    f"in {loc.file_path}:{loc.start_line}"
+                )
+        else:
+            lines.append("    (none found)")
+        lines.append(f"\n  References ({len(references)}):")
+        if references:
+            for ref in references[:50]:
+                lines.append(f"    [{ref.ref_kind}] {ref.file_path}:{ref.line}")
+            if len(references) > 50:
+                lines.append(f"    ... and {len(references) - 50} more")
+        else:
+            lines.append("    (none found)")
+        return "\n".join(lines)
+
+    def file_analysis(self, path: str) -> str:
+        analyzer = self._get_code_analyzer()
+        if not os.path.isabs(path):
+            path = os.path.join(self._project_dir, path)
+        result = analyzer.analyze_file(path)
+        lines = [f"Analysis of {result.path}:"]
+        lines.append(f"  Language: {result.language}")
+        lines.append(f"  Lines: {result.line_count}")
+        if result.imports:
+            lines.append(f"\n  Imports ({len(result.imports)}):")
+            for imp in result.imports:
+                lines.append(f"    {imp}")
+        if result.exports:
+            lines.append(f"\n  Exports ({len(result.exports)}):")
+            for exp in result.exports:
+                lines.append(f"    {exp}")
+        if result.chunks:
+            lines.append(f"\n  Code chunks ({len(result.chunks)}):")
+            for chunk in result.chunks:
+                sig = f" — {chunk.signature}" if chunk.signature else ""
+                parent = f" (in {chunk.parent})" if chunk.parent else ""
+                lines.append(
+                    f"    {chunk.kind} {chunk.name}{parent}{sig}  "
+                    f"L{chunk.start_line}-{chunk.end_line}"
+                )
+        return "\n".join(lines)
+
+    def dependency_graph(self, start_file: str, depth: int = 2) -> str:
+        svc = self._get_ast_service()
+        rel = svc._to_rel(start_file)
+        lines = [f"Dependency graph for {rel} (depth={depth}):"]
+
+        # Forward BFS
+        lines.append("\n  Imports (forward):")
+        visited_fwd: set[str] = set()
+        queue_fwd: deque[tuple[str, int]] = deque([(rel, 0)])
+        while queue_fwd:
+            current, d = queue_fwd.popleft()
+            if current in visited_fwd or d > depth:
+                continue
+            visited_fwd.add(current)
+            indent = "    " + "  " * d
+            if d > 0:
+                lines.append(f"{indent}{current}")
+            deps = svc.get_dependencies(current)
+            for dep in sorted(deps):
+                if dep not in visited_fwd:
+                    queue_fwd.append((dep, d + 1))
+        if len(visited_fwd) <= 1:
+            lines.append("    (none)")
+
+        # Reverse BFS
+        lines.append("\n  Imported by (reverse):")
+        visited_rev: set[str] = set()
+        queue_rev: deque[tuple[str, int]] = deque([(rel, 0)])
+        while queue_rev:
+            current, d = queue_rev.popleft()
+            if current in visited_rev or d > depth:
+                continue
+            visited_rev.add(current)
+            indent = "    " + "  " * d
+            if d > 0:
+                lines.append(f"{indent}{current}")
+            dependents = svc.get_dependents(current)
+            for dep in sorted(dependents):
+                if dep not in visited_rev:
+                    queue_rev.append((dep, d + 1))
+        if len(visited_rev) <= 1:
+            lines.append("    (none)")
+
+        return "\n".join(lines)
+
+    def graph_query(
+        self,
+        file: str,
+        edge_type: str = "IMPORTS",
+        direction: str = "outbound",
+        depth: int = 2,
+    ) -> str:
+        valid_edge_types = {"IMPORTS", "IMPORTED_BY"}
+        valid_directions = {"outbound", "inbound"}
+        if edge_type not in valid_edge_types:
+            return f"Error: invalid edge_type '{edge_type}'. Must be one of: {', '.join(sorted(valid_edge_types))}"
+        if direction not in valid_directions:
+            return f"Error: invalid direction '{direction}'. Must be one of: {', '.join(sorted(valid_directions))}"
+
+        svc = self._get_ast_service()
+        rel = svc._to_rel(file)
+        depth = min(depth, 5)
+        use_dependents = edge_type == "IMPORTED_BY" or direction == "inbound"
+
+        visited: set[str] = set()
+        queue: deque[tuple[str, int]] = deque([(rel, 0)])
+        result_by_depth: dict[int, list[str]] = {}
+
+        while queue:
+            current, d = queue.popleft()
+            if current in visited or d > depth:
+                continue
+            visited.add(current)
+            if d > 0:
+                result_by_depth.setdefault(d, []).append(current)
+            neighbors = svc.get_dependents(current) if use_dependents else svc.get_dependencies(current)
+            for n in sorted(neighbors):
+                if n not in visited:
+                    queue.append((n, d + 1))
+
+        label = "importers" if use_dependents else "imports"
+        lines = [f"Graph query: {rel} ({label}, depth={depth})"]
+        if not result_by_depth:
+            lines.append("  (no results)")
+        else:
+            for d in sorted(result_by_depth):
+                lines.append(f"\n  Hop {d}:")
+                for f_path in result_by_depth[d]:
+                    lines.append(f"    {'>' * d} {f_path}")
+        lines.append(f"\nTotal: {len(visited) - 1} files reachable")
+        return "\n".join(lines)
+
+    def find_related(self, file: str, top_k: int = 10) -> str:
+        svc = self._get_ast_service()
+        rel = svc._to_rel(file)
+        idx = svc._index
+
+        if rel not in idx.file_symbols and rel not in idx.file_dependencies:
+            return f"Error: file '{rel}' not found in the project index."
+
+        neighbors: Counter[str] = Counter()
+        direct_deps = idx.get_dependencies(rel)
+        direct_importers = idx.get_dependents(rel)
+        all_direct = direct_deps | direct_importers
+
+        for n in all_direct:
+            neighbors[n] += 3
+        for n in all_direct:
+            for nn in idx.get_dependencies(n):
+                if nn != rel:
+                    neighbors[nn] += 1
+            for nn in idx.get_dependents(n):
+                if nn != rel:
+                    neighbors[nn] += 1
+
+        my_deps = idx.get_dependencies(rel)
+        if my_deps:
+            candidate_files = set(neighbors.keys())
+            for other_file in candidate_files:
+                other_deps_set = idx.file_dependencies.get(other_file, set())
+                if not other_deps_set:
+                    continue
+                overlap = len(my_deps & other_deps_set)
+                if overlap > 0:
+                    union = len(my_deps | other_deps_set)
+                    jaccard = overlap / union if union else 0
+                    neighbors[other_file] += round(jaccard * 5)
+
+        top = neighbors.most_common(top_k)
+        lines = [f"Files related to {rel}:"]
+        if not top:
+            lines.append("  (no related files found)")
+        else:
+            for path, score in top:
+                rel_type = "direct" if path in all_direct else "transitive"
+                lines.append(f"  [{score:>3}] {path}  ({rel_type})")
+        return "\n".join(lines)
+
+    def community_detection(self, min_community_size: int = 3, max_communities: int = 20) -> str:
+        svc = self._get_ast_service()
+        idx = svc._index
+
+        all_files: set[str] = set()
+        all_files.update(idx.file_dependencies.keys())
+        all_files.update(idx.file_dependents.keys())
+        all_files.update(f for deps in idx.file_dependencies.values() for f in deps)
+
+        adj: dict[str, set[str]] = {f: set() for f in all_files}
+        for src, deps in idx.file_dependencies.items():
+            for tgt in deps:
+                adj.setdefault(src, set()).add(tgt)
+                adj.setdefault(tgt, set()).add(src)
+
+        visited: set[str] = set()
+        communities: list[set[str]] = []
+        for start in all_files:
+            if start in visited:
+                continue
+            component: set[str] = set()
+            bfs_queue: deque[str] = deque([start])
+            while bfs_queue:
+                node = bfs_queue.popleft()
+                if node in visited:
+                    continue
+                visited.add(node)
+                component.add(node)
+                for neighbor in adj.get(node, set()):
+                    if neighbor not in visited:
+                        bfs_queue.append(neighbor)
+            communities.append(component)
+
+        communities.sort(key=len, reverse=True)
+        communities = [c for c in communities if len(c) >= min_community_size][:max_communities]
+
+        lines = [f"Community detection: {len(communities)} communities (min size {min_community_size})"]
+        for i, community in enumerate(communities, 1):
+            lines.append(f"\n  Community {i} ({len(community)} files):")
+            hub = max(community, key=lambda f: len(adj.get(f, set())))
+            hub_degree = len(adj.get(hub, set()))
+            lines.append(f"    Hub: {hub} (degree {hub_degree})")
+            sample = sorted(community)[:5]
+            for f in sample:
+                degree = len(adj.get(f, set()))
+                lines.append(f"    - {f} (degree {degree})")
+            if len(community) > 5:
+                lines.append(f"    ... and {len(community) - 5} more")
+        return "\n".join(lines)
+
+    def relevant_context(
+        self,
+        files: list[str],
+        depth: int = 1,
+        max_tokens: int = 4000,
+        include_symbols: bool = True,
+    ) -> str:
+        svc = self._get_ast_service()
+        ctx = self._get_context_mgr()
+        ast_cache = svc._ast_cache
+        all_files = {fi.relative_path: fi for fi in ctx._files}
+
+        depth = min(depth, 2)
+        center_rels: list[str] = []
+        for f in files:
+            rel = svc._to_rel(f)
+            if rel:
+                center_rels.append(rel)
+        if not center_rels:
+            return "No valid files provided."
+
+        visited: dict[str, tuple[int, str]] = {}
+        queue: deque[tuple[str, int, str]] = deque()
+        for rel in center_rels:
+            visited[rel] = (0, "center")
+            queue.append((rel, 0, "center"))
+
+        while queue:
+            current, d, _rel_type = queue.popleft()
+            if d >= depth:
+                continue
+            for dep in svc.get_dependencies(current):
+                if dep not in visited:
+                    relationship = "imported-by-center" if d == 0 else "transitive-import"
+                    visited[dep] = (d + 1, relationship)
+                    queue.append((dep, d + 1, relationship))
+            for dep in svc.get_dependents(current):
+                if dep not in visited:
+                    relationship = "imports-center" if d == 0 else "transitive-importer"
+                    visited[dep] = (d + 1, relationship)
+                    queue.append((dep, d + 1, relationship))
+
+        def _sort_key(item):
+            rel, (dist, _) = item
+            fi = all_files.get(rel)
+            importance = fi.importance if fi else 0.0
+            return (dist, -importance)
+
+        sorted_files = sorted(visited.items(), key=_sort_key)
+        sections: list[str] = []
+        token_est = 0
+
+        for rel, (dist, relationship) in sorted_files:
+            fi = all_files.get(rel)
+            file_ast = ast_cache.get(rel)
+            lang = fi.language if fi else ""
+            line_count = fi.line_count if fi else 0
+            importance = fi.importance if fi else 0.0
+
+            header = f"{'  ' * dist}{rel}"
+            meta = f"  {lang}, {line_count}L, importance={importance:.2f}, {relationship}"
+            file_section = [header, meta]
+
+            if include_symbols and file_ast:
+                max_sym = 8 if dist == 0 else 5
+                sym_lines: list[str] = []
+                for fn in file_ast.functions[:max_sym]:
+                    params = ", ".join(p.name for p in fn.parameters[:4])
+                    ret = f" -> {fn.return_type}" if fn.return_type else ""
+                    sym_lines.append(f"    fn {fn.name}({params}){ret}")
+                for cls in file_ast.classes[:max_sym]:
+                    bases = f"({', '.join(cls.bases[:3])})" if cls.bases else ""
+                    methods_preview = ", ".join(m.name for m in cls.methods[:4])
+                    sym_lines.append(f"    class {cls.name}{bases}: {methods_preview}")
+                remaining = max_sym - len(sym_lines)
+                if remaining < 0:
+                    sym_lines = sym_lines[:max_sym]
+                    sym_lines.append("    ... and more")
+                file_section.extend(sym_lines)
+
+            section_text = "\n".join(file_section)
+            section_tokens = int(len(section_text) / 3.5)
+            if token_est + section_tokens > max_tokens and sections:
+                sections.append(f"  ... and {len(sorted_files) - len(sections)} more files (truncated)")
+                break
+            sections.append(section_text)
+            token_est += section_tokens
+
+        header_text = (
+            f"Subgraph capsule for {', '.join(center_rels)} "
+            f"(depth={depth}, {len(visited)} files):\n"
+        )
+        return header_text + "\n".join(sections)
+
+    def project_summary(self, max_tokens: int = 4000) -> str:
+        # Import the synthesis helpers from server module
+        from attocode.code_intel.server import (
+            _classify_layers,
+            _detect_build_system,
+            _detect_project_name,
+            _detect_tech_stack,
+            _find_entry_points,
+            _find_hub_files,
+            _summarize_directories,
+        )
+
+        ctx = self._get_context_mgr()
+        files = ctx._files
+        if not files:
+            return "No files discovered in this project."
+
+        repo = ctx.get_repo_map(include_symbols=False, max_tokens=500)
+        svc = self._get_ast_service()
+        index = svc._index
+        ast_cache = svc._ast_cache
+
+        sections: list[tuple[str, str, int]] = []
+
+        name = _detect_project_name(self._project_dir)
+        top_langs = sorted(repo.languages.items(), key=lambda x: -x[1])[:8]
+        lang_str = ", ".join(f"{lang} ({count})" for lang, count in top_langs)
+        identity = (
+            f"Project: {name}\n"
+            f"Files: {repo.total_files}, Lines: {repo.total_lines:,}\n"
+            f"Languages: {lang_str or 'unknown'}"
+        )
+        sections.append(("Overview", identity, 10))
+
+        entries = _find_entry_points(files, index)
+        if entries:
+            entry_lines = [f"  {path} — {reason}" for path, reason in entries[:10]]
+            sections.append(("Entry Points", "\n".join(entry_lines), 9))
+
+        if index.file_dependents:
+            hubs = _find_hub_files(files, index, top_n=10)
+            if hubs:
+                hub_lines = [f"  {path} (fan-in={fi}, fan-out={fo})" for path, fi, fo in hubs]
+                sections.append(("Core Files (by dependents)", "\n".join(hub_lines), 8))
+
+        dirs = _summarize_directories(files)
+        total_files = len(files)
+        dir_lines = []
+        for d, count, loc in dirs[:15]:
+            pct = count / total_files * 100 if total_files else 0
+            if d in ("site", "docs", "doc", ".git") and pct < 10:
+                continue
+            dir_lines.append(f"  {d}/ — {count} files, {loc:,} lines ({pct:.0f}%)")
+        if dir_lines:
+            sections.append(("Directory Layout", "\n".join(dir_lines), 7))
+
+        if index.file_dependents:
+            layers = _classify_layers(files, index)
+            layer_lines = []
+            for layer_name, layer_files in layers.items():
+                if layer_files:
+                    examples = ", ".join(layer_files[:5])
+                    more = f" (+{len(layer_files) - 5})" if len(layer_files) > 5 else ""
+                    layer_lines.append(f"  {layer_name}: {len(layer_files)} files — {examples}{more}")
+            if layer_lines:
+                sections.append(("Dependency Layers", "\n".join(layer_lines), 5))
+
+        if ast_cache:
+            stack = _detect_tech_stack(ast_cache)
+            if stack:
+                sections.append(("Tech Stack", "  " + ", ".join(stack), 6))
+
+        test_files = [f for f in files if f.is_test]
+        if test_files:
+            has_prefix = any("test_" in os.path.basename(f.relative_path) for f in test_files)
+            test_pat = "test_*.py" if has_prefix else "*_test.py"
+            sections.append(("Tests", f"  {len(test_files)} test files (pattern: {test_pat})", 4))
+
+        build = _detect_build_system(files)
+        if build != "unknown":
+            sections.append(("Build System", f"  {build}", 3))
+
+        sections.sort(key=lambda x: x[2], reverse=True)
+        output_parts: list[str] = []
+        token_est = 0
+        for header, text, _prio in sections:
+            section_text = f"## {header}\n{text}"
+            section_tokens = int(len(section_text) / 3.5)
+            if token_est + section_tokens > max_tokens and output_parts:
+                break
+            output_parts.append(section_text)
+            token_est += section_tokens
+        return "\n\n".join(output_parts)
+
+    def bootstrap(self, task_hint: str = "", max_tokens: int = 8000) -> str:
+        from attocode.code_intel.server import _analyze_conventions, _format_conventions
+
+        ctx = self._get_context_mgr()
+        files = ctx._files
+        if not files:
+            return "No files discovered in this project."
+
+        total_files = len(files)
+        if total_files < 100:
+            size_tier = "small"
+        elif total_files < 2000:
+            size_tier = "medium"
+        else:
+            size_tier = "large"
+
+        summary_budget = int(max_tokens * 0.38)
+        structure_budget = int(max_tokens * 0.38)
+        conventions_budget = int(max_tokens * 0.12)
+        search_budget = int(max_tokens * 0.12) if task_hint else 0
+        if not task_hint:
+            summary_budget = int(max_tokens * 0.40)
+            structure_budget = int(max_tokens * 0.44)
+            conventions_budget = int(max_tokens * 0.16)
+
+        sections: list[str] = []
+        sections.append(self.project_summary(max_tokens=summary_budget))
+
+        if size_tier == "small":
+            map_text = self.repo_map(include_symbols=True, max_tokens=structure_budget)
+            sections.append(f"## Repository Map\n{map_text}")
+        elif size_tier == "medium":
+            map_text = self.repo_map(include_symbols=True, max_tokens=int(structure_budget * 0.7))
+            hs_text = self.hotspots(top_n=10)
+            sections.append(f"## Repository Map\n{map_text}")
+            sections.append(f"## Hotspots\n{hs_text}")
+        else:
+            explorer = self._get_explorer()
+            root_result = explorer.explore("", max_items=20, importance_threshold=0.3)
+            explore_text = explorer.format_result(root_result)
+            hs_text = self.hotspots(top_n=10)
+            sections.append(f"## Top-Level Structure\n{explore_text}")
+            sections.append(f"## Hotspots\n{hs_text}")
+
+        svc = self._get_ast_service()
+        ast_cache = svc._ast_cache
+        if ast_cache:
+            candidates = sorted(
+                [fi for fi in files if fi.relative_path in ast_cache],
+                key=lambda fi: fi.importance,
+                reverse=True,
+            )
+            sample_rels = [fi.relative_path for fi in candidates[:25]]
+            if sample_rels:
+                stats = _analyze_conventions(ast_cache, sample_rels)
+                conv_text = _format_conventions(stats)
+                conv_chars = conventions_budget * 4
+                if len(conv_text) > conv_chars:
+                    conv_text = conv_text[:conv_chars] + "\n  ..."
+                sections.append(f"## Conventions\n{conv_text}")
+
+        if task_hint:
+            try:
+                mgr = self._get_semantic_search()
+                results = mgr.search(task_hint, top_k=5)
+                if results:
+                    search_text = mgr.format_results(results)
+                    search_chars = search_budget * 4
+                    if len(search_text) > search_chars:
+                        search_text = search_text[:search_chars] + "\n  ..."
+                    sections.append(f"## Relevant Code for: {task_hint}\n{search_text}")
+            except Exception:
+                pass
+
+        if size_tier == "small":
+            guidance = (
+                "## Navigation Guidance\n"
+                "Small codebase — the repo map above shows everything.\n"
+                "Next: `symbols(file)` or `file_analysis(file)` on files of interest."
+            )
+        elif size_tier == "medium":
+            guidance = (
+                "## Navigation Guidance\n"
+                "Medium codebase — use `explore_codebase(dir)` to drill into directories.\n"
+                "For specific symbols: `search_symbols(name)` or `semantic_search(query)`.\n"
+                "Before modifying: `impact_analysis([files])` to check blast radius."
+            )
+        else:
+            guidance = (
+                "## Navigation Guidance\n"
+                "Large codebase — do NOT request full `repo_map`, it wastes tokens.\n"
+                "Use `explore_codebase(dir)` to drill down level by level.\n"
+                "For specific symbols: `search_symbols(name)` or `semantic_search(query)`.\n"
+                "Use `relevant_context([file])` to understand a file with its neighbors.\n"
+                "Before modifying: `impact_analysis([files])` to check blast radius."
+            )
+        sections.append(guidance)
+        return "\n\n".join(sections)
+
+    def hotspots(self, top_n: int = 15) -> str:
+        from attocode.code_intel.server import _compute_file_metrics, _compute_function_hotspots
+
+        ctx = self._get_context_mgr()
+        files = ctx._files
+        if not files:
+            return "No files discovered in this project."
+
+        svc = self._get_ast_service()
+        index = svc._index
+        ast_cache = svc._ast_cache
+
+        all_metrics = _compute_file_metrics(files, index, ast_cache)
+        if not all_metrics:
+            return "No analyzable files found."
+
+        all_metrics.sort(key=lambda m: m.composite, reverse=True)
+        lines = [f"Top {min(top_n, len(all_metrics))} hotspots by complexity/coupling:\n"]
+        for i, m in enumerate(all_metrics[:top_n], 1):
+            tags = f"  [{', '.join(m.categories)}]" if m.categories else ""
+            lines.append(
+                f"  {i:2d}. {m.path}\n"
+                f"      {m.line_count} lines, {m.symbol_count} symbols, "
+                f"pub={m.public_symbols}, "
+                f"fan-in={m.fan_in}, fan-out={m.fan_out}, "
+                f"density={m.density}%, score={m.composite}{tags}"
+            )
+
+        fn_hotspots = _compute_function_hotspots(ast_cache, top_n=10)
+        if fn_hotspots:
+            lines.append("\nLongest functions:")
+            for i, fm in enumerate(fn_hotspots, 1):
+                pub_mark = "" if fm.is_public else " (private)"
+                ret_mark = "" if fm.has_return_type else " [no return type]"
+                lines.append(
+                    f"  {i:2d}. {fm.name} — {fm.line_count} lines, "
+                    f"{fm.param_count} params{pub_mark}{ret_mark}\n"
+                    f"      {fm.file_path}"
+                )
+
+        orphans = [
+            m for m in all_metrics
+            if m.fan_in == 0 and m.fan_out == 0 and m.line_count >= 20
+            and not any(fi.is_test for fi in files if fi.relative_path == m.path)
+        ]
+        if orphans:
+            lines.append(f"\nOrphan files (no imports/importers, {len(orphans)} found):")
+            for m in orphans[:10]:
+                lines.append(f"  {m.path} ({m.line_count} lines, {m.symbol_count} symbols)")
+            if len(orphans) > 10:
+                lines.append(f"  ... and {len(orphans) - 10} more")
+        return "\n".join(lines)
+
+    def conventions(self, sample_size: int = 50, path: str = "") -> str:
+        from attocode.code_intel.server import _analyze_conventions, _format_conventions
+
+        svc = self._get_ast_service()
+        ast_cache = svc._ast_cache
+        if not ast_cache:
+            return "No files parsed — cannot detect conventions."
+
+        ctx = self._get_context_mgr()
+        files = ctx._files
+        path_prefix = path.rstrip("/") + "/" if path else ""
+
+        if path_prefix:
+            scoped_candidates = sorted(
+                [
+                    fi for fi in files
+                    if fi.relative_path in ast_cache
+                    and fi.relative_path.startswith(path_prefix)
+                ],
+                key=lambda fi: fi.importance,
+                reverse=True,
+            )
+            scoped_rels = [fi.relative_path for fi in scoped_candidates[:sample_size]]
+            if not scoped_rels:
+                return f"No parsed files found in '{path}'."
+
+            scoped_stats = _analyze_conventions(ast_cache, scoped_rels)
+            global_candidates = sorted(
+                [fi for fi in files if fi.relative_path in ast_cache],
+                key=lambda fi: fi.importance,
+                reverse=True,
+            )
+            global_rels = [fi.relative_path for fi in global_candidates[:sample_size]]
+            global_stats = _analyze_conventions(ast_cache, global_rels)
+
+            header = f"Conventions in {path}/ ({len(scoped_rels)} files):\n"
+            scoped_text = _format_conventions(scoped_stats)
+
+            comparison_parts: list[str] = []
+            scoped_fn = scoped_stats["total_functions"]
+            global_fn = global_stats["total_functions"]
+            if scoped_fn > 0 and global_fn > 0:
+                scoped_type_pct = scoped_stats["typed_return"] / scoped_fn * 100
+                global_type_pct = global_stats["typed_return"] / global_fn * 100
+                if abs(scoped_type_pct - global_type_pct) > 10:
+                    comparison_parts.append(
+                        f"  Type hints: {scoped_type_pct:.0f}% here vs {global_type_pct:.0f}% project-wide"
+                    )
+                scoped_doc_pct = scoped_stats["has_docstring_fn"] / scoped_fn * 100
+                global_doc_pct = global_stats["has_docstring_fn"] / global_fn * 100
+                if abs(scoped_doc_pct - global_doc_pct) > 10:
+                    comparison_parts.append(
+                        f"  Docstrings: {scoped_doc_pct:.0f}% here vs {global_doc_pct:.0f}% project-wide"
+                    )
+                scoped_async_pct = scoped_stats["async_count"] / scoped_fn * 100
+                global_async_pct = global_stats["async_count"] / global_fn * 100
+                if abs(scoped_async_pct - global_async_pct) > 10:
+                    comparison_parts.append(
+                        f"  Async: {scoped_async_pct:.0f}% here vs {global_async_pct:.0f}% project-wide"
+                    )
+
+            if comparison_parts:
+                header += scoped_text + "\n\nDivergence from project conventions:\n" + "\n".join(comparison_parts)
+            else:
+                header += scoped_text + "\n\n(Matches project-wide conventions.)"
+            return header
+
+        candidates = sorted(
+            [fi for fi in files if fi.relative_path in ast_cache],
+            key=lambda fi: fi.importance,
+            reverse=True,
+        )
+        sample_rels = [fi.relative_path for fi in candidates[:sample_size]]
+        if not sample_rels:
+            return "No parsed files available for convention analysis."
+
+        stats = _analyze_conventions(ast_cache, sample_rels)
+        dir_groups: dict[str, list[str]] = {}
+        for rel in sample_rels:
+            parts = rel.split("/")
+            dirname = parts[0] if len(parts) > 1 else "(root)"
+            dir_groups.setdefault(dirname, []).append(rel)
+
+        dir_stats: dict[str, dict] = {}
+        for dirname, dir_rels in dir_groups.items():
+            if len(dir_rels) >= 3:
+                dir_stats[dirname] = _analyze_conventions(ast_cache, dir_rels)
+
+        header = f"Conventions detected across {len(sample_rels)} files:\n"
+        return header + _format_conventions(stats, dir_stats=dir_stats)
+
+    async def lsp_definition(self, file: str, line: int, col: int = 0) -> str:
+        lsp = self._get_lsp_manager()
+        if not os.path.isabs(file):
+            file = os.path.join(self._project_dir, file)
+        try:
+            loc = await lsp.get_definition(file, line, col)
+        except Exception as e:
+            return f"LSP not available: {e}"
+        if loc is None:
+            return f"No definition found at {file}:{line}:{col}"
+        uri = loc.uri
+        if uri.startswith("file://"):
+            uri = uri[7:]
+        try:
+            uri = os.path.relpath(uri, self._project_dir)
+        except ValueError:
+            pass
+        return f"Definition: {uri}:{loc.range.start.line + 1}:{loc.range.start.character + 1}"
+
+    async def lsp_references(
+        self, file: str, line: int, col: int = 0, include_declaration: bool = True,
+    ) -> str:
+        lsp = self._get_lsp_manager()
+        if not os.path.isabs(file):
+            file = os.path.join(self._project_dir, file)
+        try:
+            locs = await lsp.get_references(file, line, col, include_declaration=include_declaration)
+        except Exception as e:
+            return f"LSP not available: {e}"
+        if not locs:
+            return f"No references found at {file}:{line}:{col}"
+        lines = [f"References ({len(locs)}):"]
+        for loc in locs[:50]:
+            uri = loc.uri
+            if uri.startswith("file://"):
+                uri = uri[7:]
+            try:
+                uri = os.path.relpath(uri, self._project_dir)
+            except ValueError:
+                pass
+            lines.append(f"  {uri}:{loc.range.start.line + 1}:{loc.range.start.character + 1}")
+        if len(locs) > 50:
+            lines.append(f"  ... and {len(locs) - 50} more")
+        return "\n".join(lines)
+
+    async def lsp_hover(self, file: str, line: int, col: int = 0) -> str:
+        lsp = self._get_lsp_manager()
+        if not os.path.isabs(file):
+            file = os.path.join(self._project_dir, file)
+        try:
+            info = await lsp.get_hover(file, line, col)
+        except Exception as e:
+            return f"LSP not available: {e}"
+        if info is None:
+            return f"No hover information at {file}:{line}:{col}"
+        return f"Hover at {file}:{line}:{col}:\n{info}"
+
+    def lsp_diagnostics(self, file: str) -> str:
+        lsp = self._get_lsp_manager()
+        if not os.path.isabs(file):
+            file = os.path.join(self._project_dir, file)
+        try:
+            diags = lsp.get_diagnostics(file)
+        except Exception as e:
+            return f"LSP not available: {e}"
+        if not diags:
+            return f"No diagnostics for {file}"
+        lines = [f"Diagnostics ({len(diags)}):"]
+        for d in diags[:30]:
+            source = f" [{d.source}]" if d.source else ""
+            code = f" ({d.code})" if d.code else ""
+            lines.append(
+                f"  [{d.severity}]{source}{code} "
+                f"L{d.range.start.line + 1}:{d.range.start.character + 1}: "
+                f"{d.message}"
+            )
+        if len(diags) > 30:
+            lines.append(f"  ... and {len(diags) - 30} more")
+        return "\n".join(lines)
+
+    def explore_codebase(
+        self, path: str = "", max_items: int = 30, importance_threshold: float = 0.3,
+    ) -> str:
+        explorer = self._get_explorer()
+        result = explorer.explore(path, max_items=max_items, importance_threshold=importance_threshold)
+        return explorer.format_result(result)
+
+    def security_scan(self, mode: str = "full", path: str = "") -> str:
+        scanner = self._get_security_scanner()
+        report = scanner.scan(mode=mode, path=path)
+        return scanner.format_report(report)
+
+    def semantic_search(self, query: str, top_k: int = 10, file_filter: str = "") -> str:
+        mgr = self._get_semantic_search()
+        results = mgr.search(query, top_k=top_k, file_filter=file_filter)
+        return mgr.format_results(results)
+
+    def recall(self, query: str, scope: str = "", max_results: int = 10) -> str:
+        store = self._get_memory_store()
+        results = store.recall(query, scope=scope, max_results=max_results)
+        if not results:
+            return "No relevant learnings found for this project."
+        lines = [f"## Project Learnings ({len(results)} relevant)\n"]
+        for r in results:
+            lines.append(f"- **[{r['type']}]** (confidence: {r['confidence']:.0%}, id: {r['id']})")
+            lines.append(f"  {r['description']}")
+            if r["details"]:
+                lines.append(f"  _{r['details']}_")
+        for r in results:
+            try:
+                store.record_applied(r["id"])
+            except Exception:
+                logger.debug("Failed to record_applied for learning %d", r["id"])
+        return "\n".join(lines)
+
+    def record_learning(
+        self,
+        type: str,
+        description: str,
+        details: str = "",
+        scope: str = "",
+        confidence: float = 0.7,
+    ) -> str:
+        store = self._get_memory_store()
+        try:
+            learning_id = store.add(
+                type=type, description=description,
+                details=details, scope=scope, confidence=confidence,
+            )
+        except ValueError as e:
+            return f"Error: {e}"
+        return f"Recorded learning #{learning_id}: [{type}] {description}"
+
+    def learning_feedback(self, learning_id: int, helpful: bool) -> str:
+        store = self._get_memory_store()
+        store.record_feedback(learning_id, helpful)
+        action = "boosted" if helpful else "reduced"
+        return f"Feedback recorded — confidence {action} for learning #{learning_id}."
+
+    def list_learnings(self, status: str = "active", type: str = "", scope: str = "") -> str:
+        store = self._get_memory_store()
+        results = store.list_all(status=status, type=type or None)
+        if scope:
+            results = [r for r in results if r["scope"].startswith(scope) or r["scope"] == ""]
+        if not results:
+            return "No learnings found matching the filters."
+        lines = [f"## Learnings ({len(results)} total)\n"]
+        lines.append("| ID | Type | Description | Confidence | Applied | Scope |")
+        lines.append("|---|---|---|---|---|---|")
+        for r in results:
+            desc = r["description"][:60] + ("..." if len(r["description"]) > 60 else "")
+            lines.append(
+                f"| {r['id']} | {r['type']} | {desc} "
+                f"| {r['confidence']:.0%} | {r['apply_count']}x "
+                f"| {r['scope'] or '(global)'} |"
+            )
+        return "\n".join(lines)
+
+    def notify_file_changed(self, files: list[str]) -> str:
+        if not files:
+            return "No files specified."
+        svc = self._get_ast_service()
+        updated = 0
+        for f in files:
+            try:
+                p = Path(f)
+                if p.is_absolute():
+                    rel = os.path.relpath(str(p), self._project_dir)
+                else:
+                    rel = str(p)
+                rel = os.path.normpath(rel)
+                if rel.startswith(".."):
+                    continue
+                svc.notify_file_changed(rel)
+                try:
+                    smgr = self._get_semantic_search()
+                    abs_path = os.path.join(self._project_dir, rel)
+                    smgr.invalidate_file(abs_path)
+                except Exception:
+                    pass
+                updated += 1
+            except Exception as exc:
+                logger.debug("notify_file_changed: error for %s: %s", f, exc)
+        return f"Updated {updated} file(s). AST index refreshed."

--- a/tests/fixtures/sample_project/main.py
+++ b/tests/fixtures/sample_project/main.py
@@ -1,0 +1,34 @@
+"""Sample application entry point for integration tests."""
+
+from utils import parse_config, validate_input
+from models import User, Config
+
+
+class App:
+    """Main application class."""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.users: list[User] = []
+
+    def add_user(self, name: str, email: str) -> User:
+        """Create and register a new user."""
+        validate_input(name)
+        user = User(name=name, email=email)
+        self.users.append(user)
+        return user
+
+    def run(self) -> None:
+        """Start the application."""
+        settings = parse_config(self.config.path)
+        print(f"Running with {len(settings)} settings")
+
+
+def main() -> None:
+    config = Config(path="config.yaml", debug=True)
+    app = App(config)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/sample_project/models.py
+++ b/tests/fixtures/sample_project/models.py
@@ -1,0 +1,25 @@
+"""Data models for the sample project."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class User:
+    """Represents an application user."""
+
+    name: str
+    email: str
+    active: bool = True
+
+    def deactivate(self) -> None:
+        self.active = False
+
+
+@dataclass
+class Config:
+    """Application configuration."""
+
+    path: str
+    debug: bool = False
+    max_retries: int = 3
+    tags: list[str] = field(default_factory=list)

--- a/tests/fixtures/sample_project/utils.py
+++ b/tests/fixtures/sample_project/utils.py
@@ -1,0 +1,26 @@
+"""Utility functions for the sample project."""
+
+import os
+import json
+
+
+def parse_config(path: str) -> dict:
+    """Parse a configuration file and return settings."""
+    if not os.path.exists(path):
+        return {"default": True}
+    with open(path) as f:
+        return json.load(f)
+
+
+def validate_input(value: str) -> bool:
+    """Validate that input is non-empty and reasonable length."""
+    if not value or not value.strip():
+        raise ValueError("Input cannot be empty")
+    if len(value) > 255:
+        raise ValueError("Input too long")
+    return True
+
+
+def format_output(data: dict) -> str:
+    """Format data dictionary as a readable string."""
+    return "\n".join(f"{k}: {v}" for k, v in sorted(data.items()))

--- a/tests/integration/code_intel/conftest.py
+++ b/tests/integration/code_intel/conftest.py
@@ -1,0 +1,29 @@
+"""Shared fixtures for code-intel integration tests."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from attocode.code_intel.config import CodeIntelConfig
+from attocode.code_intel.service import CodeIntelService
+
+SAMPLE_PROJECT = str(Path(__file__).resolve().parent.parent.parent / "fixtures" / "sample_project")
+
+
+@pytest.fixture(scope="session")
+def sample_project_dir() -> str:
+    """Return the absolute path to the sample project fixture."""
+    assert os.path.isdir(SAMPLE_PROJECT), f"Fixture not found: {SAMPLE_PROJECT}"
+    return SAMPLE_PROJECT
+
+
+@pytest.fixture(scope="session")
+def service(sample_project_dir: str) -> CodeIntelService:
+    """Create a real CodeIntelService on the sample project (shared across session)."""
+    config = CodeIntelConfig(project_dir=sample_project_dir)
+    svc = CodeIntelService(sample_project_dir, config)
+    yield svc
+    CodeIntelService._reset_instances()

--- a/tests/integration/code_intel/test_http_smoke.py
+++ b/tests/integration/code_intel/test_http_smoke.py
@@ -1,0 +1,101 @@
+"""HTTP smoke tests: full stack with real CodeIntelService.
+
+Unlike unit tests, these do NOT mock the service — the real
+CodeIntelService handles requests through the HTTP layer.
+"""
+
+from __future__ import annotations
+
+import pytest
+import httpx
+
+from attocode.code_intel.api import deps
+from attocode.code_intel.api.app import create_app
+from attocode.code_intel.config import CodeIntelConfig
+from attocode.code_intel.service import CodeIntelService
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+async def client(sample_project_dir: str):
+    """Create an HTTP client backed by a real service on the sample project."""
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+    config = CodeIntelConfig(project_dir=sample_project_dir)
+    app = create_app(config)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+
+@pytest.mark.asyncio
+async def test_smoke_health(client: httpx.AsyncClient):
+    """GET /health returns 200."""
+    r = await client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_smoke_register_and_map(client: httpx.AsyncClient, sample_project_dir: str):
+    """POST /projects + GET /map returns a real repo tree."""
+    # Register the project
+    r = await client.post("/api/v1/projects", json={"path": sample_project_dir})
+    assert r.status_code == 200
+    project_id = r.json()["id"]
+
+    # Get map
+    r = await client.get(f"/api/v1/projects/{project_id}/map")
+    assert r.status_code == 200
+    result = r.json()["result"]
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+@pytest.mark.asyncio
+async def test_smoke_symbols(client: httpx.AsyncClient):
+    """GET /symbols returns real symbols from the default project."""
+    r = await client.get("/api/v1/projects/default/symbols", params={"path": "main.py"})
+    assert r.status_code == 200
+    result = r.json()["result"]
+    assert "App" in result
+
+
+@pytest.mark.asyncio
+async def test_smoke_search(client: httpx.AsyncClient):
+    """GET /search-symbols finds a real symbol."""
+    r = await client.get("/api/v1/projects/default/search-symbols", params={"name": "User"})
+    assert r.status_code == 200
+    result = r.json()["result"]
+    assert len(result) > 0
+    assert "User" in result
+
+
+@pytest.mark.asyncio
+async def test_smoke_learning_roundtrip(client: httpx.AsyncClient):
+    """POST /learnings + GET /learnings/recall round-trips."""
+    # Record
+    r = await client.post(
+        "/api/v1/projects/default/learnings",
+        json={
+            "type": "pattern",
+            "description": "Use dataclasses for simple models",
+            "details": "Smoke test learning",
+        },
+    )
+    assert r.status_code == 200
+
+    # Recall
+    r = await client.get(
+        "/api/v1/projects/default/learnings/recall",
+        params={"query": "dataclasses models"},
+    )
+    assert r.status_code == 200
+    result = r.json()["result"]
+    assert "dataclass" in result.lower() or "model" in result.lower()

--- a/tests/integration/code_intel/test_service_integration.py
+++ b/tests/integration/code_intel/test_service_integration.py
@@ -1,0 +1,85 @@
+"""Integration tests: real CodeIntelService on a sample project.
+
+These tests verify the service actually works end-to-end — no mocks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from attocode.code_intel.service import CodeIntelService
+
+pytestmark = pytest.mark.integration
+
+
+def test_service_initializes(service: CodeIntelService, sample_project_dir: str):
+    """CodeIntelService can be constructed on a real directory."""
+    assert service.project_dir == sample_project_dir
+
+
+def test_repo_map_returns_tree(service: CodeIntelService):
+    """repo_map() returns a non-empty string containing file paths."""
+    result = service.repo_map(include_symbols=True, max_tokens=6000)
+    assert isinstance(result, str)
+    assert len(result) > 0
+    # Should contain at least one of our fixture files
+    assert "main.py" in result or "utils.py" in result or "models.py" in result
+
+
+def test_symbols_finds_known_class(service: CodeIntelService):
+    """symbols() finds the App class from main.py."""
+    result = service.symbols("main.py")
+    assert isinstance(result, str)
+    assert "App" in result
+
+
+def test_search_symbols_finds_by_name(service: CodeIntelService):
+    """search_symbols() can find a symbol by name."""
+    result = service.search_symbols("App")
+    assert isinstance(result, str)
+    assert len(result) > 0
+    # Should mention the App class or main.py
+    assert "App" in result
+
+
+def test_dependencies_reports_imports(service: CodeIntelService):
+    """dependencies() lists known imports from main.py."""
+    result = service.dependencies("main.py")
+    assert isinstance(result, str)
+    # main.py imports from utils and models
+    assert "utils" in result.lower() or "models" in result.lower() or "import" in result.lower()
+
+
+def test_file_analysis_returns_structure(service: CodeIntelService):
+    """file_analysis() returns structured output for a file."""
+    result = service.file_analysis("main.py")
+    assert isinstance(result, str)
+    assert len(result) > 0
+    # Should contain some structural info
+    lower = result.lower()
+    assert "main.py" in lower or "class" in lower or "line" in lower or "python" in lower
+
+
+def test_learning_roundtrip(service: CodeIntelService):
+    """record_learning() + recall() round-trips correctly."""
+    record_result = service.record_learning(
+        type="convention",
+        description="Always use snake_case for function names",
+        details="This is a test learning for integration tests",
+        scope="sample_project",
+        confidence=0.9,
+    )
+    assert isinstance(record_result, str)
+
+    recall_result = service.recall(query="snake_case function names", scope="sample_project")
+    assert isinstance(recall_result, str)
+    assert "snake_case" in recall_result or "convention" in recall_result.lower()
+
+
+def test_explore_codebase_lists_files(service: CodeIntelService):
+    """explore_codebase() returns a non-empty listing."""
+    result = service.explore_codebase()
+    assert isinstance(result, str)
+    assert len(result) > 0
+    # Should list at least one of our fixture files
+    assert "main.py" in result or "utils.py" in result or "models.py" in result

--- a/tests/unit/code_intel/test_api.py
+++ b/tests/unit/code_intel/test_api.py
@@ -1,0 +1,751 @@
+"""Integration tests for the HTTP API (38 routes).
+
+Uses httpx.AsyncClient + ASGITransport with a mocked CodeIntelService.
+Tests HTTP routing, status codes, request parsing, and auth — NOT the
+underlying code intelligence logic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+import pytest
+import httpx
+
+from attocode.code_intel.api import deps
+from attocode.code_intel.api.app import create_app
+from attocode.code_intel.config import CodeIntelConfig
+from attocode.code_intel.service import CodeIntelService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_service(project_dir: str = "/tmp/test-project") -> MagicMock:
+    """Create a MagicMock with all CodeIntelService methods stubbed."""
+    svc = MagicMock(spec=CodeIntelService)
+    type(svc).project_dir = PropertyMock(return_value=project_dir)
+
+    # Sync methods returning stub strings
+    for method in (
+        "repo_map", "symbols", "search_symbols", "dependencies",
+        "impact_analysis", "cross_references", "file_analysis",
+        "dependency_graph", "hotspots", "conventions", "project_summary",
+        "bootstrap", "explore_codebase", "security_scan",
+        "notify_file_changed", "semantic_search",
+        "graph_query", "find_related", "community_detection",
+        "relevant_context", "record_learning", "recall",
+        "learning_feedback", "list_learnings",
+        "lsp_diagnostics",
+    ):
+        getattr(svc, method).return_value = f"stub:{method}"
+
+    # Async methods
+    for method in ("lsp_definition", "lsp_references", "lsp_hover"):
+        setattr(svc, method, AsyncMock(return_value=f"stub:{method}"))
+
+    # Internal methods used by reindex
+    svc._get_ast_service = MagicMock()
+    svc._get_context_mgr = MagicMock()
+
+    return svc
+
+
+@pytest.fixture()
+def mock_service():
+    return _make_mock_service()
+
+
+@pytest.fixture()
+async def client(mock_service):
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+    config = CodeIntelConfig(project_dir="/tmp/test-project")
+    app = create_app(config)
+
+    # Inject mock service
+    deps._services["default"] = mock_service
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+
+@pytest.fixture()
+async def auth_client(mock_service):
+    """Client with API key auth enabled."""
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+    config = CodeIntelConfig(project_dir="/tmp/test-project", api_key="testkey")
+    app = create_app(config)
+    deps._services["default"] = mock_service
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health(client):
+    r = await client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_ready_with_project(client):
+    r = await client.get("/ready")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_ready_without_project():
+    deps.reset()
+    config = CodeIntelConfig()
+    app = create_app(config)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get("/ready")
+    assert r.json()["status"] == "not_ready"
+    deps.reset()
+
+
+# ---------------------------------------------------------------------------
+# Projects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_projects(client):
+    r = await client.get("/api/v1/projects")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["projects"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_get_project(client):
+    r = await client.get("/api/v1/projects/default")
+    assert r.status_code == 200
+    assert r.json()["id"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_get_project_404(client):
+    r = await client.get("/api/v1/projects/nonexistent")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_register_project(client, tmp_path):
+    r = await client.post("/api/v1/projects", json={"path": str(tmp_path)})
+    assert r.status_code == 200
+    assert r.json()["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_register_bad_path(client):
+    r = await client.post("/api/v1/projects", json={"path": "/nonexistent/path/xyz"})
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_register_blocked_system_dir(auth_client):
+    r = await auth_client.post(
+        "/api/v1/projects",
+        json={"path": "/etc"},
+        headers={"Authorization": "Bearer testkey"},
+    )
+    assert r.status_code == 400
+    assert "system directory" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_register_duplicate_returns_existing(client, mock_service, tmp_path):
+    """Registering the same path twice returns the existing project."""
+    # First register creates a new project
+    r1 = await client.post("/api/v1/projects", json={"path": str(tmp_path)})
+    assert r1.status_code == 200
+    pid1 = r1.json()["id"]
+
+    # Second register of same path returns the same project
+    r2 = await client.post("/api/v1/projects", json={"path": str(tmp_path)})
+    assert r2.status_code == 200
+    assert r2.json()["id"] == pid1
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repo_map(client):
+    r = await client.get("/api/v1/projects/default/map")
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:repo_map"
+
+
+@pytest.mark.asyncio
+async def test_project_summary(client):
+    r = await client.get("/api/v1/projects/default/summary")
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:project_summary"
+
+
+@pytest.mark.asyncio
+async def test_symbols(client):
+    r = await client.get("/api/v1/projects/default/symbols", params={"path": "foo.py"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:symbols"
+
+
+@pytest.mark.asyncio
+async def test_search_symbols(client):
+    r = await client.get("/api/v1/projects/default/search-symbols", params={"name": "Foo"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:search_symbols"
+
+
+@pytest.mark.asyncio
+async def test_dependencies(client):
+    r = await client.get("/api/v1/projects/default/dependencies", params={"path": "foo.py"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:dependencies"
+
+
+@pytest.mark.asyncio
+async def test_impact_analysis(client):
+    r = await client.get("/api/v1/projects/default/impact", params=[("files", "a.py"), ("files", "b.py")])
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:impact_analysis"
+
+
+@pytest.mark.asyncio
+async def test_cross_refs(client):
+    r = await client.get("/api/v1/projects/default/cross-refs", params={"symbol": "Foo"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:cross_references"
+
+
+@pytest.mark.asyncio
+async def test_file_analysis(client):
+    r = await client.get("/api/v1/projects/default/file-analysis", params={"path": "foo.py"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:file_analysis"
+
+
+@pytest.mark.asyncio
+async def test_dependency_graph(client):
+    r = await client.post("/api/v1/projects/default/dependency-graph", json={"start_file": "foo.py"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:dependency_graph"
+
+
+@pytest.mark.asyncio
+async def test_hotspots(client):
+    r = await client.get("/api/v1/projects/default/hotspots")
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:hotspots"
+
+
+@pytest.mark.asyncio
+async def test_conventions(client):
+    r = await client.get("/api/v1/projects/default/conventions")
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:conventions"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap(client):
+    r = await client.post("/api/v1/projects/default/bootstrap", json={})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:bootstrap"
+
+
+@pytest.mark.asyncio
+async def test_explore(client):
+    r = await client.post("/api/v1/projects/default/explore", json={})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:explore_codebase"
+
+
+@pytest.mark.asyncio
+async def test_security_scan(client):
+    r = await client.post("/api/v1/projects/default/security-scan", json={})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:security_scan"
+
+
+@pytest.mark.asyncio
+async def test_notify(client):
+    r = await client.post("/api/v1/projects/default/notify", json={"files": ["a.py"]})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:notify_file_changed"
+
+
+@pytest.mark.asyncio
+async def test_analysis_404(client):
+    r = await client.get("/api/v1/projects/unknown/map")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_semantic_search(client):
+    r = await client.post("/api/v1/projects/default/search", json={"query": "auth"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:semantic_search"
+
+
+# ---------------------------------------------------------------------------
+# Graph
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_graph_query(client):
+    r = await client.post("/api/v1/projects/default/graph/query", json={"file": "foo.py"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:graph_query"
+
+
+@pytest.mark.asyncio
+async def test_find_related(client):
+    r = await client.post("/api/v1/projects/default/graph/related", json={"file": "foo.py"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:find_related"
+
+
+@pytest.mark.asyncio
+async def test_community_detection(client):
+    r = await client.get("/api/v1/projects/default/graph/communities")
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:community_detection"
+
+
+@pytest.mark.asyncio
+async def test_relevant_context(client):
+    r = await client.post("/api/v1/projects/default/graph/context", json={"files": ["a.py"]})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:relevant_context"
+
+
+# ---------------------------------------------------------------------------
+# Learning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_record_learning(client):
+    r = await client.post(
+        "/api/v1/projects/default/learnings",
+        json={"type": "pattern", "description": "test"},
+    )
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:record_learning"
+
+
+@pytest.mark.asyncio
+async def test_recall(client):
+    r = await client.get("/api/v1/projects/default/learnings/recall", params={"query": "test"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:recall"
+
+
+@pytest.mark.asyncio
+async def test_learning_feedback(client):
+    r = await client.post(
+        "/api/v1/projects/default/learnings/1/feedback",
+        json={"helpful": True},
+    )
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:learning_feedback"
+
+
+@pytest.mark.asyncio
+async def test_list_learnings(client):
+    r = await client.get("/api/v1/projects/default/learnings")
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:list_learnings"
+
+
+# ---------------------------------------------------------------------------
+# LSP
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lsp_definition(client):
+    r = await client.post("/api/v1/projects/default/lsp/definition", json={"file": "a.py", "line": 1})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:lsp_definition"
+
+
+@pytest.mark.asyncio
+async def test_lsp_references(client):
+    r = await client.post("/api/v1/projects/default/lsp/references", json={"file": "a.py", "line": 1})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:lsp_references"
+
+
+@pytest.mark.asyncio
+async def test_lsp_hover(client):
+    r = await client.post("/api/v1/projects/default/lsp/hover", json={"file": "a.py", "line": 1})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:lsp_hover"
+
+
+@pytest.mark.asyncio
+async def test_lsp_diagnostics(client):
+    r = await client.get("/api/v1/projects/default/lsp/diagnostics", params={"file": "a.py"})
+    assert r.status_code == 200
+    assert r.json()["result"] == "stub:lsp_diagnostics"
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_no_header_401(auth_client):
+    r = await auth_client.get("/api/v1/projects")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_auth_wrong_key_401(auth_client):
+    r = await auth_client.get("/api/v1/projects", headers={"Authorization": "wrong"})
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_auth_correct_key_200(auth_client):
+    r = await auth_client.get("/api/v1/projects", headers={"Authorization": "Bearer testkey"})
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# CORS
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cors_wildcard_no_credentials():
+    """Wildcard origins should NOT send Access-Control-Allow-Credentials."""
+    deps.reset()
+    CodeIntelService._reset_instances()
+    config = CodeIntelConfig(project_dir="/tmp/test-project", cors_origins=["*"])
+    app = create_app(config)
+    deps._services["default"] = _make_mock_service()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.options(
+            "/health",
+            headers={"Origin": "http://example.com", "Access-Control-Request-Method": "GET"},
+        )
+    assert r.headers.get("access-control-allow-credentials") != "true"
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+
+@pytest.mark.asyncio
+async def test_cors_specific_origin_allows_credentials():
+    """Specific origins should send Access-Control-Allow-Credentials: true."""
+    deps.reset()
+    CodeIntelService._reset_instances()
+    config = CodeIntelConfig(
+        project_dir="/tmp/test-project",
+        cors_origins=["http://example.com"],
+    )
+    app = create_app(config)
+    deps._services["default"] = _make_mock_service()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.options(
+            "/health",
+            headers={"Origin": "http://example.com", "Access-Control-Request-Method": "GET"},
+        )
+    assert r.headers.get("access-control-allow-credentials") == "true"
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+
+# ---------------------------------------------------------------------------
+# Reindex (Tier 1A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reindex_success(client, mock_service):
+    r = await client.post("/api/v1/projects/default/reindex")
+    assert r.status_code == 200
+    assert r.json()["result"] == "Reindex complete"
+    mock_service._get_ast_service.assert_called_once()
+    mock_service._get_context_mgr.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_reindex_404(client):
+    r = await client.post("/api/v1/projects/nonexistent/reindex")
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reindex_clears_caches(client, mock_service):
+    """Verify caches are set to None before reinit methods are called."""
+    call_order = []
+
+    def track_ast():
+        call_order.append(("get_ast", mock_service._ast_service))
+
+    def track_ctx():
+        call_order.append(("get_ctx", mock_service._context_mgr))
+
+    mock_service._get_ast_service.side_effect = track_ast
+    mock_service._get_context_mgr.side_effect = track_ctx
+
+    r = await client.post("/api/v1/projects/default/reindex")
+    assert r.status_code == 200
+    assert call_order[0] == ("get_ast", None)
+    assert call_order[1] == ("get_ctx", None)
+
+
+# ---------------------------------------------------------------------------
+# Auth bypass for health endpoints (Tier 1B)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_bypasses_auth(auth_client):
+    r = await auth_client.get("/health")
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_ready_bypasses_auth(auth_client):
+    r = await auth_client.get("/ready")
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Path security (Tier 1C)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("blocked_path", ["/var", "/usr", "/sys", "/proc", "/dev"])
+@pytest.mark.asyncio
+async def test_register_blocked_prefixes(auth_client, blocked_path):
+    with patch("attocode.code_intel.api.routes.projects.os.path.isdir", return_value=True):
+        r = await auth_client.post(
+            "/api/v1/projects",
+            json={"path": blocked_path},
+            headers={"Authorization": "Bearer testkey"},
+        )
+    assert r.status_code == 400
+    assert "system directory" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_register_path_traversal(auth_client):
+    """Path traversal normalizes to a blocked prefix via os.path.abspath."""
+    with patch("attocode.code_intel.api.routes.projects.os.path.isdir", return_value=True):
+        r = await auth_client.post(
+            "/api/v1/projects",
+            json={"path": "/tmp/safe/../../etc"},
+            headers={"Authorization": "Bearer testkey"},
+        )
+    assert r.status_code == 400
+    assert "system directory" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_register_system_dir_allowed_without_auth(client):
+    """Without auth configured, system directory blocking is skipped."""
+    with (
+        patch("attocode.code_intel.api.routes.projects.os.path.isdir", return_value=True),
+        patch("attocode.code_intel.api.deps.CodeIntelService.get_instance", return_value=MagicMock()),
+    ):
+        r = await client.post("/api/v1/projects", json={"path": "/etc"})
+    assert r.status_code == 200
+    assert "system directory" not in r.text
+
+
+# ---------------------------------------------------------------------------
+# Service error propagation (Tier 1D)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sync_service_error_propagates(client, mock_service):
+    """Unhandled sync errors propagate (→ 500 in production)."""
+    mock_service.repo_map.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        await client.get("/api/v1/projects/default/map")
+
+
+@pytest.mark.asyncio
+async def test_async_service_error_propagates(client, mock_service):
+    """Unhandled async errors propagate (→ 500 in production)."""
+    mock_service.lsp_definition.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        await client.post(
+            "/api/v1/projects/default/lsp/definition",
+            json={"file": "a.py", "line": 1},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Missing required query params → 422 (Tier 2A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_symbols_missing_path_422(client):
+    r = await client.get("/api/v1/projects/default/symbols")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_search_symbols_missing_name_422(client):
+    r = await client.get("/api/v1/projects/default/search-symbols")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_impact_missing_files_422(client):
+    r = await client.get("/api/v1/projects/default/impact")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_cross_refs_missing_symbol_422(client):
+    r = await client.get("/api/v1/projects/default/cross-refs")
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_lsp_diagnostics_missing_file_422(client):
+    r = await client.get("/api/v1/projects/default/lsp/diagnostics")
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Missing/invalid request bodies → 422 (Tier 2B)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dependency_graph_empty_body_422(client):
+    r = await client.post("/api/v1/projects/default/dependency-graph", json={})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_empty_body_422(client):
+    r = await client.post("/api/v1/projects/default/search", json={})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_record_learning_empty_body_422(client):
+    r = await client.post("/api/v1/projects/default/learnings", json={})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_lsp_definition_empty_body_422(client):
+    r = await client.post("/api/v1/projects/default/lsp/definition", json={})
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_post_invalid_json_422(client):
+    r = await client.post(
+        "/api/v1/projects/default/bootstrap",
+        content="not json{",
+        headers={"Content-Type": "application/json"},
+    )
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Path param validation (Tier 2C)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_learning_feedback_non_integer_id_422(client):
+    r = await client.post(
+        "/api/v1/projects/default/learnings/abc/feedback",
+        json={"helpful": True},
+    )
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# CORS response headers (Tier 3A)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cors_response_has_allow_origin():
+    """Actual GET response (not preflight) includes Allow-Origin header."""
+    deps.reset()
+    CodeIntelService._reset_instances()
+    config = CodeIntelConfig(
+        project_dir="/tmp/test-project",
+        cors_origins=["http://example.com"],
+    )
+    app = create_app(config)
+    deps._services["default"] = _make_mock_service()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get("/health", headers={"Origin": "http://example.com"})
+    assert r.headers.get("access-control-allow-origin") == "http://example.com"
+    deps.reset()
+    CodeIntelService._reset_instances()
+
+
+@pytest.mark.asyncio
+async def test_cors_non_matching_origin():
+    """Non-matching origin should not get Access-Control-Allow-Origin."""
+    deps.reset()
+    CodeIntelService._reset_instances()
+    config = CodeIntelConfig(
+        project_dir="/tmp/test-project",
+        cors_origins=["http://allowed.com"],
+    )
+    app = create_app(config)
+    deps._services["default"] = _make_mock_service()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        r = await c.get("/health", headers={"Origin": "http://disallowed.com"})
+    assert r.headers.get("access-control-allow-origin") != "http://disallowed.com"
+    deps.reset()
+    CodeIntelService._reset_instances()

--- a/tests/unit/code_intel/test_auth.py
+++ b/tests/unit/code_intel/test_auth.py
@@ -1,0 +1,84 @@
+"""Tests for API key authentication."""
+
+from __future__ import annotations
+
+import pytest
+
+from attocode.code_intel.api import deps
+from attocode.code_intel.api.auth import verify_api_key
+from attocode.code_intel.config import CodeIntelConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    deps.reset()
+    yield
+    deps.reset()
+
+
+@pytest.mark.asyncio
+async def test_no_key_allows_all():
+    deps.configure(CodeIntelConfig(api_key=""))
+    # Should not raise
+    await verify_api_key(authorization=None)
+
+
+@pytest.mark.asyncio
+async def test_key_configured_no_header_401():
+    from fastapi import HTTPException
+
+    deps.configure(CodeIntelConfig(api_key="secret"))
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_api_key(authorization=None)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_key_configured_wrong_key_401():
+    from fastapi import HTTPException
+
+    deps.configure(CodeIntelConfig(api_key="secret"))
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_api_key(authorization="wrong")
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_key_configured_correct_key_passes():
+    deps.configure(CodeIntelConfig(api_key="secret"))
+    await verify_api_key(authorization="secret")
+
+
+@pytest.mark.asyncio
+async def test_key_configured_bearer_prefix_passes():
+    deps.configure(CodeIntelConfig(api_key="secret"))
+    await verify_api_key(authorization="Bearer secret")
+
+
+@pytest.mark.asyncio
+async def test_empty_authorization_header_401():
+    """Empty string authorization should be treated as missing."""
+    from fastapi import HTTPException
+
+    deps.configure(CodeIntelConfig(api_key="secret"))
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_api_key(authorization="")
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bearer_case_sensitive():
+    """Lowercase 'bearer' prefix is not recognized."""
+    from fastapi import HTTPException
+
+    deps.configure(CodeIntelConfig(api_key="secret"))
+    with pytest.raises(HTTPException) as exc_info:
+        await verify_api_key(authorization="bearer secret")
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bearer_extra_whitespace():
+    """Extra whitespace around the token is stripped."""
+    deps.configure(CodeIntelConfig(api_key="secret"))
+    await verify_api_key(authorization="Bearer  secret ")

--- a/tests/unit/code_intel/test_config.py
+++ b/tests/unit/code_intel/test_config.py
@@ -1,0 +1,56 @@
+"""Tests for CodeIntelConfig."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from attocode.code_intel.config import CodeIntelConfig
+
+
+def test_defaults():
+    cfg = CodeIntelConfig()
+    assert cfg.project_dir == ""
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 8080
+    assert cfg.api_key == ""
+    assert cfg.cors_origins == ["*"]
+    assert cfg.log_level == "info"
+
+
+def test_from_env(monkeypatch):
+    monkeypatch.setenv("ATTOCODE_PROJECT_DIR", "/tmp/proj")
+    monkeypatch.setenv("ATTOCODE_HOST", "0.0.0.0")
+    monkeypatch.setenv("ATTOCODE_PORT", "9090")
+    monkeypatch.setenv("ATTOCODE_API_KEY", "secret123")
+    monkeypatch.setenv("ATTOCODE_CORS_ORIGINS", "http://a.com,http://b.com")
+    monkeypatch.setenv("ATTOCODE_LOG_LEVEL", "debug")
+
+    cfg = CodeIntelConfig.from_env()
+    assert cfg.project_dir == "/tmp/proj"
+    assert cfg.host == "0.0.0.0"
+    assert cfg.port == 9090
+    assert cfg.api_key == "secret123"
+    assert cfg.cors_origins == ["http://a.com", "http://b.com"]
+    assert cfg.log_level == "debug"
+
+
+def test_from_env_defaults(monkeypatch):
+    for var in ("ATTOCODE_PROJECT_DIR", "ATTOCODE_HOST", "ATTOCODE_PORT",
+                "ATTOCODE_API_KEY", "ATTOCODE_CORS_ORIGINS", "ATTOCODE_LOG_LEVEL"):
+        monkeypatch.delenv(var, raising=False)
+
+    cfg = CodeIntelConfig.from_env()
+    assert cfg.project_dir == ""
+    assert cfg.host == "127.0.0.1"
+    assert cfg.port == 8080
+    assert cfg.api_key == ""
+    assert cfg.cors_origins == ["*"]
+    assert cfg.log_level == "info"
+
+
+def test_from_env_port_non_numeric_raises(monkeypatch):
+    monkeypatch.setenv("ATTOCODE_PORT", "abc")
+    with pytest.raises(ValueError):
+        CodeIntelConfig.from_env()

--- a/tests/unit/code_intel/test_deps.py
+++ b/tests/unit/code_intel/test_deps.py
@@ -1,0 +1,94 @@
+"""Tests for the DI module (api/deps.py)."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from attocode.code_intel.api import deps
+from attocode.code_intel.config import CodeIntelConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    deps.reset()
+    yield
+    deps.reset()
+
+
+def test_configure_sets_config():
+    cfg = CodeIntelConfig(project_dir="")
+    deps.configure(cfg)
+    assert deps.get_config() is cfg
+
+
+def test_get_config_fallback_from_env(monkeypatch):
+    monkeypatch.setenv("ATTOCODE_PORT", "9999")
+    # No configure() called — should fall back to from_env()
+    cfg = deps.get_config()
+    assert cfg.port == 9999
+
+
+def test_get_service_unknown_raises():
+    with pytest.raises(ValueError, match="not found"):
+        deps.get_service("nonexistent")
+
+
+def test_register_and_get(tmp_path):
+    deps.configure(CodeIntelConfig())
+    svc = deps.register_project("test1", str(tmp_path))
+    assert deps.get_service("test1") is svc
+
+
+def test_list_projects(tmp_path):
+    deps.configure(CodeIntelConfig())
+    deps.register_project("a", str(tmp_path))
+    deps.register_project("b", str(tmp_path))
+    projects = deps.list_projects()
+    assert "a" in projects
+    assert "b" in projects
+
+
+def test_get_service_or_404():
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        deps.get_service_or_404("unknown")
+    assert exc_info.value.status_code == 404
+
+
+def test_configure_warns_double_call(caplog):
+    cfg = CodeIntelConfig()
+    deps.configure(cfg)
+    with caplog.at_level(logging.WARNING):
+        deps.configure(cfg)
+    assert "more than once" in caplog.text
+
+
+def test_reset_clears_all(tmp_path):
+    deps.configure(CodeIntelConfig())
+    deps.register_project("x", str(tmp_path))
+    assert deps.list_projects()
+    deps.reset()
+    assert not deps.list_projects()
+    assert deps.get_default_project_id() == ""
+
+
+def test_get_service_empty_string_uses_default(tmp_path):
+    deps.configure(CodeIntelConfig(project_dir=str(tmp_path)))
+    svc = deps.get_service("")
+    assert svc is deps.get_service("default")
+
+
+def test_register_overwrites_existing_id(tmp_path):
+    deps.configure(CodeIntelConfig())
+    d1 = tmp_path / "a"
+    d2 = tmp_path / "b"
+    d1.mkdir()
+    d2.mkdir()
+    deps.register_project("test", str(d1))
+    deps.register_project("test", str(d2))
+    svc = deps.get_service("test")
+    assert svc.project_dir == str(d2)

--- a/tests/unit/code_intel/test_middleware.py
+++ b/tests/unit/code_intel/test_middleware.py
@@ -1,0 +1,39 @@
+"""Tests for RequestLoggingMiddleware."""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from attocode.code_intel.api import deps
+from attocode.code_intel.api.app import create_app
+from attocode.code_intel.config import CodeIntelConfig
+
+
+@pytest.fixture()
+async def logging_client():
+    deps.reset()
+    config = CodeIntelConfig()
+    app = create_app(config)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    deps.reset()
+
+
+@pytest.mark.asyncio
+async def test_logging_middleware_logs_request(logging_client, caplog):
+    with caplog.at_level(logging.INFO, logger="attocode.code_intel.api.middleware"):
+        await logging_client.get("/health")
+    assert "GET" in caplog.text
+    assert "/health" in caplog.text
+    assert "200" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_logging_middleware_logs_duration(logging_client, caplog):
+    with caplog.at_level(logging.INFO, logger="attocode.code_intel.api.middleware"):
+        await logging_client.get("/health")
+    assert "ms" in caplog.text

--- a/tests/unit/code_intel/test_service.py
+++ b/tests/unit/code_intel/test_service.py
@@ -1,0 +1,46 @@
+"""Tests for CodeIntelService."""
+
+from __future__ import annotations
+
+import os
+
+from attocode.code_intel.config import CodeIntelConfig
+from attocode.code_intel.service import CodeIntelService
+
+
+def setup_function():
+    CodeIntelService._reset_instances()
+
+
+def teardown_function():
+    CodeIntelService._reset_instances()
+
+
+def test_get_instance_returns_same(tmp_path):
+    a = CodeIntelService.get_instance(str(tmp_path))
+    b = CodeIntelService.get_instance(str(tmp_path))
+    assert a is b
+
+
+def test_get_instance_different_paths(tmp_path):
+    d1 = tmp_path / "a"
+    d2 = tmp_path / "b"
+    d1.mkdir()
+    d2.mkdir()
+    a = CodeIntelService.get_instance(str(d1))
+    b = CodeIntelService.get_instance(str(d2))
+    assert a is not b
+
+
+def test_project_dir_is_absolute(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    svc = CodeIntelService(".")
+    assert os.path.isabs(svc.project_dir)
+    assert svc.project_dir == str(tmp_path)
+
+
+def test_reset_instances(tmp_path):
+    a = CodeIntelService.get_instance(str(tmp_path))
+    CodeIntelService._reset_instances()
+    b = CodeIntelService.get_instance(str(tmp_path))
+    assert a is not b

--- a/uv.lock
+++ b/uv.lock
@@ -87,6 +87,11 @@ dependencies = [
 anthropic = [
     { name = "anthropic" },
 ]
+code-intel = [
+    { name = "fastapi" },
+    { name = "python-multipart" },
+    { name = "uvicorn", extra = ["standard"] },
+]
 dev = [
     { name = "bump-my-version" },
     { name = "mypy" },
@@ -135,6 +140,7 @@ requires-dist = [
     { name = "bump-my-version", marker = "extra == 'dev'", specifier = ">=0.28" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "einops", marker = "extra == 'semantic-nomic'" },
+    { name = "fastapi", marker = "extra == 'code-intel'", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6" },
@@ -151,6 +157,7 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14" },
     { name = "pytest-textual-snapshot", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-multipart", marker = "extra == 'code-intel'", specifier = ">=0.0.18" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "respx", marker = "extra == 'dev'", specifier = ">=0.22" },
     { name = "rich", specifier = ">=13.0.0" },
@@ -171,6 +178,7 @@ requires-dist = [
     { name = "tree-sitter-python", marker = "extra == 'tree-sitter'" },
     { name = "tree-sitter-ruby", marker = "extra == 'tree-sitter'" },
     { name = "tree-sitter-rust", marker = "extra == 'tree-sitter'" },
+    { name = "uvicorn", extras = ["standard"], marker = "extra == 'code-intel'", specifier = ">=0.34" },
     { name = "watchfiles", marker = "extra == 'watch'", specifier = ">=1.0" },
 ]
 provides-extras = ["anthropic", "openai", "tree-sitter", "watch", "semantic", "semantic-nomic", "code-intel", "docs", "dev"]
@@ -568,6 +576,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -649,6 +673,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
 ]
 
 [[package]]
@@ -2764,6 +2817,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
 [[package]]
 name = "watchdog"
 version = "6.0.0"
@@ -2877,4 +2973,49 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]


### PR DESCRIPTION
- Introduced a new HTTP API for the Code Intelligence server, allowing access to 27 tools via REST.
- Updated CLI to support `code-intel serve` command with options for HTTP transport.
- Enhanced documentation to include details on the new API and server deployment.
- Added new tools and improved existing ones for better codebase analysis and interaction.