### PR TITLE
feat: rule-bench harness + community rule pack expansion (v0.2.22)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,22 @@ jobs:
       - name: Verify all extras resolve
         run: uv sync --locked --all-extras
 
+  pack-license-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies (PyYAML for the script)
+        run: uv sync --locked --extra dev
+
+      - name: Verify community pack licenses
+        run: uv run python scripts/check_pack_licenses.py
+
   research-integration:
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ snapshot_report.html
 # scripts
 scripts/*
 !scripts/validate_release_version.py
+!scripts/check_pack_licenses.py
 .DS_Store
 
 #playwright

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,130 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.22] - 2026-04-16
+
+### Added — Rule-Bench Harness + Community Pack Expansion
+
+Extends the meta-harness with a rule-quality optimizer and significantly
+expands language coverage by importing community rule packs from
+permissive sources. Lets the optimizer tune existing rules (stage 1)
+and generate new rules from templates (stage 2), with a per-language
+floor predicate preventing the "win-Python-break-Go" regression
+pattern observed in the search-bench experiments.
+
+#### Rule-Bench Harness (`eval/meta_harness/rule_bench/`)
+
+- **`scoring.py`** — severity-weighted F1 (critical=4x..info=0.5x),
+  per-language macro-aggregation with universal-rule bucket "*",
+  composite via macro mean. Skips zero-signal rules so unused rules
+  don't dilute scores.
+- **`corpus.py`** — `CorpusLoader` discovers labeled samples from three
+  sources: `packs/community/<pack>/fixtures/`, hand-labeled
+  `eval/rule_harness/fixtures/attocode/`, and the legacy CWE corpus
+  under `eval/rule_accuracy/corpus/`. Reuses
+  `parse_annotations` so semgrep `# ruleid:` markers normalize to
+  `expect` automatically.
+- **`config.py`** — `RuleBenchConfig` holds per-rule overrides
+  (`enabled`, `confidence`, `severity`), pack activation flags, global
+  `min_confidence`, and stage-2 `extra_rules`. `apply_to_registry`
+  returns a fresh cloned `RuleRegistry` so retries and parallel
+  candidates never share mutable state.
+- **`evaluator.py`** — `RuleBenchEvaluator` mirrors
+  `CodeIntelBenchEvaluator.evaluate(working_dir) -> EvalResult`. Lazily
+  loads packs and corpus, applies the candidate's config, scores per-rule
+  TP/FP/FN, aggregates to severity-weighted F1 per language. Disabled
+  rules still surface in the per-rule report.
+- **`predicate.py`** — `rule_accept_predicate` enforces a 5%
+  per-language F1 floor on top of strict-improvement.
+- **`proposer.py`** — stage-1 sweep proposer mutates 1-3 random rule
+  overrides per candidate; stage-2 LLM proposer fills rule templates
+  with slot validation + fixture-coverage gate (≥2 TPs, ≤1 FP).
+- **`template_engine.py`** + 6 templates (`deprecated_api_call`,
+  `missing_error_check`, `insecure_default_arg`, `regex_redos`,
+  `string_concat_in_loop`, `unsafe_deserialization`).
+- **`composite_evaluator.py`** — `CompositeBenchEvaluator` runs search +
+  rule legs in parallel; composite =
+  `0.3 * search + 0.5 * mcp + 0.2 * rule`. Forwards rule-leg
+  `per_language` metadata so the floor predicate still rejects
+  single-language regressions.
+
+#### Meta-Harness Refactor (`eval/meta_harness/`)
+
+- **`_llm_client.py`** — extracted shared LLM scaffolding (`call_llm`,
+  `load_env`, `diff_from_defaults`) so the rule-bench proposer reuses
+  the same client.
+- **`meta_loop.py`** — `MetaHarnessRunner` now accepts a `BenchSpec`
+  (evaluator, config_default, propose_sweep, propose_llm,
+  accept_predicate, artifact_prefix); default preserves legacy
+  search-bench behavior. `EvolutionEntry` gains optional
+  `per_language`, `reject_reason`, `bench_metadata` fields.
+- **`__main__.py`** — adds `--bench {search|rule|composite}` flag plus
+  `_select_bench` factory.
+- **`paths.py`** — `prefixed`/`baseline_path`/`evolution_path`/
+  `best_config_path` helpers so each bench writes its own artifacts
+  side-by-side.
+
+#### Community Rule Packs (`packs/community/`)
+
+Three permissively-licensed packs hand-ported from upstream sources,
+each shipping with its own LICENSE + NOTICE + manifest declaring SPDX
+license, source URL, commit, and attribution:
+
+- **bandit-python** (Apache-2.0, 8 rules): hardcoded passwords, weak
+  hashes (MD5/SHA1), weak ciphers, dynamic eval, TLS verify disabled,
+  shell=True, SQL string concat
+- **gosec-go** (Apache-2.0, 8 rules): hardcoded creds, bind-all
+  interfaces, unsafe package use, fmt.Sprintf SQL, file path
+  inclusion, weak ciphers, low TLS MinVersion, crypto/md5 import
+- **eslint-typescript** (MIT, 7 rules): no-eval, no-implied-eval,
+  no-new-func, no-var, eqeqeq, no-with, no-throw-literal
+
+#### Pack Tooling (`eval/rule_harness/`)
+
+- **`import_pack.py`** — scaffolds the legal shell for a new community
+  pack (LICENSE, NOTICE, manifest, PORTING.md checklist) so porting
+  starts in a license-compliant state. Sources: bandit, gosec, eslint.
+- **`scripts/seed_attocode_fixtures.py`** — generates 15 fixture stubs
+  from example pack rules' `examples` fields for hand-curation.
+- **`fixtures/attocode/`** — 21 labeled fixtures across 6 languages
+  (python, go, typescript, javascript, rust, java).
+
+#### Schema Groundwork
+
+- **`UnifiedRule`** gains a `references: list[str]` field for preserving
+  external links from imports.
+- **`PackManifest`** gains provenance fields (`source`, `source_url`,
+  `source_commit`, `source_license`, `attribution`, `imported_at`,
+  `upstream_rule_count`, `imported_rule_count`).
+- **`testing._ANNOTATION_RE`** accepts `ruleid` as an alias for `expect`
+  so semgrep test fixtures import without preprocessing.
+- New `list_community_packs()` and `get_community_pack_dir()` in
+  `pack_loader.py`.
+
+#### CI
+
+- New `pack-license-check` job runs `scripts/check_pack_licenses.py`
+  on every push: every community pack must ship LICENSE + NOTICE +
+  manifest with SPDX license in the permissive allowlist (Apache-2.0,
+  MIT, BSD-2/3-Clause, ISC).
+
+#### Validated Results
+
+- Composite F1 = 0.857 across 6 languages on the baseline corpus
+- Sweep mode finds +1.42% improvement candidates per iteration
+- Per-language floor correctly rejects regression candidates in
+  integration tests
+- 207 unit + integration tests pass
+
+#### Documentation
+
+- New `docs/guides/rule-bench-corpus.md` — annotation format,
+  community pack onboarding, hand-labeling workflow, running
+  `--bench rule`, the per-language floor predicate, stage-2 templates,
+  quarterly upstream-license maintenance, troubleshooting.
+- `docs/guides/meta-harness-optimization.md` — new "Bench Modes"
+  section.
+
 ## [0.2.21] - 2026-04-16
 
 ### Added — Search Scoring Optimization via Meta-Harness

--- a/docs/guides/meta-harness-optimization.md
+++ b/docs/guides/meta-harness-optimization.md
@@ -4,6 +4,16 @@ Attocode includes an automated hyperparameter optimization framework for code-in
 
 **Validated result:** +25.5% overall MRR across 5 ground-truth repositories (4/5 repos improved, 0 significant regressions) when comparing the pre-optimization defaults to the shipped `best_config.yaml`.
 
+## Bench Modes
+
+The harness supports three bench modes selected via `--bench`:
+
+- `--bench search` (default) — optimizes search scoring + MCP bench; the historical use case described in this guide.
+- `--bench rule` — optimizes rule packs by tuning per-rule overrides (enabled, confidence, severity) and (stage 2) generating new rules from templates. Uses severity-weighted F1 macro-averaged across languages with a per-language floor predicate. See [Rule-Bench Corpus](rule-bench-corpus.md) for the corpus contract and how to add new community packs.
+- `--bench composite` — runs both legs in parallel and folds them into one score (`0.3 * search + 0.5 * mcp + 0.2 * rule`). The per-language rule floor still applies, so a candidate that wins search but breaks Go rules is rejected.
+
+Artifacts are prefixed by mode (`baseline.json` / `rule_baseline.json` / `composite_baseline.json`) so the modes coexist in the same results directory.
+
 ## Quick Start
 
 ```bash

--- a/docs/guides/rule-bench-corpus.md
+++ b/docs/guides/rule-bench-corpus.md
@@ -1,0 +1,269 @@
+# Rule-Bench Corpus
+
+The rule-bench harness measures rule precision/recall against a labeled corpus, then drives LLM-guided optimization to tune rule fields and generate new rules. This guide covers:
+
+- The labeled corpus contract (what a fixture looks like)
+- How to add a new community pack with proper license attribution
+- The hand-labeling workflow for attocode-specific fixtures
+- Running `--bench rule` and reading the results
+- Quarterly upstream-license maintenance
+
+For the broader optimization framework see [Meta-Harness Optimization](meta-harness-optimization.md).
+
+## Why a labeled corpus
+
+A rule's value is "true positives caught minus false positives raised, weighted by severity". You can only measure that against fixtures someone wrote down the answer for. Without labels, the optimizer is flying blind.
+
+## Annotation format
+
+Fixtures use inline comments to mark expectations:
+
+| Marker | Meaning |
+|---|---|
+| `# expect: rule-id` | Rule MUST fire on this line (TP assertion) |
+| `# ok: rule-id` | Rule must NOT fire on this line (FP guard) |
+| `# todoruleid: rule-id` | Known miss — informational, not scored |
+| `# ruleid: rule-id` | Semgrep alias — automatically normalized to `expect` |
+
+`//` works in place of `#` for languages with C-style comments. The annotation regex lives at `attocode.code_intel.rules.testing._ANNOTATION_RE`.
+
+Example (`eval/rule_harness/fixtures/attocode/python/bandit-secrets.py`):
+
+```python
+api_key = "sk-1234567890abcdef"  # expect: B105-hardcoded-password
+PLACEHOLDER = "EXAMPLE_VALUE"    # ok: B105-hardcoded-password
+```
+
+## Corpus sources (in priority order)
+
+The `CorpusLoader` discovers fixtures from three sources, in this order:
+
+1. **Community pack fixtures** — `packs/community/<pack>/fixtures/<rule-id>/{positive,negative}.<ext>`. Honors `--packs` filter.
+2. **Hand-labeled attocode fixtures** — `eval/rule_harness/fixtures/attocode/<lang>/*.<ext>`. Targets the shipped example packs.
+3. **Legacy CWE corpus** — `eval/rule_accuracy/corpus/<lang>/<cwe>/{tp_,tn_}<name>.<ext>`. Pre-existing benchmark, kept for back-compat.
+
+Toggle each source via CLI flags:
+
+```bash
+python -m eval.meta_harness --bench rule \
+    --include-community --include-attocode-fixtures --include-legacy-corpus \
+    baseline
+```
+
+When `--packs` is unset, all three sources are enabled by default.
+
+## Adding a community pack
+
+Community packs live under `src/attocode/code_intel/rules/packs/community/<pack-name>/` with their own `LICENSE` + `NOTICE` files plus a `manifest.yaml` declaring source provenance.
+
+### License policy
+
+**Permissive licenses only.** The CI job `pack-license-check` (`scripts/check_pack_licenses.py`) enforces this on every push:
+
+| Source license | Allowed | Required attribution |
+|---|---|---|
+| MIT | yes | Copyright notice + license text |
+| Apache-2.0 | yes | NOTICE file + license text |
+| BSD-2/3-Clause | yes | Copyright notice + license text |
+| ISC | yes | Copyright notice + license text |
+| LGPL-2.1+ | **no** — copyleft adds redistribution friction | n/a |
+| GPL | **no** — incompatible with attocode's distribution model | n/a |
+
+Bundled license templates ship under `packs/community/_license_templates/`.
+
+### Scaffold a new pack
+
+Use the importer to scaffold a license-compliant skeleton:
+
+```bash
+uv run python -m eval.rule_harness.import_pack \
+    --source bandit \
+    --lang python \
+    --output src/attocode/code_intel/rules/packs/community/bandit-python \
+    --commit <upstream-sha>
+```
+
+Built-in sources (each contributes a `PORTING.md` checklist of high-value rule IDs):
+
+- `bandit` (Apache-2.0) → Python security rules
+- `gosec` (Apache-2.0) → Go security rules
+- `eslint` (MIT) → JavaScript/TypeScript lint rules
+
+The scaffolder produces:
+
+```
+packs/community/bandit-python/
+├── LICENSE         # Apache-2.0 full text
+├── NOTICE          # attribution + provenance
+├── manifest.yaml   # name, source, source_url, source_commit, source_license, …
+├── PORTING.md      # checklist of upstream rule IDs to hand-port
+└── rules/          # empty — fill with attocode YAML rules
+```
+
+### Hand-port a rule
+
+For each rule in `PORTING.md`, write a YAML file under `rules/` with the attribution comment header at the top:
+
+```yaml
+# Adapted from bandit rule 'B105 hardcoded_password_string'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B105-hardcoded-password
+name: Hardcoded password string
+message: Possible hardcoded password assignment
+severity: high
+category: security
+languages: [python]
+confidence: 0.7
+cwe: CWE-798
+pattern: '(?i)\b(password|passwd|pwd|secret|token|api_key)\s*=\s*[''"][^''"]{3,}[''"]'
+explanation: |
+  Storing credentials in source code makes them easy to leak …
+recommendation: |
+  Move credentials to a secret manager …
+references:
+  - https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
+  - https://cwe.mitre.org/data/definitions/798.html
+```
+
+Pattern guidance:
+
+- Prefer narrow patterns over broad ones — false positives kill adoption.
+- Use `(?i)` for case-insensitive matches when the language permits.
+- Test with `python -m eval.meta_harness --bench rule baseline` and inspect the per-rule F1 in `rule_baseline.json`.
+
+### Adding fixtures
+
+Drop labeled samples under `packs/community/<pack>/fixtures/<rule-id>/`:
+
+```
+fixtures/B105-hardcoded-password/
+├── positive.py    # rule MUST fire here (annotated with `# expect:`)
+└── negative.py    # rule must NOT fire (annotated with `# ok:`)
+```
+
+Each file should compile in its language toolchain so optional LSP enrichment doesn't choke. Include unrelated nearby code in `negative.py` to measure FP rate against realistic non-targets.
+
+## Hand-labeling attocode fixtures
+
+For the shipped example packs (`packs/examples/<lang>/`), fixtures live at `eval/rule_harness/fixtures/attocode/<lang>/<rule-id>.<ext>`. Use the seed scaffolder to generate stubs from each rule's `examples` field:
+
+```bash
+uv run python -m eval.rule_harness.scripts.seed_attocode_fixtures
+```
+
+Output:
+
+```
+Seeded 15 fixture stub(s)
+  go: 6
+  java: 1
+  python: 4
+  rust: 1
+  typescript: 3
+```
+
+Then **hand-curate each fixture**:
+
+1. Confirm the `# expect:` line targets the actual offending position
+2. Add nearby unrelated code so we measure FP rate
+3. Ensure the file compiles in your target toolchain
+4. Add at least one `# ok:` annotation per rule for FP guarding
+
+Pass `--overwrite` to regenerate fixtures (destroys hand-curation).
+
+## Running the harness
+
+### Baseline
+
+```bash
+# Score the current corpus with default rule overrides
+python -m eval.meta_harness --bench rule baseline
+```
+
+Output (truncated):
+
+```
+Composite score: 0.8854
+
+Component scores:
+  weighted_f1: 0.8444
+  precision: 0.9135
+  recall: 0.7851
+
+Rule-bench per language:
+  go: F1=0.7191
+  java: F1=0.8235
+  python: F1=0.9714
+  rust: F1=0.9474
+  typescript: F1=0.9655
+```
+
+The full per-rule + per-language report lands in `.attocode/meta_harness/results/rule_baseline.json`.
+
+### Optimization
+
+```bash
+# Sweep mode (no API key required)
+python -m eval.meta_harness --bench rule run --iterations 10 --propose-mode sweep
+
+# LLM mode (needs OPENROUTER_API_KEY or ANTHROPIC_API_KEY)
+python -m eval.meta_harness --bench rule run --iterations 10 --propose-mode llm
+```
+
+The runner appends every candidate to `rule_evolution_summary.jsonl` with full per-language F1 and the `reject_reason` for floor violations. The best accepted config lands in `rule_best_config.yaml`.
+
+### Per-language floor
+
+A candidate is accepted only when:
+
+1. Its composite score strictly improves on the current best, AND
+2. **No language drops below 95% of its baseline F1** (the floor predicate, in `rule_bench/predicate.py`).
+
+This prevents the "win-Python-break-Go" pattern observed in the original search-bench experiments. Configurable via `make_rule_accept_predicate(floor_ratio=…)` if 5% slack is too strict for your corpus.
+
+### Composite mode
+
+Run search + rule together:
+
+```bash
+python -m eval.meta_harness --bench composite baseline
+```
+
+Composite formula: `0.3 * search_quality + 0.5 * mcp_bench + 0.2 * rule_bench`. The rule-leg per-language scores still drive the floor predicate.
+
+## Stage-2 template proposer
+
+When `--propose-mode llm` runs, the proposer can also instantiate rule templates from `eval/meta_harness/rule_bench/templates/`:
+
+- `deprecated_api_call`
+- `missing_error_check`
+- `insecure_default_arg`
+- `regex_redos`
+- `string_concat_in_loop`
+- `unsafe_deserialization`
+
+Each template declares slots (regex_fragment, language, enum, text). The LLM fills slots; the engine validates each (regex compiles, language supported, enum value valid) and runs a fixture-coverage gate (must earn ≥2 TPs, ≤1 FP across the labeled corpus) before the rule reaches the full evaluator.
+
+To add a template, drop a YAML file in `templates/` matching the schema in `template_engine.py:Template`.
+
+## Quarterly maintenance
+
+Upstream rule sources occasionally relicense or restructure. Recommended cadence:
+
+1. **Every quarter**, refresh each community pack:
+   - Re-clone the upstream repo at the latest commit
+   - Re-run `import_pack.py --commit <new-sha>` (regenerates manifest)
+   - Diff the upstream rule list against `PORTING.md`; port newly-relevant rules
+2. **Whenever upstream changes license**, audit the change (`License: …` line in NOTICE) and either keep the pinned commit or remove the pack
+3. **Run `scripts/check_pack_licenses.py` locally** before opening any pack-related PR
+
+## Troubleshooting
+
+**Rule baseline is 0.0** — the registry is empty. Pass `--packs <name>` or run with no `--packs` to load all shipped + community packs.
+
+**A specific language has F1 = 0** — either no rules target that language OR no fixtures exist for it. Check `rule_baseline.json` → `per_language` for `rule_count` and `fixture_count`.
+
+**Floor predicate rejects every candidate** — your baseline-per-lang vector includes a language with very high F1 (close to 1.0). Even small noise breaches the 5% floor. Either widen the floor (`make_rule_accept_predicate(floor_ratio=0.9)`) or add more fixtures to stabilize the per-language signal.
+
+**LLM proposer returns 0 candidates** — most often the fixture-coverage gate is rejecting them. Check your corpus has at least 2 examples per rule the LLM is targeting; otherwise no template instance can earn 2 TPs.

--- a/eval/meta_harness/__main__.py
+++ b/eval/meta_harness/__main__.py
@@ -1,10 +1,15 @@
-"""CLI for meta-harness code-intel optimization.
+"""CLI for meta-harness optimization.
 
 Usage:
     python -m eval.meta_harness baseline              # Evaluate current defaults
     python -m eval.meta_harness run --iterations 10   # Run optimization loop
     python -m eval.meta_harness report                # Show results summary
     python -m eval.meta_harness evaluate config.yaml  # Evaluate a specific config
+
+The optional ``--bench {search|rule|composite}`` flag selects which
+inner-loop benchmark to optimize. ``search`` is the default and matches
+historical behavior; ``rule`` drives the rule-bench harness (Step 5);
+``composite`` runs both legs (Step 10).
 """
 
 from __future__ import annotations
@@ -15,31 +20,87 @@ import json
 import os
 import sys
 import time
+from typing import Any
 
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, os.path.join(_PROJECT_ROOT, "src"))
     sys.path.insert(0, _PROJECT_ROOT)
 
-from eval.meta_harness.paths import ensure_results_dir, results_dir as _results_dir_fn
+from eval.meta_harness.paths import (
+    baseline_path as _baseline_path,
+)
+from eval.meta_harness.paths import (
+    ensure_results_dir,
+)
+from eval.meta_harness.paths import (
+    evolution_path as _evolution_path,
+)
+
+
+def _select_bench(args: argparse.Namespace) -> dict[str, Any]:
+    """Resolve a bench mode into the plumbing required by each subcommand.
+
+    Returns a dict with keys: ``name``, ``spec`` (BenchSpec for the runner),
+    ``evaluator`` (for one-shot baseline/evaluate), ``config_default``,
+    ``config_loader`` (callable: path -> config), and ``artifact_prefix``.
+    """
+    bench = getattr(args, "bench", "search") or "search"
+
+    if bench == "search":
+        from eval.meta_harness.evaluator import CodeIntelBenchEvaluator
+        from eval.meta_harness.harness_config import HarnessConfig
+        from eval.meta_harness.meta_loop import make_search_bench_spec
+
+        evaluator = CodeIntelBenchEvaluator(
+            search_repos=args.search_repos.split(",") if args.search_repos else None,
+            bench_repos=args.bench_repos.split(",") if args.bench_repos else None,
+            split="" if args.no_split else "eval",
+        )
+        return {
+            "name": "search",
+            "spec": make_search_bench_spec(
+                search_repos=args.search_repos.split(",") if args.search_repos else None,
+                bench_repos=args.bench_repos.split(",") if args.bench_repos else None,
+                split="" if args.no_split else "eval",
+            ),
+            "evaluator": evaluator,
+            "config_default": HarnessConfig.default(),
+            "config_loader": HarnessConfig.load_yaml,
+            "config_filename": "harness_config.yaml",
+            "artifact_prefix": "",
+        }
+
+    if bench == "rule":
+        # Wired in Step 5. Stub out gracefully so --help / argparse still works.
+        try:
+            from eval.meta_harness.rule_bench.cli import build_rule_bench  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - exercised pre-Step-5
+            raise SystemExit(
+                f"--bench rule is not yet wired ({exc}). Land Steps 3-5 first."
+            ) from exc
+        return build_rule_bench(args)
+
+    if bench == "composite":
+        try:
+            from eval.meta_harness.composite_evaluator import build_composite_bench  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - exercised pre-Step-10
+            raise SystemExit(
+                f"--bench composite is not yet wired ({exc}). Land Step 10 first."
+            ) from exc
+        return build_composite_bench(args)
+
+    raise SystemExit(f"Unknown bench: {bench!r}")
 
 
 def cmd_baseline(args: argparse.Namespace) -> None:
     """Evaluate current default config and save as baseline."""
-    from eval.meta_harness.evaluator import CodeIntelBenchEvaluator
-    from eval.meta_harness.harness_config import HarnessConfig
+    bench = _select_bench(args)
 
-    print("Evaluating baseline (default scoring config)...")
+    print(f"Evaluating baseline ({bench['name']} bench)...")
     print()
 
-    evaluator = CodeIntelBenchEvaluator(
-        search_repos=args.search_repos.split(",") if args.search_repos else None,
-        bench_repos=args.bench_repos.split(",") if args.bench_repos else None,
-        split="" if args.no_split else "eval",
-    )
-
-    # Run evaluation
-    result = asyncio.run(evaluator.evaluate(_PROJECT_ROOT))
+    result = asyncio.run(bench["evaluator"].evaluate(_PROJECT_ROOT))
 
     print(f"Composite score: {result.metric_value:.4f}")
     print()
@@ -52,7 +113,6 @@ def cmd_baseline(args: argparse.Namespace) -> None:
         print()
 
     if result.metadata:
-        # Search quality details
         sq = result.metadata.get("search_quality", {})
         if sq and "per_repo" in sq:
             print("Search quality per repo:")
@@ -61,7 +121,6 @@ def cmd_baseline(args: argparse.Namespace) -> None:
                       f"P@10={metrics['precision_at_10']:.3f} R@20={metrics['recall_at_20']:.3f}")
             print()
 
-        # MCP bench details
         mb = result.metadata.get("mcp_bench", {})
         if mb and "per_category" in mb:
             print("MCP bench per category:")
@@ -69,15 +128,22 @@ def cmd_baseline(args: argparse.Namespace) -> None:
                 print(f"  {cat}: score={metrics['mean_score']:.2f}/5.0 ({metrics['count']} tasks)")
             print()
 
-    # Save baseline
-    output_dir = ensure_results_dir()
-    baseline_path = os.path.join(output_dir, "baseline.json")
+        per_lang = result.metadata.get("per_language")
+        if per_lang:
+            print("Rule-bench per language:")
+            for lang, score in per_lang.items():
+                print(f"  {lang}: F1={score:.4f}")
+            print()
+
+    ensure_results_dir()
+    baseline_path = _baseline_path(bench["artifact_prefix"])
     baseline_data = {
         "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "bench": bench["name"],
         "composite_score": result.metric_value,
         "metrics": result.metrics,
         "metadata": result.metadata,
-        "config": HarnessConfig.default().to_dict(),
+        "config": bench["config_default"].to_dict(),
     }
     with open(baseline_path, "w") as f:
         json.dump(baseline_data, f, indent=2, default=str)
@@ -86,10 +152,9 @@ def cmd_baseline(args: argparse.Namespace) -> None:
 
 def cmd_evaluate(args: argparse.Namespace) -> None:
     """Evaluate a specific config file."""
-    from eval.meta_harness.evaluator import CodeIntelBenchEvaluator
-    from eval.meta_harness.harness_config import HarnessConfig
+    bench = _select_bench(args)
 
-    config = HarnessConfig.load_yaml(args.config_file)
+    config = bench["config_loader"](args.config_file)
     errors = config.validate()
     if errors:
         print("Config validation errors:")
@@ -98,20 +163,13 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
         sys.exit(1)
 
     print(f"Evaluating config from: {args.config_file}")
-    print(f"Config: {json.dumps(config.to_dict(), indent=2)}")
+    print(f"Config: {json.dumps(config.to_dict(), indent=2, default=str)}")
     print()
 
-    # Write config to temp location for evaluator
     import tempfile
     with tempfile.TemporaryDirectory() as tmpdir:
-        config.save_yaml(os.path.join(tmpdir, "harness_config.yaml"))
-
-        evaluator = CodeIntelBenchEvaluator(
-            search_repos=args.search_repos.split(",") if args.search_repos else None,
-            bench_repos=args.bench_repos.split(",") if args.bench_repos else None,
-            split="" if args.no_split else "eval",
-        )
-        result = asyncio.run(evaluator.evaluate(tmpdir))
+        config.save_yaml(os.path.join(tmpdir, bench["config_filename"]))
+        result = asyncio.run(bench["evaluator"].evaluate(tmpdir))
 
     print(f"Composite score: {result.metric_value:.4f}")
     if result.metrics:
@@ -121,53 +179,53 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
 
 
 def cmd_report(args: argparse.Namespace) -> None:
-    """Show summary of all evaluation results."""
-    results_dir = _results_dir_fn()
+    """Show summary of all evaluation results for the selected bench."""
+    bench_name = getattr(args, "bench", "search") or "search"
+    prefix = "" if bench_name == "search" else f"{bench_name}_"
 
-    # Load baseline
-    baseline_path = os.path.join(results_dir, "baseline.json")
+    baseline_path = _baseline_path(prefix)
     if os.path.isfile(baseline_path):
         with open(baseline_path) as f:
             baseline = json.load(f)
-        print(f"Baseline: {baseline['composite_score']:.4f} ({baseline['timestamp']})")
+        print(f"Baseline ({bench_name}): {baseline['composite_score']:.4f} ({baseline['timestamp']})")
     else:
-        print("No baseline found. Run: python -m eval.meta_harness baseline")
+        print(f"No baseline found for bench '{bench_name}'.")
+        print(f"Run: python -m eval.meta_harness --bench {bench_name} baseline")
         return
 
-    # Load evolution summary
-    evo_path = os.path.join(results_dir, "evolution_summary.jsonl")
+    evo_path = _evolution_path(prefix)
     if os.path.isfile(evo_path):
         print()
         print("Evolution history:")
-        print(f"{'Iter':>5} {'Score':>8} {'Delta':>8} {'Status':>10}")
-        print(f"{'─' * 5} {'─' * 8} {'─' * 8} {'─' * 10}")
+        print(f"{'Iter':>5} {'Score':>8} {'Delta':>8} {'Status':>10} {'Reason':<40}")
+        print(f"{'─' * 5} {'─' * 8} {'─' * 8} {'─' * 10} {'─' * 40}")
         with open(evo_path) as f:
             for line in f:
                 entry = json.loads(line)
                 delta = entry.get("score", 0) - baseline["composite_score"]
+                reason = entry.get("reject_reason") or ""
                 print(
                     f"{entry.get('iteration', '?'):>5} "
                     f"{entry.get('score', 0):>8.4f} "
                     f"{delta:>+8.4f} "
-                    f"{entry.get('status', '?'):>10}"
+                    f"{entry.get('status', '?'):>10} "
+                    f"{reason[:40]:<40}"
                 )
     else:
-        print("\nNo evolution history yet. Run: python -m eval.meta_harness run --iterations N")
+        print(f"\nNo evolution history yet. Run: python -m eval.meta_harness --bench {bench_name} run --iterations N")
 
 
 def cmd_run(args: argparse.Namespace) -> None:
     """Run the meta-harness optimization loop."""
-    try:
-        from eval.meta_harness.meta_loop import MetaHarnessRunner
-    except ImportError:
-        print("Meta loop not yet implemented. Run 'baseline' first to verify the inner loop.")
-        sys.exit(1)
+    from eval.meta_harness.meta_loop import MetaHarnessRunner
+
+    bench = _select_bench(args)
 
     runner = MetaHarnessRunner(
         iterations=args.iterations,
-        search_repos=args.search_repos.split(",") if args.search_repos else None,
-        bench_repos=args.bench_repos.split(",") if args.bench_repos else None,
+        candidates_per_iteration=args.candidates,
         propose_mode=args.propose_mode,
+        bench_spec=bench["spec"],
     )
     asyncio.run(runner.run())
 
@@ -175,8 +233,10 @@ def cmd_run(args: argparse.Namespace) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="eval.meta_harness",
-        description="Meta-harness optimization for code-intel search",
+        description="Meta-harness optimization for code-intel",
     )
+    parser.add_argument("--bench", choices=["search", "rule", "composite"], default="search",
+                        help="Which inner-loop benchmark to optimize (default: search)")
     parser.add_argument("--search-repos", type=str, default=None,
                         help="Comma-separated repos for search quality (default: all)")
     parser.add_argument("--bench-repos", type=str, default=None,
@@ -184,12 +244,24 @@ def main() -> None:
     parser.add_argument("--no-split", action="store_true",
                         help="Use all tasks (no train/eval split)")
 
+    # Rule-bench specific (ignored by other benches; used in Step 5)
+    parser.add_argument("--packs", type=str, default=None,
+                        help="Comma-separated rule packs to load (rule bench)")
+    parser.add_argument("--corpus-dir", type=str, default=None,
+                        help="Path to fixture corpus root (rule bench)")
+    parser.add_argument("--include-community", action="store_true",
+                        help="Include packs/community/* in rule-bench corpus")
+    parser.add_argument("--include-attocode-fixtures", action="store_true",
+                        help="Include eval/rule_harness/fixtures/attocode/* in rule-bench corpus")
+    parser.add_argument("--include-legacy-corpus", action="store_true",
+                        help="Include eval/rule_accuracy/corpus/* in rule-bench corpus")
+
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     subparsers.add_parser("baseline", help="Evaluate default config as baseline")
 
     eval_parser = subparsers.add_parser("evaluate", help="Evaluate a config file")
-    eval_parser.add_argument("config_file", help="Path to harness_config.yaml")
+    eval_parser.add_argument("config_file", help="Path to config YAML")
 
     subparsers.add_parser("report", help="Show results summary")
 

--- a/eval/meta_harness/__main__.py
+++ b/eval/meta_harness/__main__.py
@@ -102,6 +102,10 @@ def cmd_baseline(args: argparse.Namespace) -> None:
 
     result = asyncio.run(bench["evaluator"].evaluate(_PROJECT_ROOT))
 
+    if not result.success:
+        print(f"Baseline evaluation failed: {result.error}")
+        sys.exit(1)
+
     print(f"Composite score: {result.metric_value:.4f}")
     print()
 

--- a/eval/meta_harness/_llm_client.py
+++ b/eval/meta_harness/_llm_client.py
@@ -1,0 +1,102 @@
+"""Shared LLM client scaffolding for meta-harness proposers.
+
+Both the search-scoring proposer (``proposer.py``) and the rule-bench
+proposer (``rule_bench/proposer.py``) call into Claude via the same
+underlying client. This module owns the keys, model selection, and the
+``.env`` loader so we don't duplicate that logic in each proposer.
+
+Public surface:
+- :func:`call_llm` — send a single-prompt completion request
+- :func:`load_env` — populate API keys from project ``.env`` files
+- :func:`diff_from_defaults` — render a parameter diff string
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def call_llm(prompt: str, model: str = "", max_tokens: int = 4096) -> str:
+    """Call the LLM via OpenRouter or Anthropic direct.
+
+    Routes to OpenRouter when ``OPENROUTER_API_KEY`` is set (preferred),
+    falling back to ``ANTHROPIC_API_KEY``. Raises ``RuntimeError`` if
+    neither key is present.
+    """
+    or_key = os.environ.get("OPENROUTER_API_KEY", "")
+    anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
+
+    if or_key:
+        import openai
+
+        if not model:
+            model = "anthropic/claude-sonnet-4"
+        client = openai.OpenAI(
+            base_url="https://openrouter.ai/api/v1",
+            api_key=or_key,
+        )
+        response = client.chat.completions.create(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message.content or ""
+
+    if anthropic_key:
+        import anthropic
+
+        if not model:
+            model = "claude-sonnet-4-20250514"
+        client = anthropic.Anthropic(api_key=anthropic_key)
+        response = client.messages.create(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.content[0].text
+
+    raise RuntimeError(
+        "No API key found. Set OPENROUTER_API_KEY or ANTHROPIC_API_KEY "
+        "in environment or .env file."
+    )
+
+
+def load_env() -> None:
+    """Load API keys from project ``.env`` files if missing from environment."""
+    needed = ["OPENROUTER_API_KEY", "ANTHROPIC_API_KEY"]
+    if any(os.environ.get(k) for k in needed):
+        return
+
+    project_root = os.path.dirname(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    for env_file in [".env", ".env.dev"]:
+        env_path = os.path.join(project_root, env_file)
+        if not os.path.isfile(env_path):
+            continue
+        with open(env_path) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("#") or "=" not in line:
+                    continue
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip().strip("'\"")
+                if key in needed and value:
+                    os.environ[key] = value
+
+
+def diff_from_defaults(
+    config: dict[str, Any], defaults: dict[str, Any]
+) -> str:
+    """Render a comma-separated diff of *config* vs *defaults* (for prompts)."""
+    diffs: list[str] = []
+    for k, v in config.items():
+        default_v = defaults.get(k)
+        if default_v is not None and v != default_v:
+            if isinstance(v, float):
+                diffs.append(f"{k}={v:.3f}")
+            else:
+                diffs.append(f"{k}={v}")
+    return ", ".join(diffs) if diffs else "(defaults)"

--- a/eval/meta_harness/composite_evaluator.py
+++ b/eval/meta_harness/composite_evaluator.py
@@ -1,0 +1,260 @@
+"""Composite bench evaluator — combines search + rule legs in one score.
+
+Runs :class:`CodeIntelBenchEvaluator` (search + mcp_bench, weighted 0.4/0.6
+internally) and :class:`RuleBenchEvaluator` in parallel, then folds them
+into a single composite::
+
+    composite = 0.3 * search_quality + 0.5 * mcp_bench + 0.2 * rule_bench
+
+The per-language floor predicate still applies on the rule leg via
+``metadata["per_language"]`` propagation, so a candidate that wins
+search but breaks Go rules is still rejected.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import logging
+import time
+from typing import Any
+
+from attoswarm.research.evaluator import EvalResult
+
+from eval.meta_harness.evaluator import CodeIntelBenchEvaluator
+from eval.meta_harness.harness_config import HarnessConfig
+from eval.meta_harness.meta_loop import _BenchSpec
+from eval.meta_harness.rule_bench.config import RuleBenchConfig
+from eval.meta_harness.rule_bench.evaluator import RuleBenchEvaluator
+from eval.meta_harness.rule_bench.predicate import rule_accept_predicate
+
+logger = logging.getLogger(__name__)
+
+# Composite weights — search 30%, mcp_bench 50%, rule 20%.
+SEARCH_WEIGHT = 0.30
+MCP_WEIGHT = 0.50
+RULE_WEIGHT = 0.20
+
+
+@dataclasses.dataclass(slots=True)
+class CompositeConfig:
+    """Wraps both leg configs into a single optimization candidate."""
+
+    scoring: HarnessConfig = dataclasses.field(default_factory=HarnessConfig.default)
+    rule_bench: RuleBenchConfig = dataclasses.field(
+        default_factory=RuleBenchConfig.default,
+    )
+
+    @classmethod
+    def default(cls) -> CompositeConfig:
+        return cls()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scoring": self.scoring.to_dict(),
+            "rule_bench": self.rule_bench.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CompositeConfig:
+        scoring = HarnessConfig.from_dict(data.get("scoring") or {})
+        rb_raw = data.get("rule_bench") or {}
+        rule_bench = RuleBenchConfig.from_dict(rb_raw)
+        return cls(scoring=scoring, rule_bench=rule_bench)
+
+    def save_yaml(self, path: str) -> None:
+        import yaml as _yaml
+        from pathlib import Path
+
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            _yaml.safe_dump(self.to_dict(), f, sort_keys=False)
+
+    @classmethod
+    def load_yaml(cls, path: str) -> CompositeConfig:
+        import yaml as _yaml
+
+        with open(path, encoding="utf-8") as f:
+            data = _yaml.safe_load(f) or {}
+        return cls.from_dict(data)
+
+    def validate(self) -> list[str]:
+        errs = list(self.scoring.validate())
+        errs.extend(self.rule_bench.validate())
+        return errs
+
+
+class CompositeBenchEvaluator:
+    """Runs search + rule legs in parallel and folds them into a composite."""
+
+    def __init__(
+        self,
+        *,
+        search_evaluator: CodeIntelBenchEvaluator,
+        rule_evaluator: RuleBenchEvaluator,
+        config_filename: str = "composite_config.yaml",
+        search_weight: float = SEARCH_WEIGHT,
+        mcp_weight: float = MCP_WEIGHT,
+        rule_weight: float = RULE_WEIGHT,
+    ) -> None:
+        self._search = search_evaluator
+        self._rule = rule_evaluator
+        self._config_filename = config_filename
+        self._w_search = search_weight
+        self._w_mcp = mcp_weight
+        self._w_rule = rule_weight
+
+    async def evaluate(self, working_dir: str) -> EvalResult:
+        from pathlib import Path
+        import os
+        import tempfile
+
+        t0 = time.monotonic()
+
+        # Load composite config (if present) and split it across legs by
+        # writing each half into a sibling temp dir for the leg's loader.
+        config_path = os.path.join(working_dir, self._config_filename)
+        if os.path.isfile(config_path):
+            try:
+                composite = CompositeConfig.load_yaml(config_path)
+                errs = composite.validate()
+                if errs:
+                    return EvalResult(
+                        metric_value=0.0,
+                        error=f"Invalid composite config: {'; '.join(errs)}",
+                        success=False,
+                    )
+            except Exception as exc:
+                return EvalResult(
+                    metric_value=0.0,
+                    error=f"Failed to load composite config: {exc}",
+                    success=False,
+                )
+        else:
+            composite = CompositeConfig.default()
+
+        with tempfile.TemporaryDirectory() as search_tmp, \
+                tempfile.TemporaryDirectory() as rule_tmp:
+            composite.scoring.save_yaml(
+                os.path.join(search_tmp, "harness_config.yaml"),
+            )
+            composite.rule_bench.save_yaml(
+                os.path.join(rule_tmp, "rule_harness_config.yaml"),
+            )
+
+            search_task = asyncio.create_task(self._search.evaluate(search_tmp))
+            rule_task = asyncio.create_task(self._rule.evaluate(rule_tmp))
+            search_result, rule_result = await asyncio.gather(
+                search_task, rule_task,
+            )
+
+        elapsed = time.monotonic() - t0
+
+        # Pull the search-leg sub-scores so we can re-weight at the
+        # composite level rather than the search evaluator's internal 40/60.
+        search_md = search_result.metadata or {}
+        search_quality = (search_md.get("search_quality") or {}).get("composite") or 0.0
+        mcp_bench = (search_md.get("mcp_bench") or {}).get("composite") or 0.0
+        rule_score = rule_result.metric_value if rule_result.success else 0.0
+
+        composite_score = (
+            self._w_search * float(search_quality)
+            + self._w_mcp * float(mcp_bench)
+            + self._w_rule * float(rule_score)
+        )
+
+        # Forward the rule-bench per_language so the floor predicate can
+        # still reject candidates that regress any single language.
+        per_language: dict[str, float] = {}
+        rule_md = rule_result.metadata or {}
+        if isinstance(rule_md.get("per_language"), dict):
+            per_language = {
+                str(k): float(v) for k, v in rule_md["per_language"].items()
+            }
+
+        metadata: dict[str, Any] = {
+            "search_quality": search_md.get("search_quality"),
+            "mcp_bench": search_md.get("mcp_bench"),
+            "rule_bench": rule_md.get("rule_bench"),
+            "per_language": per_language,
+            "composite": round(composite_score, 4),
+            "weights": {
+                "search": self._w_search,
+                "mcp": self._w_mcp,
+                "rule": self._w_rule,
+            },
+            "elapsed_seconds": round(elapsed, 2),
+        }
+
+        return EvalResult(
+            metric_value=round(composite_score, 4),
+            raw_output=json.dumps(metadata, indent=2, default=str),
+            metadata=metadata,
+            metrics={
+                "search_composite": float(search_quality),
+                "mcp_composite": float(mcp_bench),
+                "rule_composite": float(rule_score),
+            },
+            constraint_checks={
+                "latency_ok": elapsed < 600,
+                "all_legs_ok": (
+                    search_result.success and rule_result.success
+                ),
+            },
+        )
+
+
+def build_composite_bench(args: argparse.Namespace) -> dict[str, Any]:
+    """Factory consumed by ``__main__._select_bench("composite")``."""
+    from eval.meta_harness.rule_bench.cli import build_rule_bench
+
+    search_evaluator = CodeIntelBenchEvaluator(
+        search_repos=args.search_repos.split(",") if args.search_repos else None,
+        bench_repos=args.bench_repos.split(",") if args.bench_repos else None,
+        split="" if args.no_split else "eval",
+    )
+    rule_plumbing = build_rule_bench(args)
+    rule_evaluator = rule_plumbing["evaluator"]
+
+    composite_evaluator = CompositeBenchEvaluator(
+        search_evaluator=search_evaluator,
+        rule_evaluator=rule_evaluator,
+    )
+
+    spec = _BenchSpec(
+        name="composite",
+        evaluator=composite_evaluator,
+        config_default=CompositeConfig.default(),
+        config_filename="composite_config.yaml",
+        propose_sweep=_composite_propose_stub,
+        propose_llm=_composite_propose_stub,
+        accept_predicate=rule_accept_predicate,
+        artifact_prefix="composite_",
+    )
+
+    return {
+        "name": "composite",
+        "spec": spec,
+        "evaluator": composite_evaluator,
+        "config_default": CompositeConfig.default(),
+        "config_loader": CompositeConfig.load_yaml,
+        "config_filename": "composite_config.yaml",
+        "artifact_prefix": "composite_",
+    }
+
+
+def _composite_propose_stub(
+    current_best: Any,
+    eval_metadata: dict[str, Any],
+    history: list[dict[str, Any]],
+    n_candidates: int,
+    iteration: int,
+) -> list:
+    """Composite proposer is intentionally minimal — runners typically
+    drive the search and rule benches independently, then run composite
+    to confirm joint performance. Returns no candidates so the runner
+    just re-evaluates the current best each iteration.
+    """
+    return []

--- a/eval/meta_harness/meta_loop.py
+++ b/eval/meta_harness/meta_loop.py
@@ -1,8 +1,10 @@
 """Outer-loop meta-harness runner for code-intel optimization.
 
 Orchestrates the evolution loop: propose configs → evaluate → accept/reject.
-Uses the research orchestrator as the campaign backbone when available,
-with a standalone fallback for simpler usage.
+The runner is bench-agnostic: pass any evaluator that yields ``EvalResult``,
+any config dataclass with ``to_dict``/``from_dict``/``save_yaml``/``validate``
+shape, and any propose function with the correct signature. Defaults remain
+the search bench (``CodeIntelBenchEvaluator`` + ``HarnessConfig``).
 """
 
 from __future__ import annotations
@@ -12,23 +14,71 @@ import json
 import logging
 import os
 import sys
+import tempfile
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Protocol, runtime_checkable
 
 _PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, os.path.join(_PROJECT_ROOT, "src"))
     sys.path.insert(0, _PROJECT_ROOT)
 
-import yaml
+from attoswarm.research.evaluator import EvalResult
 
 from eval.meta_harness.evaluator import CodeIntelBenchEvaluator
-from eval.meta_harness.harness_config import PARAMETER_RANGES, HarnessConfig
-from eval.meta_harness.paths import results_dir as default_results_dir
+from eval.meta_harness.harness_config import HarnessConfig
+from eval.meta_harness.paths import (
+    baseline_path as default_baseline_path,
+)
+from eval.meta_harness.paths import (
+    best_config_path as default_best_config_path,
+)
+from eval.meta_harness.paths import (
+    evolution_path as default_evolution_path,
+)
+from eval.meta_harness.paths import (
+    results_dir as default_results_dir,
+)
 
 logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class _ConfigLike(Protocol):
+    """Minimal protocol every bench config dataclass must satisfy."""
+
+    def to_dict(self) -> dict[str, Any]: ...
+    def save_yaml(self, path: str) -> None: ...
+    def validate(self) -> list[str]: ...
+
+
+# A propose function takes (current_best_config, eval_metadata, history,
+# n_candidates, iteration) and returns a list of (candidate, hypothesis)
+# tuples. Implementations may ignore arguments they don't need.
+ProposeFn = Callable[
+    [Any, dict[str, Any], list[dict[str, Any]], int, int],
+    list[tuple[Any, str]],
+]
+
+# An accept predicate decides whether a candidate's result improves on
+# current best. Returns (accepted, reason). Default: strict score > best.
+AcceptPredicate = Callable[
+    [EvalResult, EvalResult | None, float],
+    tuple[bool, str],
+]
+
+
+def default_accept_predicate(
+    result: EvalResult,
+    baseline_result: EvalResult | None,  # noqa: ARG001 - signature parity
+    current_best: float,
+) -> tuple[bool, str]:
+    """Strict-improvement predicate (preserves legacy search-bench behavior)."""
+    if result.metric_value > current_best:
+        return True, "improved"
+    return False, f"no_improvement: {result.metric_value:.4f} <= {current_best:.4f}"
 
 
 @dataclass
@@ -46,6 +96,115 @@ class EvolutionEntry:
     mcp_bench: dict[str, Any] | None = None
     timestamp: str = ""
 
+    # Rule-bench additions — optional so search-bench entries stay compact.
+    per_language: dict[str, float] | None = None
+    reject_reason: str | None = None
+    bench_metadata: dict[str, Any] | None = None
+
+
+def _default_search_propose(
+    current_best: HarnessConfig,
+    eval_metadata: dict[str, Any],
+    history: list[dict[str, Any]],
+    n_candidates: int,
+    iteration: int,
+) -> list[tuple[HarnessConfig, str]]:
+    """Default search-bench proposer — random parameter sweep."""
+    import random
+
+    from eval.meta_harness.harness_config import PARAMETER_RANGES
+
+    random.seed(42 + iteration)
+    base_dict = current_best.to_dict()
+    candidates: list[tuple[HarnessConfig, str]] = []
+    param_names = list(PARAMETER_RANGES.keys())
+
+    for _ in range(n_candidates):
+        new_dict = dict(base_dict)
+        n_params = random.randint(1, 3)
+        chosen = random.sample(param_names, min(n_params, len(param_names)))
+        changes: list[str] = []
+
+        for param in chosen:
+            lo, hi = PARAMETER_RANGES[param]
+            current = new_dict.get(param, (lo + hi) / 2)
+
+            if isinstance(lo, int) and isinstance(hi, int):
+                new_val: float | int = random.randint(int(lo), int(hi))
+            else:
+                spread = (hi - lo) * 0.2
+                new_val = max(lo, min(hi, current + random.gauss(0, spread)))
+
+            new_dict[param] = new_val
+            if isinstance(new_val, float):
+                changes.append(f"{param}: {current}->{new_val:.3f}")
+            else:
+                changes.append(f"{param}: {current}->{new_val}")
+
+        hypothesis = f"sweep: {', '.join(changes)}"
+        candidates.append((HarnessConfig.from_dict(new_dict), hypothesis))
+
+    return candidates
+
+
+def _default_search_propose_llm(
+    current_best: HarnessConfig,
+    eval_metadata: dict[str, Any],
+    history: list[dict[str, Any]],
+    n_candidates: int,
+    iteration: int,  # noqa: ARG001 - signature parity
+) -> list[tuple[HarnessConfig, str]]:
+    """Default search-bench LLM proposer — wraps ``proposer.propose_configs_llm``."""
+    from eval.meta_harness.proposer import propose_configs_llm
+
+    try:
+        return propose_configs_llm(
+            current_config=current_best,
+            eval_result=eval_metadata,
+            history=history,
+            n_candidates=n_candidates,
+        )
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.warning("LLM proposal failed (%s), returning empty list", exc)
+        return []
+
+
+@dataclass
+class _BenchSpec:
+    """Per-bench plumbing used by :class:`MetaHarnessRunner`."""
+
+    name: str
+    evaluator: Any
+    config_default: _ConfigLike
+    config_filename: str
+    propose_sweep: ProposeFn
+    propose_llm: ProposeFn
+    accept_predicate: AcceptPredicate = field(default=default_accept_predicate)
+    artifact_prefix: str = ""
+
+
+def make_search_bench_spec(
+    *,
+    search_repos: list[str] | None = None,
+    bench_repos: list[str] | None = None,
+    split: str = "eval",
+) -> _BenchSpec:
+    """Construct the default search-bench spec (back-compat shim)."""
+    return _BenchSpec(
+        name="search",
+        evaluator=CodeIntelBenchEvaluator(
+            search_repos=search_repos,
+            bench_repos=bench_repos,
+            split=split,
+        ),
+        config_default=HarnessConfig.default(),
+        config_filename="harness_config.yaml",
+        propose_sweep=_default_search_propose,
+        propose_llm=_default_search_propose_llm,
+        accept_predicate=default_accept_predicate,
+        artifact_prefix="",
+    )
+
 
 class MetaHarnessRunner:
     """Standalone meta-harness optimization loop.
@@ -54,8 +213,11 @@ class MetaHarnessRunner:
     1. Loads current best config (or baseline defaults)
     2. Generates candidate configs (via LLM proposer or parameter sweep)
     3. Evaluates each candidate
-    4. Accepts if score improves over current best
-    5. Logs evolution_summary.jsonl
+    4. Calls the bench's ``accept_predicate`` to decide accept/reject
+    5. Logs the evolution entry to JSONL
+
+    The default constructor preserves legacy search-bench behavior. Pass
+    ``bench_spec=`` to drive a different bench (e.g. rule-bench).
     """
 
     def __init__(
@@ -66,36 +228,56 @@ class MetaHarnessRunner:
         bench_repos: list[str] | None = None,
         results_dir: str | None = None,
         propose_mode: str = "sweep",  # "sweep" | "llm"
+        *,
+        bench_spec: _BenchSpec | None = None,
     ) -> None:
         self._iterations = iterations
         self._candidates_per_iter = candidates_per_iteration
         self._results_dir = Path(results_dir or default_results_dir())
         self._propose_mode = propose_mode
 
-        self._evaluator = CodeIntelBenchEvaluator(
+        self._spec = bench_spec or make_search_bench_spec(
             search_repos=search_repos,
             bench_repos=bench_repos,
-            split="eval",
         )
 
-        self._best_config = HarnessConfig.default()
+        self._best_config: _ConfigLike = self._spec.config_default
         self._best_score = 0.0
         self._baseline_score = 0.0
+        self._baseline_result: EvalResult | None = None
         self._history: list[EvolutionEntry] = []
-        self._last_eval_metadata: dict[str, Any] = {}  # for LLM proposer context
+        self._last_eval_metadata: dict[str, Any] = {}
+
+    # ---------------------------------------------------------------
+    # Path helpers (per-bench prefixed)
+    # ---------------------------------------------------------------
+
+    def _baseline_artifact(self) -> Path:
+        return Path(default_baseline_path(self._spec.artifact_prefix))
+
+    def _evolution_artifact(self) -> Path:
+        return Path(default_evolution_path(self._spec.artifact_prefix))
+
+    def _best_config_artifact(self) -> Path:
+        return Path(default_best_config_path(self._spec.artifact_prefix))
+
+    # ---------------------------------------------------------------
+    # Main loop
+    # ---------------------------------------------------------------
 
     async def run(self) -> None:
         """Run the full evolution loop."""
         self._results_dir.mkdir(parents=True, exist_ok=True)
-        evo_path = self._results_dir / "evolution_summary.jsonl"
+        evo_path = self._evolution_artifact()
 
         # Phase 0: Evaluate baseline
-        print("Phase 0: Evaluating baseline...")
-        baseline_result = await self._evaluator.evaluate(_PROJECT_ROOT)
+        print(f"Phase 0: Evaluating baseline ({self._spec.name} bench)...")
+        baseline_result = await self._spec.evaluator.evaluate(_PROJECT_ROOT)
         if not baseline_result.success:
             print(f"Baseline evaluation failed: {baseline_result.error}")
             return
 
+        self._baseline_result = baseline_result
         self._baseline_score = baseline_result.metric_value
         self._best_score = baseline_result.metric_value
         self._last_eval_metadata = baseline_result.metadata or {}
@@ -105,11 +287,13 @@ class MetaHarnessRunner:
         # Save baseline
         baseline_data = {
             "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+            "bench": self._spec.name,
             "composite_score": baseline_result.metric_value,
             "metrics": baseline_result.metrics,
+            "metadata": baseline_result.metadata,
             "config": self._best_config.to_dict(),
         }
-        with open(self._results_dir / "baseline.json", "w") as f:
+        with open(self._baseline_artifact(), "w") as f:
             json.dump(baseline_data, f, indent=2, default=str)
 
         # Evolution iterations
@@ -117,7 +301,6 @@ class MetaHarnessRunner:
             print(f"\nIteration {iteration}/{self._iterations}")
             print(f"  Current best: {self._best_score:.4f}")
 
-            # Generate candidates: list of (HarnessConfig, hypothesis) tuples
             raw_candidates = self._propose_candidates(iteration)
             print(f"  Generated {len(raw_candidates)} candidates")
 
@@ -130,11 +313,9 @@ class MetaHarnessRunner:
                 if hypothesis:
                     print(f"  Candidate {i} hypothesis: {hypothesis[:80]}")
 
-                # Evaluate
-                import tempfile
                 with tempfile.TemporaryDirectory() as tmpdir:
-                    candidate.save_yaml(os.path.join(tmpdir, "harness_config.yaml"))
-                    result = await self._evaluator.evaluate(tmpdir)
+                    candidate.save_yaml(os.path.join(tmpdir, self._spec.config_filename))
+                    result = await self._spec.evaluator.evaluate(tmpdir)
 
                 if not result.success:
                     entry = EvolutionEntry(
@@ -146,6 +327,7 @@ class MetaHarnessRunner:
                         delta=0.0,
                         hypothesis=hypothesis,
                         timestamp=time.strftime("%Y-%m-%d %H:%M:%S"),
+                        reject_reason=f"error: {result.error}",
                     )
                     self._history.append(entry)
                     self._write_entry(evo_path, entry)
@@ -155,18 +337,23 @@ class MetaHarnessRunner:
                 score = result.metric_value
                 delta = score - self._best_score
 
-                if score > self._best_score:
+                accepted, reason = self._spec.accept_predicate(
+                    result, self._baseline_result, self._best_score,
+                )
+
+                if accepted:
                     status = "accepted"
                     self._best_score = score
                     self._best_config = candidate
                     self._last_eval_metadata = result.metadata or {}
                     self._last_eval_metadata["composite"] = score
-                    candidate.save_yaml(str(self._results_dir / "best_config.yaml"))
+                    candidate.save_yaml(str(self._best_config_artifact()))
                     print(f"  Candidate {i}: ACCEPTED score={score:.4f} delta={delta:+.4f}")
                 else:
                     status = "rejected"
-                    print(f"  Candidate {i}: REJECTED score={score:.4f} delta={delta:+.4f}")
+                    print(f"  Candidate {i}: REJECTED score={score:.4f} delta={delta:+.4f} reason={reason}")
 
+                metadata = result.metadata or {}
                 entry = EvolutionEntry(
                     iteration=iteration,
                     config=candidate.to_dict(),
@@ -175,88 +362,54 @@ class MetaHarnessRunner:
                     baseline_score=self._baseline_score,
                     delta=delta,
                     hypothesis=hypothesis,
-                    search_quality=result.metadata.get("search_quality"),
-                    mcp_bench=result.metadata.get("mcp_bench"),
+                    search_quality=metadata.get("search_quality"),
+                    mcp_bench=metadata.get("mcp_bench"),
                     timestamp=time.strftime("%Y-%m-%d %H:%M:%S"),
+                    per_language=metadata.get("per_language"),
+                    reject_reason=None if accepted else reason,
+                    bench_metadata=metadata.get(self._spec.name),
                 )
                 self._history.append(entry)
                 self._write_entry(evo_path, entry)
 
         # Summary
         print(f"\n{'=' * 60}")
-        print(f"Evolution complete: {self._iterations} iterations")
+        print(f"Evolution complete: {self._iterations} iterations ({self._spec.name} bench)")
         print(f"  Baseline:  {self._baseline_score:.4f}")
         print(f"  Best:      {self._best_score:.4f}")
         print(f"  Delta:     {self._best_score - self._baseline_score:+.4f}")
         accepted = sum(1 for e in self._history if e.status == "accepted")
         print(f"  Accepted:  {accepted}/{len(self._history)} candidates")
         if self._best_score > self._baseline_score:
-            print(f"\n  Best config saved to: {self._results_dir / 'best_config.yaml'}")
+            print(f"\n  Best config saved to: {self._best_config_artifact()}")
 
-    def _propose_candidates(self, iteration: int) -> list[tuple[HarnessConfig, str]]:
-        """Generate candidate configs for this iteration.
+    # ---------------------------------------------------------------
+    # Proposer dispatch
+    # ---------------------------------------------------------------
 
-        Returns list of (HarnessConfig, hypothesis) tuples.
-        """
-        if self._propose_mode == "llm":
-            return self._propose_llm(iteration)
-        return self._propose_sweep(iteration)
-
-    def _propose_sweep(self, iteration: int) -> list[tuple[HarnessConfig, str]]:
-        """Random parameter perturbation."""
-        import random
-        random.seed(42 + iteration)
-
-        base_dict = self._best_config.to_dict()
-        candidates: list[tuple[HarnessConfig, str]] = []
-
-        param_names = list(PARAMETER_RANGES.keys())
-
-        for _ in range(self._candidates_per_iter):
-            new_dict = dict(base_dict)
-            n_params = random.randint(1, 3)
-            chosen = random.sample(param_names, min(n_params, len(param_names)))
-            changes: list[str] = []
-
-            for param in chosen:
-                lo, hi = PARAMETER_RANGES[param]
-                current = new_dict.get(param, (lo + hi) / 2)
-
-                if isinstance(lo, int) and isinstance(hi, int):
-                    new_val = random.randint(int(lo), int(hi))
-                else:
-                    spread = (hi - lo) * 0.2
-                    new_val = max(lo, min(hi, current + random.gauss(0, spread)))
-
-                new_dict[param] = new_val
-                changes.append(f"{param}: {current}->{new_val:.3f}" if isinstance(new_val, float) else f"{param}: {current}->{new_val}")
-
-            hypothesis = f"sweep: {', '.join(changes)}"
-            candidates.append((HarnessConfig.from_dict(new_dict), hypothesis))
-
-        return candidates
-
-    def _propose_llm(self, iteration: int) -> list[tuple[HarnessConfig, str]]:
-        """Use Claude to propose configs based on failure analysis."""
-        from eval.meta_harness.proposer import propose_configs_llm
-
+    def _propose_candidates(self, iteration: int) -> list[tuple[Any, str]]:
         history_dicts = [asdict(e) for e in self._history]
-
-        print(f"  Calling Claude for proposals...")
-        try:
-            candidates = propose_configs_llm(
-                current_config=self._best_config,
-                eval_result=self._last_eval_metadata,
-                history=history_dicts,
-                n_candidates=self._candidates_per_iter,
-            )
-            if not candidates:
-                print(f"  LLM returned no valid candidates, falling back to sweep")
-                return self._propose_sweep(iteration)
-            return candidates
-        except Exception as exc:
-            print(f"  LLM proposal failed ({exc}), falling back to sweep")
-            return self._propose_sweep(iteration)
+        if self._propose_mode == "llm":
+            try:
+                candidates = self._spec.propose_llm(
+                    self._best_config,
+                    self._last_eval_metadata,
+                    history_dicts,
+                    self._candidates_per_iter,
+                    iteration,
+                )
+                if candidates:
+                    return candidates
+                print("  LLM returned no valid candidates, falling back to sweep")
+            except Exception as exc:
+                print(f"  LLM proposal failed ({exc}), falling back to sweep")
+        return self._spec.propose_sweep(
+            self._best_config,
+            self._last_eval_metadata,
+            history_dicts,
+            self._candidates_per_iter,
+            iteration,
+        )
 
     @staticmethod
     def _write_entry(path: Path, entry: EvolutionEntry) -> None:

--- a/eval/meta_harness/paths.py
+++ b/eval/meta_harness/paths.py
@@ -5,6 +5,10 @@ Separation of concerns:
 - Ephemeral results (gitignored under ``.attocode/meta_harness/``): per-run outputs
 
 Override via ``ATTOCODE_META_HARNESS_RESULTS`` env var.
+
+Bench mode artifacts share the same results directory but use a per-bench
+prefix on filenames (e.g. ``rule_baseline.json``, ``rule_evolution.jsonl``)
+so multiple benches can coexist without clobbering each other.
 """
 
 from __future__ import annotations
@@ -21,6 +25,11 @@ BEST_CONFIG_REFERENCE = os.path.join(CONFIGS_DIR, "best_config.yaml")
 # Ephemeral results — gitignored by living under .attocode/
 DEFAULT_RESULTS_DIR = os.path.join(_PROJECT_ROOT, ".attocode", "meta_harness", "results")
 
+# Default artifact filenames (search bench, no prefix for back-compat)
+BASELINE_NAME = "baseline.json"
+EVOLUTION_NAME = "evolution_summary.jsonl"
+BEST_CONFIG_NAME = "best_config.yaml"
+
 
 def results_dir() -> str:
     """Get the ephemeral results directory (env-overridable)."""
@@ -32,3 +41,29 @@ def ensure_results_dir() -> str:
     path = results_dir()
     os.makedirs(path, exist_ok=True)
     return path
+
+
+def prefixed(name: str, prefix: str = "") -> str:
+    """Prepend *prefix* to *name* if non-empty.
+
+    Used so each bench mode (search/rule/composite) writes its artifacts
+    side-by-side in the results dir without conflicting filenames.
+    """
+    if not prefix:
+        return name
+    return f"{prefix}{name}" if prefix.endswith("_") else f"{prefix}_{name}"
+
+
+def baseline_path(prefix: str = "") -> str:
+    """Path to ``[prefix_]baseline.json`` in the results dir."""
+    return os.path.join(results_dir(), prefixed(BASELINE_NAME, prefix))
+
+
+def evolution_path(prefix: str = "") -> str:
+    """Path to ``[prefix_]evolution_summary.jsonl`` in the results dir."""
+    return os.path.join(results_dir(), prefixed(EVOLUTION_NAME, prefix))
+
+
+def best_config_path(prefix: str = "") -> str:
+    """Path to ``[prefix_]best_config.yaml`` in the results dir."""
+    return os.path.join(results_dir(), prefixed(BEST_CONFIG_NAME, prefix))

--- a/eval/meta_harness/proposer.py
+++ b/eval/meta_harness/proposer.py
@@ -6,7 +6,6 @@ parameter configurations based on failure analysis.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import re
@@ -14,7 +13,8 @@ from typing import Any
 
 import yaml
 
-from eval.meta_harness.harness_config import PARAMETER_RANGES, HarnessConfig
+from eval.meta_harness._llm_client import call_llm, diff_from_defaults, load_env
+from eval.meta_harness.harness_config import HarnessConfig
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +48,9 @@ def _build_prompt(
     if history:
         recent = history[-10:]
         lines = []
+        defaults = HarnessConfig.default().to_dict()
         for h in recent:
-            cfg_changes = _diff_from_defaults(h.get("config", {}))
+            cfg_changes = diff_from_defaults(h.get("config", {}), defaults)
             lines.append(
                 f"  - score={h.get('score', 0):.4f} status={h.get('status', '?')} "
                 f"changes: {cfg_changes}"
@@ -198,75 +199,16 @@ def propose_configs_llm(
     Returns:
         List of (HarnessConfig, hypothesis) tuples.
     """
-    _load_env()
+    load_env()
 
     prompt = _build_prompt(current_config, eval_result, history, n_candidates)
-    text = _call_llm(prompt, model)
+    text = call_llm(prompt, model)
     return _parse_candidates(text)
 
 
-def _call_llm(prompt: str, model: str = "") -> str:
-    """Call the LLM via OpenRouter or Anthropic direct."""
-    import openai
-
-    or_key = os.environ.get("OPENROUTER_API_KEY", "")
-    anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
-
-    if or_key:
-        # OpenRouter via OpenAI-compatible API
-        if not model:
-            model = "anthropic/claude-sonnet-4"
-        client = openai.OpenAI(
-            base_url="https://openrouter.ai/api/v1",
-            api_key=or_key,
-        )
-        response = client.chat.completions.create(
-            model=model,
-            max_tokens=4096,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        return response.choices[0].message.content or ""
-
-    elif anthropic_key:
-        import anthropic
-        if not model:
-            model = "claude-sonnet-4-20250514"
-        client = anthropic.Anthropic(api_key=anthropic_key)
-        response = client.messages.create(
-            model=model,
-            max_tokens=4096,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        return response.content[0].text
-
-    else:
-        raise RuntimeError(
-            "No API key found. Set OPENROUTER_API_KEY or ANTHROPIC_API_KEY "
-            "in environment or .env file."
-        )
-
-
-def _load_env() -> None:
-    """Load API keys from .env files if not already in environment."""
-    needed = ["OPENROUTER_API_KEY", "ANTHROPIC_API_KEY"]
-    if any(os.environ.get(k) for k in needed):
-        return
-
-    project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    for env_file in [".env", ".env.dev"]:
-        env_path = os.path.join(project_root, env_file)
-        if not os.path.isfile(env_path):
-            continue
-        with open(env_path) as f:
-            for line in f:
-                line = line.strip()
-                if line.startswith("#") or "=" not in line:
-                    continue
-                key, _, value = line.partition("=")
-                key = key.strip()
-                value = value.strip().strip("'\"")
-                if key in needed and value:
-                    os.environ[key] = value
+def _diff_from_defaults(config: dict[str, Any]) -> str:
+    """Backward-compat shim — see :func:`_llm_client.diff_from_defaults`."""
+    return diff_from_defaults(config, HarnessConfig.default().to_dict())
 
 
 def _parse_candidates(text: str) -> list[tuple[HarnessConfig, str]]:

--- a/eval/meta_harness/rule_bench/__init__.py
+++ b/eval/meta_harness/rule_bench/__init__.py
@@ -1,0 +1,34 @@
+"""Rule-bench harness — measures rule precision/recall to drive optimization.
+
+Plugs into :class:`eval.meta_harness.meta_loop.MetaHarnessRunner` via the
+``BenchSpec`` interface so the same outer loop, proposer, and evolution
+journal can optimize rule packs alongside search-scoring parameters.
+"""
+
+from eval.meta_harness.rule_bench.corpus import (
+    CorpusLoader,
+    ExpectedFinding,
+    LabeledSample,
+)
+from eval.meta_harness.rule_bench.scoring import (
+    DEFAULT_SEVERITY_WEIGHTS,
+    LanguageScore,
+    RuleBenchResult,
+    RuleScore,
+    aggregate_per_language,
+    compute_composite,
+    severity_weighted_f1,
+)
+
+__all__ = [
+    "DEFAULT_SEVERITY_WEIGHTS",
+    "CorpusLoader",
+    "ExpectedFinding",
+    "LabeledSample",
+    "LanguageScore",
+    "RuleBenchResult",
+    "RuleScore",
+    "aggregate_per_language",
+    "compute_composite",
+    "severity_weighted_f1",
+]

--- a/eval/meta_harness/rule_bench/cli.py
+++ b/eval/meta_harness/rule_bench/cli.py
@@ -1,0 +1,69 @@
+"""CLI factory for the rule-bench mode.
+
+``__main__._select_bench`` calls :func:`build_rule_bench` to assemble the
+plumbing dict consumed by ``cmd_baseline`` / ``cmd_evaluate`` / ``cmd_run``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from eval.meta_harness.meta_loop import _BenchSpec
+from eval.meta_harness.rule_bench.config import RuleBenchConfig
+from eval.meta_harness.rule_bench.evaluator import RuleBenchEvaluator
+from eval.meta_harness.rule_bench.predicate import rule_accept_predicate
+from eval.meta_harness.rule_bench.proposer import (
+    propose_llm_rule_overrides,
+    propose_sweep_rule_overrides,
+)
+
+
+def build_rule_bench(args: argparse.Namespace) -> dict[str, Any]:
+    """Assemble the rule-bench plumbing from parsed CLI args.
+
+    Recognized args:
+        --packs              comma-separated pack names to load
+        --include-community  include packs/community/* (default: True
+                             when --packs unset, False when --packs given
+                             unless explicitly passed)
+        --include-attocode-fixtures  include hand-labeled attocode corpus
+        --include-legacy-corpus      include eval/rule_accuracy/corpus
+    """
+    packs: list[str] = []
+    if getattr(args, "packs", None):
+        packs = [p.strip() for p in args.packs.split(",") if p.strip()]
+
+    # Default inclusion: if user gave --packs, narrow to those; otherwise
+    # include every source so the harness has something to score.
+    include_community = bool(getattr(args, "include_community", False)) or not packs
+    include_attocode = bool(getattr(args, "include_attocode_fixtures", False)) or not packs
+    include_legacy = bool(getattr(args, "include_legacy_corpus", False)) or not packs
+
+    evaluator = RuleBenchEvaluator(
+        packs=packs,
+        include_community=include_community,
+        include_attocode=include_attocode,
+        include_legacy=include_legacy,
+    )
+
+    spec = _BenchSpec(
+        name="rule",
+        evaluator=evaluator,
+        config_default=RuleBenchConfig.default(),
+        config_filename="rule_harness_config.yaml",
+        propose_sweep=propose_sweep_rule_overrides,
+        propose_llm=propose_llm_rule_overrides,
+        accept_predicate=rule_accept_predicate,
+        artifact_prefix="rule_",
+    )
+
+    return {
+        "name": "rule",
+        "spec": spec,
+        "evaluator": evaluator,
+        "config_default": RuleBenchConfig.default(),
+        "config_loader": RuleBenchConfig.load_yaml,
+        "config_filename": "rule_harness_config.yaml",
+        "artifact_prefix": "rule_",
+    }

--- a/eval/meta_harness/rule_bench/config.py
+++ b/eval/meta_harness/rule_bench/config.py
@@ -1,0 +1,231 @@
+"""Rule-bench configuration: per-rule overrides + pack activation.
+
+A ``RuleBenchConfig`` describes one optimization candidate. The harness
+applies it to a *clone* of the base ``RuleRegistry`` so the original is
+never mutated — this lets repeated evaluations and parallel candidates
+coexist without leaking state.
+
+Stage-1 (tune-only) candidates only touch numeric/boolean fields:
+``enabled``, ``confidence``, ``severity``. Stage-2 (templates) populates
+``extra_rules`` with synthesized YAML — those are layered onto the cloned
+registry the same way overrides are.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from attocode.code_intel.rules.loader import _parse_yaml_rule
+from attocode.code_intel.rules.model import (
+    RuleSeverity,
+    RuleSource,
+    UnifiedRule,
+)
+from attocode.code_intel.rules.registry import RuleRegistry
+
+logger = logging.getLogger(__name__)
+
+_VALID_SEVERITIES = {s.value for s in RuleSeverity}
+
+
+@dataclass(slots=True)
+class RuleOverride:
+    """Per-rule tunable overrides. ``None`` fields inherit from the base rule."""
+
+    rule_id: str  # qualified id (e.g. "python/py-mutable-default-arg")
+    enabled: bool | None = None
+    confidence_override: float | None = None
+    severity_override: str | None = None  # RuleSeverity value
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"rule_id": self.rule_id}
+        if self.enabled is not None:
+            out["enabled"] = self.enabled
+        if self.confidence_override is not None:
+            out["confidence_override"] = round(self.confidence_override, 4)
+        if self.severity_override is not None:
+            out["severity_override"] = self.severity_override
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RuleOverride:
+        return cls(
+            rule_id=str(data["rule_id"]),
+            enabled=data.get("enabled"),
+            confidence_override=data.get("confidence_override"),
+            severity_override=data.get("severity_override"),
+        )
+
+
+@dataclass(slots=True)
+class RuleBenchConfig:
+    """One rule-bench optimization candidate."""
+
+    rule_overrides: dict[str, RuleOverride] = field(default_factory=dict)
+    pack_activation: dict[str, bool] = field(default_factory=dict)
+    global_min_confidence: float = 0.5
+    enabled_languages: list[str] = field(default_factory=list)
+    extra_rules: list[dict[str, Any]] = field(default_factory=list)
+
+    @classmethod
+    def default(cls) -> RuleBenchConfig:
+        return cls()
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate(self) -> list[str]:
+        errors: list[str] = []
+        for ov in self.rule_overrides.values():
+            if ov.confidence_override is not None and not (
+                0.0 <= ov.confidence_override <= 1.0
+            ):
+                errors.append(
+                    f"override {ov.rule_id}: confidence_override out of [0,1]: "
+                    f"{ov.confidence_override}"
+                )
+            if (
+                ov.severity_override is not None
+                and ov.severity_override not in _VALID_SEVERITIES
+            ):
+                errors.append(
+                    f"override {ov.rule_id}: invalid severity_override "
+                    f"{ov.severity_override!r}"
+                )
+        if not (0.0 <= self.global_min_confidence <= 0.95):
+            errors.append(
+                f"global_min_confidence out of [0,0.95]: {self.global_min_confidence}"
+            )
+        return errors
+
+    # ------------------------------------------------------------------
+    # Apply to registry — never mutates caller's registry
+    # ------------------------------------------------------------------
+
+    def apply_to_registry(self, base_registry: RuleRegistry) -> RuleRegistry:
+        """Return a fresh ``RuleRegistry`` with overrides + extras applied.
+
+        The base registry is read-only after construction in this codebase,
+        but we still clone defensively so retries / parallel evaluations
+        never share mutable state.
+        """
+        cloned = RuleRegistry()
+
+        for rule in base_registry.all_rules(enabled_only=False):
+            # Pack-level toggle wins over per-rule (a deactivated pack
+            # disables every rule it ships).
+            pack_enabled = self.pack_activation.get(rule.pack)
+            if pack_enabled is False:
+                replacement = dataclasses.replace(rule, enabled=False)
+                cloned.register(replacement)
+                continue
+
+            # Per-rule override (qualified id first, then bare id fallback)
+            override = (
+                self.rule_overrides.get(rule.qualified_id)
+                or self.rule_overrides.get(rule.id)
+            )
+            if override is None:
+                cloned.register(rule)
+                continue
+
+            new_rule = dataclasses.replace(
+                rule,
+                enabled=rule.enabled if override.enabled is None else override.enabled,
+                confidence=(
+                    rule.confidence
+                    if override.confidence_override is None
+                    else override.confidence_override
+                ),
+                severity=(
+                    rule.severity
+                    if override.severity_override is None
+                    else RuleSeverity(override.severity_override)
+                ),
+            )
+            cloned.register(new_rule)
+
+        # Layer in stage-2 synthesized rules (parsed from raw dicts so the
+        # config can be JSON/YAML-serialized end to end).
+        for raw in self.extra_rules:
+            try:
+                rule = _parse_yaml_rule(
+                    raw,
+                    source=RuleSource.PACK,
+                    pack=str(raw.get("pack", "rule_bench_synth")),
+                    origin="rule_bench.extra_rules",
+                )
+            except Exception as exc:
+                logger.warning("Skipping invalid extra_rule: %s", exc)
+                continue
+            if rule is not None:
+                cloned.register(rule)
+
+        return cloned
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule_overrides": [ov.to_dict() for ov in self.rule_overrides.values()],
+            "pack_activation": dict(self.pack_activation),
+            "global_min_confidence": round(self.global_min_confidence, 4),
+            "enabled_languages": list(self.enabled_languages),
+            "extra_rules": list(self.extra_rules),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RuleBenchConfig:
+        overrides_raw = data.get("rule_overrides") or []
+        if isinstance(overrides_raw, dict):
+            # Tolerate legacy/alt format: {rule_id: override_dict}
+            overrides_raw = [
+                {"rule_id": rid, **(payload or {})}
+                for rid, payload in overrides_raw.items()
+            ]
+        rule_overrides = {
+            str(ov["rule_id"]): RuleOverride.from_dict(ov) for ov in overrides_raw
+        }
+        return cls(
+            rule_overrides=rule_overrides,
+            pack_activation={
+                str(k): bool(v) for k, v in (data.get("pack_activation") or {}).items()
+            },
+            global_min_confidence=float(data.get("global_min_confidence", 0.5)),
+            enabled_languages=list(data.get("enabled_languages") or []),
+            extra_rules=list(data.get("extra_rules") or []),
+        )
+
+    def save_yaml(self, path: str) -> None:
+        import yaml
+
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(self.to_dict(), f, sort_keys=True)
+
+    @classmethod
+    def load_yaml(cls, path: str) -> RuleBenchConfig:
+        import yaml
+
+        with open(path, encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+        return cls.from_dict(data)
+
+
+def merge_overrides(base: RuleBenchConfig, *patches: RuleOverride) -> RuleBenchConfig:
+    """Helper: produce a new config with additional overrides applied.
+
+    Lets the proposer compose a candidate by stacking small mutations on
+    top of the current best instead of rebuilding from scratch.
+    """
+    new = RuleBenchConfig.from_dict(base.to_dict())
+    for patch in patches:
+        new.rule_overrides[patch.rule_id] = patch
+    return new

--- a/eval/meta_harness/rule_bench/corpus.py
+++ b/eval/meta_harness/rule_bench/corpus.py
@@ -1,0 +1,225 @@
+"""Fixture corpus discovery for the rule-bench harness.
+
+Discovers labeled samples from three sources:
+
+1. Community pack fixtures — ``packs/community/<pack>/fixtures/<rule-id>/{positive,negative}.<ext>``
+2. Hand-labeled attocode fixtures — ``eval/rule_harness/fixtures/attocode/<lang>/*.<ext>``
+3. Legacy CWE corpus — ``eval/rule_accuracy/corpus/<lang>/<cwe>/{tp_,tn_}<name>.<ext>``
+
+All sources funnel through :class:`CorpusLoader.iter_samples` which yields
+:class:`LabeledSample` instances. Annotation parsing reuses
+``attocode.code_intel.rules.testing.parse_annotations`` so the harness
+respects both attocode-native ``# expect:``/``# ok:`` markers AND the
+semgrep-compat ``# ruleid:`` alias added in Step 1.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from attocode.code_intel.rules.executor import detect_language
+from attocode.code_intel.rules.packs.pack_loader import (
+    get_community_pack_dir,
+    list_community_packs,
+)
+from attocode.code_intel.rules.testing import parse_annotations
+
+# Per-pack project-relative fixture root layout under packs/community/<pack>/
+_PACK_FIXTURE_DIR = "fixtures"
+
+# Hand-labeled attocode-specific fixtures
+_ATTOCODE_FIXTURE_DIR = (
+    Path(__file__).parents[3]  # eval/meta_harness/rule_bench/ -> repo root
+    / "eval" / "rule_harness" / "fixtures" / "attocode"
+)
+
+# Legacy CWE-organized corpus from eval/rule_accuracy/
+_LEGACY_CORPUS_DIR = (
+    Path(__file__).parents[3]
+    / "eval" / "rule_accuracy" / "corpus"
+)
+
+# File extensions we'll consider as labeled samples
+_LANG_EXTENSIONS = {
+    ".py", ".pyi", ".js", ".jsx", ".mjs", ".cjs",
+    ".ts", ".tsx", ".mts", ".cts",
+    ".go", ".rs", ".java", ".kt", ".kts",
+    ".rb", ".php", ".swift", ".cs",
+    ".c", ".h", ".cpp", ".hpp", ".cc", ".cxx",
+}
+
+
+@dataclass(slots=True, frozen=True)
+class ExpectedFinding:
+    """A single annotation parsed from a labeled fixture file."""
+
+    line: int
+    rule_id: str
+    kind: str  # "expect" | "ok" | "todoruleid"
+
+
+@dataclass(slots=True)
+class LabeledSample:
+    """One source file in the corpus plus its expected findings."""
+
+    file_path: str
+    language: str
+    pack: str = ""  # empty for hand-labeled / legacy
+    cwe: str = ""  # populated from legacy corpus dir layout
+    expected_findings: list[ExpectedFinding] = field(default_factory=list)
+    has_negative_assertions: bool = False  # any "# ok:" or "# no-expect:" markers
+
+
+class CorpusLoader:
+    """Iterate labeled samples from all enabled corpus sources."""
+
+    def __init__(
+        self,
+        *,
+        include_community: bool = True,
+        include_attocode: bool = True,
+        include_legacy: bool = True,
+        enabled_packs: set[str] | None = None,
+        community_dir: Path | None = None,
+        attocode_dir: Path | None = None,
+        legacy_dir: Path | None = None,
+    ) -> None:
+        self._include_community = include_community
+        self._include_attocode = include_attocode
+        self._include_legacy = include_legacy
+        # ``None`` means "no filter, take all enabled packs found on disk".
+        # An empty set means "no community fixtures" — the explicit zero state.
+        self._enabled_packs = enabled_packs
+        self._community_dir = community_dir or get_community_pack_dir()
+        self._attocode_dir = attocode_dir or _ATTOCODE_FIXTURE_DIR
+        self._legacy_dir = legacy_dir or _LEGACY_CORPUS_DIR
+
+    # ------------------------------------------------------------------
+    # Iteration
+    # ------------------------------------------------------------------
+
+    def iter_samples(self) -> Iterator[LabeledSample]:
+        if self._include_community:
+            yield from self._iter_community()
+        if self._include_attocode:
+            yield from self._iter_attocode()
+        if self._include_legacy:
+            yield from self._iter_legacy()
+
+    def sample_count_by_language(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for sample in self.iter_samples():
+            counts[sample.language] = counts.get(sample.language, 0) + 1
+        return counts
+
+    # ------------------------------------------------------------------
+    # Community pack fixtures
+    # ------------------------------------------------------------------
+
+    def _iter_community(self) -> Iterator[LabeledSample]:
+        if not self._community_dir.is_dir():
+            return
+        # Enumerate manifests so we know each pack's name even if its
+        # fixtures dir is empty (informational only — empty dirs yield zero
+        # samples). Falls back to directory walk if pack_loader is missing
+        # the community dir entirely.
+        try:
+            manifests = list_community_packs()
+        except Exception:
+            manifests = []
+        manifest_packs = {m.name for m in manifests}
+        for entry in sorted(self._community_dir.iterdir()):
+            if not entry.is_dir() or entry.name.startswith("_"):
+                continue
+            pack = entry.name
+            if pack not in manifest_packs:
+                # Stale dir without a manifest — skip rather than guess.
+                continue
+            if self._enabled_packs is not None and pack not in self._enabled_packs:
+                continue
+            fixtures_root = entry / _PACK_FIXTURE_DIR
+            if not fixtures_root.is_dir():
+                continue
+            for rule_dir in sorted(fixtures_root.iterdir()):
+                if not rule_dir.is_dir():
+                    continue
+                for fixture in sorted(rule_dir.iterdir()):
+                    sample = self._load_sample(str(fixture), pack=pack)
+                    if sample is not None:
+                        yield sample
+
+    # ------------------------------------------------------------------
+    # Hand-labeled attocode-specific fixtures
+    # ------------------------------------------------------------------
+
+    def _iter_attocode(self) -> Iterator[LabeledSample]:
+        if not self._attocode_dir.is_dir():
+            return
+        for lang_dir in sorted(self._attocode_dir.iterdir()):
+            if not lang_dir.is_dir():
+                continue
+            for fixture in sorted(lang_dir.rglob("*")):
+                if not fixture.is_file():
+                    continue
+                sample = self._load_sample(str(fixture), pack="attocode")
+                if sample is not None:
+                    yield sample
+
+    # ------------------------------------------------------------------
+    # Legacy CWE-organized corpus
+    # ------------------------------------------------------------------
+
+    def _iter_legacy(self) -> Iterator[LabeledSample]:
+        if not self._legacy_dir.is_dir():
+            return
+        for lang_dir in sorted(self._legacy_dir.iterdir()):
+            if not lang_dir.is_dir():
+                continue
+            for cwe_dir in sorted(lang_dir.iterdir()):
+                if not cwe_dir.is_dir():
+                    continue
+                for fixture in sorted(cwe_dir.iterdir()):
+                    sample = self._load_sample(
+                        str(fixture), pack="legacy", cwe=cwe_dir.name,
+                    )
+                    if sample is not None:
+                        yield sample
+
+    # ------------------------------------------------------------------
+    # Per-file loader (shared)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _load_sample(
+        file_path: str, *, pack: str = "", cwe: str = "",
+    ) -> LabeledSample | None:
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext not in _LANG_EXTENSIONS:
+            return None
+        language = detect_language(file_path)
+        if not language:
+            return None
+
+        annotations = parse_annotations(file_path)
+        expected: list[ExpectedFinding] = [
+            ExpectedFinding(line=a.line, rule_id=a.rule_id, kind=a.kind)
+            for a in annotations
+        ]
+        has_negatives = any(a.kind == "ok" for a in annotations)
+
+        # Skip files with neither expectations nor negative assertions —
+        # they're fixture scaffolding (imports, helpers) not labeled signal.
+        if not expected and not has_negatives:
+            return None
+
+        return LabeledSample(
+            file_path=file_path,
+            language=language,
+            pack=pack,
+            cwe=cwe,
+            expected_findings=expected,
+            has_negative_assertions=has_negatives,
+        )

--- a/eval/meta_harness/rule_bench/evaluator.py
+++ b/eval/meta_harness/rule_bench/evaluator.py
@@ -1,0 +1,390 @@
+"""Rule-bench inner-loop evaluator.
+
+Loads the active rule registry, applies a candidate's overrides, runs
+rules over the labeled fixture corpus, scores per-rule TP/FP/FN, then
+aggregates to severity-weighted F1 per language. The result feeds the
+outer ``MetaHarnessRunner`` like any other ``EvalResult``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from collections import defaultdict
+from typing import Any
+
+from attoswarm.research.evaluator import EvalResult
+
+from attocode.code_intel.rules.executor import execute_rules
+from attocode.code_intel.rules.filters.pipeline import run_pipeline
+from attocode.code_intel.rules.loader import load_yaml_rules
+from attocode.code_intel.rules.model import (
+    RuleSource,
+    UnifiedRule,
+)
+from attocode.code_intel.rules.packs.pack_loader import (
+    get_community_pack_dir,
+    list_community_packs,
+)
+from attocode.code_intel.rules.registry import RuleRegistry
+from attocode.code_intel.rules.testing import _finding_matches_rule
+
+from eval.meta_harness.rule_bench.config import RuleBenchConfig
+from eval.meta_harness.rule_bench.corpus import CorpusLoader, LabeledSample
+from eval.meta_harness.rule_bench.scoring import (
+    DEFAULT_SEVERITY_WEIGHTS,
+    RuleBenchResult,
+    RuleScore,
+    aggregate_per_language,
+    compute_composite,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RuleBenchEvaluator:
+    """Evaluator that scores a ``RuleBenchConfig`` against a labeled corpus.
+
+    Mirrors the contract of :class:`CodeIntelBenchEvaluator` so the same
+    outer loop drives both. ``evaluate(working_dir)`` reads
+    ``rule_harness_config.yaml`` from ``working_dir`` if present; otherwise
+    uses defaults.
+    """
+
+    def __init__(
+        self,
+        *,
+        packs: list[str] | None = None,
+        corpus_dir: str | None = None,
+        severity_weights: dict[str, float] | None = None,
+        config_filename: str = "rule_harness_config.yaml",
+        include_community: bool = True,
+        include_attocode: bool = True,
+        include_legacy: bool = True,
+    ) -> None:
+        self._packs = list(packs) if packs else []
+        self._corpus_dir = corpus_dir
+        self._severity_weights = severity_weights or DEFAULT_SEVERITY_WEIGHTS
+        self._config_filename = config_filename
+        self._include_community = include_community
+        self._include_attocode = include_attocode
+        self._include_legacy = include_legacy
+
+        # Cache: base registry + corpus get built once per evaluator instance.
+        self._base_registry: RuleRegistry | None = None
+        self._corpus: list[LabeledSample] | None = None
+
+    # ------------------------------------------------------------------
+    # Lazy initialization (so import time stays cheap)
+    # ------------------------------------------------------------------
+
+    def _build_base_registry(self) -> RuleRegistry:
+        if self._base_registry is not None:
+            return self._base_registry
+
+        registry = RuleRegistry()
+        loaded_packs: set[str] = set()
+
+        # 1. Shipped example packs the harness was asked to load
+        if self._packs:
+            from attocode.code_intel.rules.packs.pack_loader import (
+                _EXAMPLES_DIR,  # type: ignore[attr-defined]
+            )
+            for pack in self._packs:
+                pack_dir = _EXAMPLES_DIR / pack
+                if not pack_dir.is_dir():
+                    continue
+                rules_dir = pack_dir / "rules"
+                if not rules_dir.is_dir():
+                    rules_dir = pack_dir
+                rules = load_yaml_rules(
+                    rules_dir, source=RuleSource.PACK, pack=pack,
+                )
+                for r in rules:
+                    registry.register(r)
+                loaded_packs.add(pack)
+
+        # 2. Community packs (when included)
+        if self._include_community:
+            community_dir = get_community_pack_dir()
+            if community_dir.is_dir():
+                for manifest in list_community_packs():
+                    if self._packs and manifest.name not in self._packs:
+                        continue
+                    pack_dir = community_dir / manifest.name
+                    rules_dir = pack_dir / "rules"
+                    if not rules_dir.is_dir():
+                        rules_dir = pack_dir
+                    rules = load_yaml_rules(
+                        rules_dir, source=RuleSource.PACK, pack=manifest.name,
+                    )
+                    for r in rules:
+                        registry.register(r)
+                    loaded_packs.add(manifest.name)
+
+        logger.info(
+            "Rule-bench registry: %d rules across %d packs",
+            registry.count, len(loaded_packs),
+        )
+        self._base_registry = registry
+        return registry
+
+    def _build_corpus(self) -> list[LabeledSample]:
+        if self._corpus is not None:
+            return self._corpus
+
+        # If --packs was given, narrow the community fixtures to the same set.
+        enabled_packs: set[str] | None = (
+            set(self._packs) if self._packs else None
+        )
+        loader = CorpusLoader(
+            include_community=self._include_community,
+            include_attocode=self._include_attocode,
+            include_legacy=self._include_legacy,
+            enabled_packs=enabled_packs,
+        )
+        corpus = list(loader.iter_samples())
+        logger.info("Rule-bench corpus: %d labeled samples", len(corpus))
+        self._corpus = corpus
+        return corpus
+
+    # ------------------------------------------------------------------
+    # Public evaluator contract
+    # ------------------------------------------------------------------
+
+    async def evaluate(self, working_dir: str) -> EvalResult:
+        t0 = time.monotonic()
+
+        config_path = os.path.join(working_dir, self._config_filename)
+        if os.path.isfile(config_path):
+            try:
+                config = RuleBenchConfig.load_yaml(config_path)
+                errors = config.validate()
+                if errors:
+                    return EvalResult(
+                        metric_value=0.0,
+                        error=f"Invalid config: {'; '.join(errors)}",
+                        success=False,
+                    )
+            except Exception as exc:
+                return EvalResult(
+                    metric_value=0.0,
+                    error=f"Failed to load config: {exc}",
+                    success=False,
+                )
+        else:
+            config = RuleBenchConfig.default()
+
+        try:
+            base_registry = self._build_base_registry()
+            corpus = self._build_corpus()
+        except Exception as exc:  # pragma: no cover - defensive
+            return EvalResult(
+                metric_value=0.0,
+                error=f"Setup failed: {exc}",
+                success=False,
+            )
+
+        if base_registry.count == 0:
+            return EvalResult(
+                metric_value=0.0,
+                error="Empty rule registry — pass --packs",
+                success=False,
+            )
+        if not corpus:
+            return EvalResult(
+                metric_value=0.0,
+                error="Empty corpus — no labeled fixtures discovered",
+                success=False,
+            )
+
+        cloned = config.apply_to_registry(base_registry)
+
+        # Filter corpus by enabled languages (if any)
+        if config.enabled_languages:
+            allowed = set(config.enabled_languages)
+            corpus = [s for s in corpus if s.language in allowed]
+
+        result = self._score_corpus(cloned, corpus, config.global_min_confidence)
+        elapsed = time.monotonic() - t0
+
+        per_lang_scalars = result.per_language_scalars()
+        rule_bench_payload = result.to_dict()
+        metadata: dict[str, Any] = {
+            "rule_bench": rule_bench_payload,
+            "per_language": per_lang_scalars,
+            "config": config.to_dict(),
+            "elapsed_seconds": round(elapsed, 2),
+        }
+
+        return EvalResult(
+            metric_value=round(result.composite_score, 4),
+            raw_output=json.dumps(rule_bench_payload, indent=2, default=str),
+            metadata=metadata,
+            metrics={
+                "weighted_f1": round(result.weighted_f1, 4),
+                "precision": round(result.precision, 4),
+                "recall": round(result.recall, 4),
+            },
+            constraint_checks={
+                "latency_ok": elapsed < 300,
+                "any_per_lang_signal": bool(per_lang_scalars),
+            },
+        )
+
+    # ------------------------------------------------------------------
+    # Scoring (pure)
+    # ------------------------------------------------------------------
+
+    def _score_corpus(
+        self,
+        registry: RuleRegistry,
+        corpus: list[LabeledSample],
+        min_confidence: float,
+    ) -> RuleBenchResult:
+        # Run only enabled rules, but score every rule so disabled rules
+        # still surface in the per-rule report (their unmet expects become
+        # FNs the proposer can see).
+        enabled_rules = registry.all_rules(enabled_only=True)
+        all_rules = registry.all_rules(enabled_only=False)
+        rule_index: dict[str, UnifiedRule] = {r.qualified_id: r for r in all_rules}
+
+        rule_scores: dict[str, RuleScore] = {}
+        for r in all_rules:
+            language = r.languages[0] if r.languages else ""
+            rule_scores[r.qualified_id] = RuleScore(
+                rule_id=r.qualified_id,
+                pack=r.pack,
+                language=language,
+                severity=r.severity,
+                enabled=r.enabled,
+            )
+
+        rules = enabled_rules
+
+        annotations_total = 0
+        fixture_counts_by_language: dict[str, int] = defaultdict(int)
+
+        for sample in corpus:
+            fixture_counts_by_language[sample.language] += 1
+            annotations_total += len(sample.expected_findings)
+
+            findings = execute_rules(
+                [sample.file_path], rules, project_dir="",
+            )
+            findings = run_pipeline(findings, min_confidence=min_confidence)
+
+            # Group findings by line for fast match lookup
+            findings_by_line: dict[int, list[Any]] = defaultdict(list)
+            for f in findings:
+                findings_by_line[f.line].append(f)
+
+            # Lines that have any expectation (positive or negative)
+            expected_lines = {a.line for a in sample.expected_findings}
+
+            # Track which findings have been "claimed" by an expectation so
+            # they don't double-count as both TP and FP.
+            claimed: set[tuple[int, str]] = set()
+
+            for ann in sample.expected_findings:
+                line_findings = findings_by_line.get(ann.line, [])
+                matched_finding = None
+                for fnd in line_findings:
+                    if _finding_matches_rule(fnd.rule_id, ann.rule_id):
+                        matched_finding = fnd
+                        break
+
+                if ann.kind == "expect":
+                    if matched_finding is not None:
+                        # TP — credit goes to the resolved rule
+                        rule_id = matched_finding.rule_id
+                        if rule_id in rule_scores:
+                            rule_scores[rule_id].tp += 1
+                            claimed.add((ann.line, rule_id))
+                    else:
+                        # FN — try to credit the expected rule by suffix
+                        target_rule_id = self._resolve_expected_rule(
+                            ann.rule_id, rule_index,
+                        )
+                        if target_rule_id and target_rule_id in rule_scores:
+                            rule_scores[target_rule_id].fn += 1
+
+                elif ann.kind == "ok":
+                    if matched_finding is not None:
+                        # FP — rule fired where we said it shouldn't
+                        rule_id = matched_finding.rule_id
+                        if rule_id in rule_scores:
+                            rule_scores[rule_id].fp += 1
+                            claimed.add((ann.line, rule_id))
+                # "todoruleid" is informational — never counts as TP/FP/FN.
+
+            # Findings on lines without any expectation are FPs (the file
+            # didn't claim those rules should fire here). Limited to lines
+            # with at least one annotation in the file as a whole, AND not
+            # already claimed.
+            if expected_lines:
+                for line, line_findings in findings_by_line.items():
+                    for fnd in line_findings:
+                        key = (line, fnd.rule_id)
+                        if key in claimed:
+                            continue
+                        if line in expected_lines:
+                            continue  # handled above
+                        if fnd.rule_id in rule_scores:
+                            rule_scores[fnd.rule_id].fp += 1
+
+        per_language = aggregate_per_language(
+            rule_scores,
+            severity_weights=self._severity_weights,
+            fixture_counts_by_language=dict(fixture_counts_by_language),
+        )
+
+        # Per-rule weighted_f1 too, for downstream LLM proposer analysis
+        for score in rule_scores.values():
+            weight = self._severity_weights.get(score.severity, 1.0)
+            tp_w = score.tp * weight
+            fp_w = score.fp * weight
+            fn_w = score.fn * weight
+            from eval.meta_harness.rule_bench.scoring import severity_weighted_f1
+
+            _, _, f1 = severity_weighted_f1(tp_w, fp_w, fn_w)
+            score.weighted_f1 = f1
+
+        composite = compute_composite(per_language)
+
+        # Aggregate-level precision/recall (severity-weighted across all rules)
+        total_tp = sum(s.true_positives_weighted for s in per_language.values())
+        total_fp = sum(s.false_positives_weighted for s in per_language.values())
+        total_fn = sum(s.false_negatives_weighted for s in per_language.values())
+        from eval.meta_harness.rule_bench.scoring import severity_weighted_f1
+
+        precision, recall, weighted_f1_overall = severity_weighted_f1(
+            total_tp, total_fp, total_fn,
+        )
+
+        return RuleBenchResult(
+            composite_score=composite,
+            weighted_f1=weighted_f1_overall,
+            precision=precision,
+            recall=recall,
+            per_language=per_language,
+            per_rule=rule_scores,
+            fixtures_total=len(corpus),
+            annotations_total=annotations_total,
+        )
+
+    @staticmethod
+    def _resolve_expected_rule(
+        annotation_rule_id: str,
+        rule_index: dict[str, UnifiedRule],
+    ) -> str | None:
+        """Find a registered rule whose qualified_id matches the annotation."""
+        if annotation_rule_id in rule_index:
+            return annotation_rule_id
+        # Suffix match (annotation may use bare id when rule is pack-qualified)
+        for qid in rule_index:
+            if qid.endswith("/" + annotation_rule_id):
+                return qid
+        return None

--- a/eval/meta_harness/rule_bench/evaluator.py
+++ b/eval/meta_harness/rule_bench/evaluator.py
@@ -84,34 +84,44 @@ class RuleBenchEvaluator:
         if self._base_registry is not None:
             return self._base_registry
 
+        from attocode.code_intel.rules.packs.pack_loader import (
+            _EXAMPLES_DIR,  # type: ignore[attr-defined]
+            list_example_packs,
+        )
+
         registry = RuleRegistry()
         loaded_packs: set[str] = set()
+        # Explicit pack filter, or "all packs found on disk" when empty.
+        explicit_filter = bool(self._packs)
+        wanted = set(self._packs)
 
-        # 1. Shipped example packs the harness was asked to load
-        if self._packs:
-            from attocode.code_intel.rules.packs.pack_loader import (
-                _EXAMPLES_DIR,  # type: ignore[attr-defined]
+        # 1. Shipped example packs
+        example_manifests = list_example_packs() if not explicit_filter else [
+            type("M", (), {"name": p})() for p in self._packs
+        ]
+        for manifest in example_manifests:
+            pack = manifest.name
+            if explicit_filter and pack not in wanted:
+                continue
+            pack_dir = _EXAMPLES_DIR / pack
+            if not pack_dir.is_dir():
+                continue
+            rules_dir = pack_dir / "rules"
+            if not rules_dir.is_dir():
+                rules_dir = pack_dir
+            rules = load_yaml_rules(
+                rules_dir, source=RuleSource.PACK, pack=pack,
             )
-            for pack in self._packs:
-                pack_dir = _EXAMPLES_DIR / pack
-                if not pack_dir.is_dir():
-                    continue
-                rules_dir = pack_dir / "rules"
-                if not rules_dir.is_dir():
-                    rules_dir = pack_dir
-                rules = load_yaml_rules(
-                    rules_dir, source=RuleSource.PACK, pack=pack,
-                )
-                for r in rules:
-                    registry.register(r)
-                loaded_packs.add(pack)
+            for r in rules:
+                registry.register(r)
+            loaded_packs.add(pack)
 
         # 2. Community packs (when included)
         if self._include_community:
             community_dir = get_community_pack_dir()
             if community_dir.is_dir():
                 for manifest in list_community_packs():
-                    if self._packs and manifest.name not in self._packs:
+                    if explicit_filter and manifest.name not in wanted:
                         continue
                     pack_dir = community_dir / manifest.name
                     rules_dir = pack_dir / "rules"

--- a/eval/meta_harness/rule_bench/predicate.py
+++ b/eval/meta_harness/rule_bench/predicate.py
@@ -1,0 +1,94 @@
+"""Per-language floor predicate for the rule-bench harness.
+
+A candidate is accepted only when:
+
+1. Its composite score strictly improves on the current best, AND
+2. No language drops below 95% of its baseline F1.
+
+This guards against the "win-Python-break-Go" pattern observed in the
+search-bench experiments — global improvements that hide a regression
+on one language. The 5% slack accounts for measurement noise.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from attoswarm.research.evaluator import EvalResult
+
+# Default slack: a candidate may dip up to 5% below the per-language
+# baseline before being rejected. Tuneable via ``floor_ratio`` arg.
+DEFAULT_FLOOR_RATIO = 0.95
+
+
+def make_rule_accept_predicate(floor_ratio: float = DEFAULT_FLOOR_RATIO):
+    """Build an accept predicate closure with a configurable floor.
+
+    Returned predicate signature matches ``AcceptPredicate`` in
+    :mod:`eval.meta_harness.meta_loop`.
+    """
+
+    def predicate(
+        result: EvalResult,
+        baseline_result: EvalResult | None,
+        current_best: float,
+    ) -> tuple[bool, str]:
+        score = result.metric_value
+
+        # Pull per-language scalars off the candidate result. Missing means
+        # the evaluator didn't populate them — fall back to strict score check.
+        candidate_per_lang: dict[str, float] = {}
+        if result.metadata:
+            raw = result.metadata.get("per_language") or {}
+            if isinstance(raw, dict):
+                candidate_per_lang = {
+                    str(k): float(v) for k, v in raw.items()
+                }
+
+        baseline_per_lang: dict[str, float] = {}
+        if baseline_result is not None and baseline_result.metadata:
+            raw = baseline_result.metadata.get("per_language") or {}
+            if isinstance(raw, dict):
+                baseline_per_lang = {
+                    str(k): float(v) for k, v in raw.items()
+                }
+
+        # Floor check first — a regression on any language is a hard reject
+        # even if the global score went up.
+        for lang, base_f1 in baseline_per_lang.items():
+            if base_f1 <= 0.0:
+                continue  # nothing to floor against
+            floor = base_f1 * floor_ratio
+            cand_f1 = candidate_per_lang.get(lang, 0.0)
+            if cand_f1 < floor:
+                return (
+                    False,
+                    f"floor_violation:{lang} {cand_f1:.4f} < {floor:.4f} "
+                    f"(baseline {base_f1:.4f})",
+                )
+
+        if score <= current_best:
+            return (
+                False,
+                f"no_improvement: {score:.4f} <= {current_best:.4f}",
+            )
+
+        return True, "improved"
+
+    return predicate
+
+
+# Convenience alias for the default 5% floor.
+rule_accept_predicate = make_rule_accept_predicate()
+
+
+def _stub_eval_result(
+    *,
+    metric_value: float,
+    per_language: dict[str, float] | None = None,
+) -> EvalResult:
+    """Test helper — build an EvalResult with the metadata shape we expect."""
+    metadata: dict[str, Any] = {}
+    if per_language is not None:
+        metadata["per_language"] = dict(per_language)
+    return EvalResult(metric_value=metric_value, metadata=metadata, success=True)

--- a/eval/meta_harness/rule_bench/proposer.py
+++ b/eval/meta_harness/rule_bench/proposer.py
@@ -1,0 +1,163 @@
+"""Stage-1 sweep proposer for the rule-bench harness.
+
+Stage 1 only mutates numeric/boolean rule fields (enabled, confidence,
+severity). Stage-2 template generation lands in Step 9.
+
+The proposer is intentionally simple: pick 1-3 random rules from the
+current best config's registry view, perturb each one, package as a new
+``RuleBenchConfig``. Deterministic per-iteration seed for reproducibility.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+from attocode.code_intel.rules.model import RuleSeverity
+
+from eval.meta_harness.rule_bench.config import (
+    RuleBenchConfig,
+    RuleOverride,
+)
+
+_SEVERITY_LADDER: list[str] = [
+    RuleSeverity.CRITICAL.value,
+    RuleSeverity.HIGH.value,
+    RuleSeverity.MEDIUM.value,
+    RuleSeverity.LOW.value,
+    RuleSeverity.INFO.value,
+]
+
+
+def propose_sweep_rule_overrides(
+    current_best: RuleBenchConfig,
+    eval_metadata: dict[str, Any],
+    history: list[dict[str, Any]],  # noqa: ARG001 - signature parity
+    n_candidates: int,
+    iteration: int,
+) -> list[tuple[RuleBenchConfig, str]]:
+    """Generate ``n_candidates`` perturbations of ``current_best``.
+
+    Picks rule ids from the most recent eval's per-rule report (so we
+    target rules with actual signal). Falls back to existing override
+    keys if the report is unavailable (e.g. before the first evaluation).
+    """
+    rng = random.Random(42 + iteration)
+
+    available_rule_ids = _candidate_rule_ids(current_best, eval_metadata)
+    if not available_rule_ids:
+        # Nothing to perturb — return empty so the runner moves on.
+        return []
+
+    candidates: list[tuple[RuleBenchConfig, str]] = []
+    for _ in range(n_candidates):
+        n_changes = rng.randint(1, min(3, len(available_rule_ids)))
+        chosen = rng.sample(available_rule_ids, n_changes)
+
+        new_overrides = dict(current_best.rule_overrides)
+        changes: list[str] = []
+        for rule_id in chosen:
+            existing = new_overrides.get(rule_id) or RuleOverride(rule_id=rule_id)
+            mutation = rng.choice(["toggle_enabled", "bump_confidence", "shift_severity"])
+
+            if mutation == "toggle_enabled":
+                # Bias toward enabling — disabled rules mean lost recall.
+                new_enabled = existing.enabled is False  # only flip if currently False
+                if existing.enabled is None:
+                    new_enabled = True if rng.random() > 0.3 else False
+                updated = RuleOverride(
+                    rule_id=rule_id,
+                    enabled=new_enabled,
+                    confidence_override=existing.confidence_override,
+                    severity_override=existing.severity_override,
+                )
+                changes.append(f"{rule_id}.enabled={new_enabled}")
+
+            elif mutation == "bump_confidence":
+                base = existing.confidence_override
+                if base is None:
+                    base = 0.7  # Roughly the most common default in shipped packs
+                shift = rng.gauss(0.0, 0.15)
+                new_conf = max(0.0, min(1.0, base + shift))
+                updated = RuleOverride(
+                    rule_id=rule_id,
+                    enabled=existing.enabled,
+                    confidence_override=round(new_conf, 3),
+                    severity_override=existing.severity_override,
+                )
+                changes.append(f"{rule_id}.confidence={new_conf:.3f}")
+
+            else:  # shift_severity
+                current_sev = existing.severity_override
+                if current_sev not in _SEVERITY_LADDER:
+                    current_sev = "medium"
+                idx = _SEVERITY_LADDER.index(current_sev)
+                # Move ±1 step on the ladder, clamped.
+                step = rng.choice([-1, 1])
+                new_idx = max(0, min(len(_SEVERITY_LADDER) - 1, idx + step))
+                new_sev = _SEVERITY_LADDER[new_idx]
+                updated = RuleOverride(
+                    rule_id=rule_id,
+                    enabled=existing.enabled,
+                    confidence_override=existing.confidence_override,
+                    severity_override=new_sev,
+                )
+                changes.append(f"{rule_id}.severity={new_sev}")
+
+            new_overrides[rule_id] = updated
+
+        new_cfg = RuleBenchConfig(
+            rule_overrides=new_overrides,
+            pack_activation=dict(current_best.pack_activation),
+            global_min_confidence=current_best.global_min_confidence,
+            enabled_languages=list(current_best.enabled_languages),
+            extra_rules=list(current_best.extra_rules),
+        )
+        hypothesis = f"sweep: {', '.join(changes)}"
+        candidates.append((new_cfg, hypothesis))
+
+    return candidates
+
+
+def propose_llm_rule_overrides(
+    current_best: RuleBenchConfig,  # noqa: ARG001 - signature parity
+    eval_metadata: dict[str, Any],  # noqa: ARG001
+    history: list[dict[str, Any]],  # noqa: ARG001
+    n_candidates: int,  # noqa: ARG001
+    iteration: int,  # noqa: ARG001
+) -> list[tuple[RuleBenchConfig, str]]:
+    """Stage-2 LLM proposer placeholder — wired in Step 9.
+
+    Returns an empty list for now so the runner falls back to sweep mode.
+    """
+    return []
+
+
+def _candidate_rule_ids(
+    current_best: RuleBenchConfig,
+    eval_metadata: dict[str, Any],
+) -> list[str]:
+    """Pick rule ids worth mutating.
+
+    Prefers the per-rule report from the last evaluation so we target
+    rules with actual signal. Falls back to the override keys we already
+    know about.
+    """
+    rule_bench = (eval_metadata or {}).get("rule_bench") or {}
+    per_rule = rule_bench.get("per_rule") or {}
+    if isinstance(per_rule, dict) and per_rule:
+        # Surface rules with at least one TP/FP/FN — those are the ones
+        # the corpus actually exercises; tuning anything else is noise.
+        live = [
+            rid for rid, score in per_rule.items()
+            if (score.get("tp", 0) + score.get("fp", 0) + score.get("fn", 0)) > 0
+        ]
+        if live:
+            return live
+        return list(per_rule.keys())
+
+    # Fall back to override keys (first iteration before any eval ran)
+    if current_best.rule_overrides:
+        return list(current_best.rule_overrides.keys())
+
+    return []

--- a/eval/meta_harness/rule_bench/proposer.py
+++ b/eval/meta_harness/rule_bench/proposer.py
@@ -1,17 +1,21 @@
-"""Stage-1 sweep proposer for the rule-bench harness.
+"""Rule-bench proposers (stage 1 sweep + stage 2 template).
 
-Stage 1 only mutates numeric/boolean rule fields (enabled, confidence,
-severity). Stage-2 template generation lands in Step 9.
+Stage 1 (``propose_sweep_rule_overrides``) mutates numeric/boolean rule
+fields — enabled, confidence, severity. Deterministic per-iteration seed.
 
-The proposer is intentionally simple: pick 1-3 random rules from the
-current best config's registry view, perturb each one, package as a new
-``RuleBenchConfig``. Deterministic per-iteration seed for reproducibility.
+Stage 2 (``propose_llm_rule_overrides``) asks an LLM to fill rule
+templates, validates each instance, and runs the fixture-coverage gate
+before adding survivors to the candidate's ``extra_rules``.
 """
 
 from __future__ import annotations
 
+import logging
 import random
+import re
 from typing import Any
+
+import yaml
 
 from attocode.code_intel.rules.model import RuleSeverity
 
@@ -120,17 +124,166 @@ def propose_sweep_rule_overrides(
 
 
 def propose_llm_rule_overrides(
-    current_best: RuleBenchConfig,  # noqa: ARG001 - signature parity
-    eval_metadata: dict[str, Any],  # noqa: ARG001
-    history: list[dict[str, Any]],  # noqa: ARG001
-    n_candidates: int,  # noqa: ARG001
-    iteration: int,  # noqa: ARG001
+    current_best: RuleBenchConfig,
+    eval_metadata: dict[str, Any],
+    history: list[dict[str, Any]],
+    n_candidates: int,
+    iteration: int,  # noqa: ARG001 - signature parity
 ) -> list[tuple[RuleBenchConfig, str]]:
-    """Stage-2 LLM proposer placeholder — wired in Step 9.
+    """Stage-2 LLM proposer — fills templates and gates against the corpus.
 
-    Returns an empty list for now so the runner falls back to sweep mode.
+    Calls Claude with the template manifest and worst-performing rules,
+    parses returned slot fillings, validates each, runs the
+    fixture-coverage gate, and packages survivors as new candidates.
+
+    Returns an empty list when no LLM API key is configured or when
+    every proposed candidate fails validation/gating.
     """
-    return []
+    try:
+        from eval.meta_harness._llm_client import call_llm, load_env
+    except Exception:  # pragma: no cover - import sanity
+        return []
+
+    try:
+        load_env()
+    except Exception:
+        return []
+
+    from eval.meta_harness.rule_bench.template_engine import (
+        gate_against_corpus,
+        load_templates,
+        substitute_slots,
+        validate_template_instance,
+    )
+
+    templates = load_templates()
+    if not templates:
+        return []
+
+    prompt = _build_template_prompt(
+        templates, current_best, eval_metadata, history, n_candidates,
+    )
+    try:
+        text = call_llm(prompt)
+    except Exception as exc:
+        # No key, network failure, etc. — runner falls back to sweep.
+        logging.getLogger(__name__).debug("LLM template call failed: %s", exc)
+        return []
+
+    proposals = _parse_llm_template_response(text)
+
+    # Build a tiny in-memory corpus snapshot for the gate. We re-read the
+    # full corpus rather than relying on cached state to keep the gate
+    # decoupled from the evaluator instance.
+    from eval.meta_harness.rule_bench.corpus import CorpusLoader
+
+    corpus = list(CorpusLoader().iter_samples())
+
+    candidates: list[tuple[RuleBenchConfig, str]] = []
+    for proposal in proposals[:n_candidates]:
+        template_id = proposal.get("template_id")
+        slots = proposal.get("slots") or {}
+        hypothesis = proposal.get("hypothesis", "")
+
+        template = templates.get(template_id)
+        if template is None:
+            continue
+
+        errors = validate_template_instance(template, slots)
+        if errors:
+            logging.getLogger(__name__).debug(
+                "Template %s failed validation: %s", template_id, errors,
+            )
+            continue
+
+        try:
+            rule_dict = substitute_slots(template, slots)
+        except Exception as exc:
+            logging.getLogger(__name__).debug(
+                "Template substitution failed for %s: %s", template_id, exc,
+            )
+            continue
+
+        accepted, reason = gate_against_corpus(rule_dict, corpus)
+        if not accepted:
+            continue
+
+        new_cfg = RuleBenchConfig(
+            rule_overrides=dict(current_best.rule_overrides),
+            pack_activation=dict(current_best.pack_activation),
+            global_min_confidence=current_best.global_min_confidence,
+            enabled_languages=list(current_best.enabled_languages),
+            extra_rules=[*current_best.extra_rules, rule_dict],
+        )
+        full_hypothesis = (
+            f"template:{template_id} ({reason})" + (
+                f" — {hypothesis}" if hypothesis else ""
+            )
+        )
+        candidates.append((new_cfg, full_hypothesis))
+
+    return candidates
+
+
+def _build_template_prompt(
+    templates: dict,
+    current_best: RuleBenchConfig,  # noqa: ARG001 - reserved for future signal
+    eval_metadata: dict[str, Any],
+    history: list[dict[str, Any]],  # noqa: ARG001
+    n_candidates: int,
+) -> str:
+    """Build the LLM prompt — template manifest + worst-performing rules."""
+    rule_bench = (eval_metadata or {}).get("rule_bench") or {}
+    per_rule = rule_bench.get("per_rule") or {}
+    worst = sorted(
+        per_rule.values(),
+        key=lambda r: r.get("weighted_f1", 0.0),
+    )[:3]
+
+    template_blocks: list[str] = []
+    for tid, t in templates.items():
+        slot_lines = "\n".join(
+            f"  - {s.name} ({s.kind}): {s.description}" for s in t.slots
+        )
+        template_blocks.append(
+            f"### {tid}\n{t.description}\nSlots:\n{slot_lines}"
+        )
+
+    worst_block = "\n".join(
+        f"  - {r.get('rule_id')}: F1={r.get('weighted_f1', 0):.3f} "
+        f"(tp={r.get('tp', 0)} fp={r.get('fp', 0)} fn={r.get('fn', 0)})"
+        for r in worst
+    ) or "  (no per-rule data yet)"
+
+    return (
+        "You are extending a rule-bench harness with new rules.\n\n"
+        f"Worst-performing rules from the last evaluation:\n{worst_block}\n\n"
+        f"Available templates:\n\n" + "\n\n".join(template_blocks) + "\n\n"
+        f"Propose up to {n_candidates} new rules by filling templates. "
+        f"For each, output a fenced YAML block:\n\n"
+        "```yaml\n"
+        "template_id: <one-of-the-templates>\n"
+        "hypothesis: <why this rule helps>\n"
+        "slots:\n"
+        "  language: <python|go|...>\n"
+        "  <slot>: <value>\n"
+        "  ...\n"
+        "```\n"
+    )
+
+
+def _parse_llm_template_response(text: str) -> list[dict[str, Any]]:
+    """Extract template-instance dicts from fenced YAML blocks in *text*."""
+    pattern = re.compile(r"```ya?ml\s*\n(.*?)```", re.DOTALL)
+    out: list[dict[str, Any]] = []
+    for block in pattern.findall(text):
+        try:
+            data = yaml.safe_load(block)
+        except Exception:
+            continue
+        if isinstance(data, dict) and "template_id" in data:
+            out.append(data)
+    return out
 
 
 def _candidate_rule_ids(

--- a/eval/meta_harness/rule_bench/scoring.py
+++ b/eval/meta_harness/rule_bench/scoring.py
@@ -1,0 +1,209 @@
+"""Severity-weighted scoring for the rule-bench harness.
+
+We measure rule effectiveness as severity-weighted F1, then macro-average
+across languages so a pack with one rule per language doesn't get drowned
+out by a pack with twenty rules in another language. The composite score
+fed to the optimizer is the macro mean of per-language F1s.
+
+Why severity weighting:
+    A missed ``critical`` security rule (FN) is much more painful than a
+    missed ``info`` style nit. We weight precision and recall numerators
+    + denominators by per-finding severity weight so the score reflects
+    real-world impact rather than raw counts.
+
+The companion floor predicate (see ``predicate.py``, Step 5) further
+guards against per-language regressions: a candidate that improves the
+mean composite while degrading any single language below 95% of baseline
+is rejected.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any
+
+from attocode.code_intel.rules.model import RuleSeverity
+
+# Defaults match the brainstorming decision: critical 4x, high 3x,
+# medium 2x, low 1x, info 0.5x.
+DEFAULT_SEVERITY_WEIGHTS: dict[str, float] = {
+    RuleSeverity.CRITICAL.value: 4.0,
+    RuleSeverity.HIGH.value: 3.0,
+    RuleSeverity.MEDIUM.value: 2.0,
+    RuleSeverity.LOW.value: 1.0,
+    RuleSeverity.INFO.value: 0.5,
+}
+
+
+@dataclass(slots=True)
+class RuleScore:
+    """Per-rule TP/FP/FN counts plus a weighted F1."""
+
+    rule_id: str
+    pack: str
+    language: str
+    severity: str  # RuleSeverity value
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
+    weighted_f1: float = 0.0
+    enabled: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "rule_id": self.rule_id,
+            "pack": self.pack,
+            "language": self.language,
+            "severity": self.severity,
+            "tp": self.tp,
+            "fp": self.fp,
+            "fn": self.fn,
+            "weighted_f1": round(self.weighted_f1, 4),
+            "enabled": self.enabled,
+        }
+
+
+@dataclass(slots=True)
+class LanguageScore:
+    """Per-language aggregate with severity-weighted F1."""
+
+    language: str
+    weighted_f1: float = 0.0
+    precision: float = 0.0
+    recall: float = 0.0
+    true_positives_weighted: float = 0.0
+    false_positives_weighted: float = 0.0
+    false_negatives_weighted: float = 0.0
+    rule_count: int = 0
+    fixture_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "language": self.language,
+            "weighted_f1": round(self.weighted_f1, 4),
+            "precision": round(self.precision, 4),
+            "recall": round(self.recall, 4),
+            "true_positives_weighted": round(self.true_positives_weighted, 3),
+            "false_positives_weighted": round(self.false_positives_weighted, 3),
+            "false_negatives_weighted": round(self.false_negatives_weighted, 3),
+            "rule_count": self.rule_count,
+            "fixture_count": self.fixture_count,
+        }
+
+
+@dataclass(slots=True)
+class RuleBenchResult:
+    """Full rule-bench evaluation output."""
+
+    composite_score: float = 0.0
+    weighted_f1: float = 0.0
+    precision: float = 0.0
+    recall: float = 0.0
+    per_language: dict[str, LanguageScore] = field(default_factory=dict)
+    per_rule: dict[str, RuleScore] = field(default_factory=dict)
+    fixtures_total: int = 0
+    annotations_total: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "composite_score": round(self.composite_score, 4),
+            "weighted_f1": round(self.weighted_f1, 4),
+            "precision": round(self.precision, 4),
+            "recall": round(self.recall, 4),
+            "per_language": {
+                lang: score.to_dict() for lang, score in self.per_language.items()
+            },
+            "per_rule": {
+                rule_id: score.to_dict() for rule_id, score in self.per_rule.items()
+            },
+            "fixtures_total": self.fixtures_total,
+            "annotations_total": self.annotations_total,
+        }
+
+    def per_language_scalars(self) -> dict[str, float]:
+        """Flat ``{language: weighted_f1}`` map for the floor predicate."""
+        return {lang: score.weighted_f1 for lang, score in self.per_language.items()}
+
+
+def severity_weighted_f1(
+    tp_weighted: float,
+    fp_weighted: float,
+    fn_weighted: float,
+) -> tuple[float, float, float]:
+    """Compute (precision, recall, F1) from severity-weighted counts.
+
+    Returns ``(0.0, 0.0, 0.0)`` cleanly when there's nothing to score —
+    callers can rely on this never raising on empty corpora.
+    """
+    precision_denom = tp_weighted + fp_weighted
+    precision = tp_weighted / precision_denom if precision_denom > 0 else 0.0
+
+    recall_denom = tp_weighted + fn_weighted
+    recall = tp_weighted / recall_denom if recall_denom > 0 else 0.0
+
+    pr_sum = precision + recall
+    f1 = 2 * precision * recall / pr_sum if pr_sum > 0 else 0.0
+    return precision, recall, f1
+
+
+def aggregate_per_language(
+    rule_scores: dict[str, RuleScore],
+    *,
+    severity_weights: dict[str, float] | None = None,
+    fixture_counts_by_language: dict[str, int] | None = None,
+) -> dict[str, LanguageScore]:
+    """Aggregate per-rule scores into per-language buckets.
+
+    Each rule contributes its TP/FP/FN counts weighted by its own severity
+    so a critical rule with 1 missed positive hurts more than an info rule
+    with 4 missed positives.
+    """
+    weights = severity_weights or DEFAULT_SEVERITY_WEIGHTS
+    fixture_counts = fixture_counts_by_language or {}
+
+    by_lang: dict[str, LanguageScore] = {}
+    rule_counts_by_lang: dict[str, int] = defaultdict(int)
+    tp_w: dict[str, float] = defaultdict(float)
+    fp_w: dict[str, float] = defaultdict(float)
+    fn_w: dict[str, float] = defaultdict(float)
+
+    for score in rule_scores.values():
+        # Skip rules with no fixtures hitting them — they have no signal
+        if score.tp + score.fp + score.fn == 0:
+            continue
+        weight = weights.get(score.severity, 1.0)
+        # Universal rules (empty language) bucket under "*"
+        lang = score.language or "*"
+        rule_counts_by_lang[lang] += 1
+        tp_w[lang] += score.tp * weight
+        fp_w[lang] += score.fp * weight
+        fn_w[lang] += score.fn * weight
+
+    for lang in rule_counts_by_lang:
+        precision, recall, f1 = severity_weighted_f1(tp_w[lang], fp_w[lang], fn_w[lang])
+        by_lang[lang] = LanguageScore(
+            language=lang,
+            weighted_f1=f1,
+            precision=precision,
+            recall=recall,
+            true_positives_weighted=tp_w[lang],
+            false_positives_weighted=fp_w[lang],
+            false_negatives_weighted=fn_w[lang],
+            rule_count=rule_counts_by_lang[lang],
+            fixture_count=fixture_counts.get(lang, 0),
+        )
+
+    return by_lang
+
+
+def compute_composite(per_language: dict[str, LanguageScore]) -> float:
+    """Macro-average per-language F1.
+
+    Macro (not micro) so a sparsely-populated language can't be ignored
+    just because it has fewer fixtures. Universal-rule scores ("*") are
+    folded into the average too — they apply to every file.
+    """
+    if not per_language:
+        return 0.0
+    return sum(s.weighted_f1 for s in per_language.values()) / len(per_language)

--- a/eval/meta_harness/rule_bench/template_engine.py
+++ b/eval/meta_harness/rule_bench/template_engine.py
@@ -1,0 +1,282 @@
+"""Stage-2 template engine for the rule-bench harness.
+
+A template is a YAML file describing:
+
+- ``template_id``: short identifier
+- ``description``: free text
+- ``slots``: list of ``{name, kind, description?}`` entries the LLM fills
+- ``rule``: a rule template body containing ``{{slot_name}}`` placeholders
+
+When the proposer instantiates a template, we:
+
+1. Substitute all slots into the rule body
+2. Validate each slot against its declared kind (regex_fragment compiles,
+   enum values match, language is recognized)
+3. Run the rule against the existing labeled corpus and reject any that
+   doesn't earn at least 2 TPs while staying under 2 FPs (the
+   *fixture-coverage gate*)
+
+Surviving rules get appended to the candidate's ``RuleBenchConfig.extra_rules``
+so the inner-loop evaluator can score them alongside the base packs.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from attocode.code_intel.rules.executor import execute_rules
+from attocode.code_intel.rules.loader import _parse_yaml_rule
+from attocode.code_intel.rules.model import RuleSource
+from attocode.code_intel.rules.testing import _finding_matches_rule
+
+from eval.meta_harness.rule_bench.corpus import LabeledSample
+
+logger = logging.getLogger(__name__)
+
+TEMPLATES_DIR = Path(__file__).parent / "templates"
+
+# Languages we know how to ship rules for. Keep in sync with executor._EXT_LANG.
+SUPPORTED_LANGUAGES = {
+    "python", "go", "javascript", "typescript",
+    "rust", "java", "kotlin", "ruby", "php", "c", "cpp",
+}
+
+VALID_SEVERITIES = {"critical", "high", "medium", "low", "info"}
+
+# Regex matching a `{{slot_name}}` placeholder
+_SLOT_RE = re.compile(r"\{\{\s*([\w]+)\s*\}\}")
+
+
+# ---------------------------------------------------------------------------
+# Template model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class Slot:
+    name: str
+    kind: str
+    description: str = ""
+
+    @property
+    def enum_choices(self) -> list[str]:
+        if self.kind.startswith("enum:"):
+            return self.kind.split(":", 1)[1].split("|")
+        return []
+
+
+@dataclass(slots=True)
+class Template:
+    template_id: str
+    description: str
+    slots: list[Slot] = field(default_factory=list)
+    rule_body: dict[str, Any] = field(default_factory=dict)
+
+    def slot_names(self) -> set[str]:
+        return {s.name for s in self.slots}
+
+
+def load_templates(templates_dir: Path | None = None) -> dict[str, Template]:
+    """Load every ``*.yaml`` template from ``templates_dir``."""
+    base = templates_dir or TEMPLATES_DIR
+    out: dict[str, Template] = {}
+    if not base.is_dir():
+        return out
+    for path in sorted(base.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Skipping template %s: %s", path, exc)
+            continue
+        if not isinstance(data, dict):
+            continue
+        template = _parse_template(data, path)
+        if template is not None:
+            out[template.template_id] = template
+    return out
+
+
+def _parse_template(data: dict, path: Path) -> Template | None:
+    tid = data.get("template_id")
+    if not tid:
+        logger.warning("Template %s missing template_id", path)
+        return None
+    rule_body = data.get("rule")
+    if not isinstance(rule_body, dict):
+        logger.warning("Template %s missing rule body", path)
+        return None
+    slots_raw = data.get("slots") or []
+    slots: list[Slot] = []
+    for s in slots_raw:
+        if not isinstance(s, dict) or "name" not in s or "kind" not in s:
+            continue
+        slots.append(
+            Slot(
+                name=str(s["name"]),
+                kind=str(s["kind"]),
+                description=str(s.get("description", "")),
+            )
+        )
+    return Template(
+        template_id=str(tid),
+        description=str(data.get("description", "")),
+        slots=slots,
+        rule_body=rule_body,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Substitution + validation
+# ---------------------------------------------------------------------------
+
+
+def substitute_slots(
+    template: Template, filled_slots: dict[str, str],
+) -> dict[str, Any]:
+    """Substitute slot placeholders into the template's rule body.
+
+    Adds an implicit ``slot_safe_name`` derived from the first regex_fragment
+    or text slot — used by templates to build collision-resistant rule ids.
+    """
+    enriched = dict(filled_slots)
+    enriched.setdefault("slot_safe_name", _build_safe_name(template, filled_slots))
+
+    def _sub_str(value: str) -> str:
+        def repl(m: re.Match[str]) -> str:
+            slot_name = m.group(1)
+            if slot_name not in enriched:
+                raise KeyError(f"Missing slot value: {slot_name}")
+            return str(enriched[slot_name])
+
+        return _SLOT_RE.sub(repl, value)
+
+    def _walk(node: Any) -> Any:
+        if isinstance(node, str):
+            return _sub_str(node)
+        if isinstance(node, dict):
+            return {k: _walk(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [_walk(v) for v in node]
+        return node
+
+    return _walk(template.rule_body)
+
+
+def _build_safe_name(template: Template, filled: dict[str, str]) -> str:
+    """Build a stable slug for the rule id from the first text-ish slot."""
+    for slot in template.slots:
+        value = filled.get(slot.name, "")
+        if not value:
+            continue
+        slug = re.sub(r"[^\w]+", "-", value).strip("-").lower()
+        if slug:
+            return slug[:48]
+    return template.template_id
+
+
+def validate_template_instance(
+    template: Template, filled_slots: dict[str, str],
+) -> list[str]:
+    """Validate slot values against their declared kinds. Return error list."""
+    errors: list[str] = []
+    expected = template.slot_names()
+    missing = expected - set(filled_slots)
+    if missing:
+        errors.append(f"missing slots: {sorted(missing)}")
+    extra = set(filled_slots) - expected - {"slot_safe_name"}
+    if extra:
+        errors.append(f"unknown slots: {sorted(extra)}")
+
+    for slot in template.slots:
+        value = filled_slots.get(slot.name)
+        if value is None:
+            continue
+        if slot.kind == "regex_fragment":
+            try:
+                re.compile(value)
+            except re.error as exc:
+                errors.append(f"slot {slot.name}: invalid regex: {exc}")
+        elif slot.kind == "text":
+            if not value.strip():
+                errors.append(f"slot {slot.name}: empty text")
+        elif slot.kind == "language":
+            if value not in SUPPORTED_LANGUAGES:
+                errors.append(
+                    f"slot {slot.name}: unsupported language {value!r}"
+                )
+        elif slot.kind.startswith("enum:"):
+            if value not in slot.enum_choices:
+                errors.append(
+                    f"slot {slot.name}: not in enum {slot.enum_choices}"
+                )
+
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Fixture-coverage gate
+# ---------------------------------------------------------------------------
+
+
+def gate_against_corpus(
+    rule_dict: dict[str, Any],
+    corpus: list[LabeledSample],
+    *,
+    min_tp: int = 2,
+    max_fp: int = 1,
+) -> tuple[bool, str]:
+    """Reject candidate rules that are too broad or too narrow.
+
+    Returns ``(accepted, reason)``. ``min_tp=2`` ensures the rule has at
+    least some signal on the existing corpus; ``max_fp<=1`` prevents
+    candidates from regressing precision too aggressively before the
+    full inner-loop eval even runs.
+    """
+    rule = _parse_yaml_rule(
+        rule_dict, source=RuleSource.PACK, pack="rule_bench_synth",
+        origin="template_gate",
+    )
+    if rule is None:
+        return False, "rule failed to parse"
+
+    tp = 0
+    fp = 0
+    for sample in corpus:
+        # Quick language filter — universal rules apply everywhere
+        if rule.languages and sample.language not in rule.languages:
+            continue
+        findings = execute_rules([sample.file_path], [rule], project_dir="")
+        if not findings:
+            continue
+        # Map findings to expectations (just use the same matcher as the eval)
+        for f in findings:
+            matched_expect = False
+            matched_ok = False
+            for ann in sample.expected_findings:
+                if ann.line != f.line:
+                    continue
+                if not _finding_matches_rule(f.rule_id, ann.rule_id):
+                    continue
+                if ann.kind == "expect":
+                    matched_expect = True
+                elif ann.kind == "ok":
+                    matched_ok = True
+            if matched_expect:
+                tp += 1
+            elif matched_ok:
+                fp += 1
+            elif sample.expected_findings:
+                # Unexpected finding on a labeled file → FP
+                fp += 1
+
+    if tp < min_tp:
+        return False, f"insufficient TPs (got {tp}, need >= {min_tp})"
+    if fp > max_fp:
+        return False, f"too many FPs (got {fp}, max {max_fp})"
+    return True, f"tp={tp} fp={fp}"

--- a/eval/meta_harness/rule_bench/templates/deprecated_api_call.yaml
+++ b/eval/meta_harness/rule_bench/templates/deprecated_api_call.yaml
@@ -1,0 +1,23 @@
+# Template: flag calls to a deprecated API.
+template_id: deprecated_api_call
+description: Flag calls to a deprecated API and suggest a replacement
+slots:
+  - name: language
+    kind: language
+  - name: api_pattern
+    kind: regex_fragment
+    description: Regex matching the deprecated API call (e.g. ``foo\\.bar\\(``)
+  - name: replacement_hint
+    kind: text
+    description: Short text describing the recommended replacement
+rule:
+  id: 'deprecated/{{language}}/{{slot_safe_name}}'
+  name: Deprecated API call
+  message: '{{api_pattern}} is deprecated; use {{replacement_hint}}'
+  severity: medium
+  category: deprecated
+  languages:
+    - '{{language}}'
+  pattern: '{{api_pattern}}'
+  confidence: 0.7
+  recommendation: 'Replace with {{replacement_hint}}'

--- a/eval/meta_harness/rule_bench/templates/insecure_default_arg.yaml
+++ b/eval/meta_harness/rule_bench/templates/insecure_default_arg.yaml
@@ -1,0 +1,22 @@
+# Template: flag an insecure default argument value.
+template_id: insecure_default_arg
+description: Flag an insecure default that callers can leave at its risky value
+slots:
+  - name: language
+    kind: language
+  - name: arg_pattern
+    kind: regex_fragment
+    description: Regex matching the insecure default literal in code
+  - name: severity
+    kind: enum:critical|high|medium|low
+rule:
+  id: 'security/{{language}}/{{slot_safe_name}}-default'
+  name: Insecure default argument
+  message: 'Default {{arg_pattern}} is insecure'
+  severity: '{{severity}}'
+  category: security
+  languages:
+    - '{{language}}'
+  pattern: '{{arg_pattern}}'
+  confidence: 0.65
+  recommendation: 'Override the default with a safer value'

--- a/eval/meta_harness/rule_bench/templates/missing_error_check.yaml
+++ b/eval/meta_harness/rule_bench/templates/missing_error_check.yaml
@@ -1,0 +1,23 @@
+# Template: flag a function call whose error/exception result isn't checked.
+template_id: missing_error_check
+description: Flag a call that returns an error/exception path that isn't handled
+slots:
+  - name: language
+    kind: language
+  - name: call_pattern
+    kind: regex_fragment
+    description: Regex matching the unchecked call expression
+  - name: required_check
+    kind: text
+    description: How callers should handle the error (e.g. ``check err != nil``)
+rule:
+  id: 'safety/{{language}}/{{slot_safe_name}}-unchecked'
+  name: Missing error check
+  message: '{{call_pattern}} return value should be {{required_check}}'
+  severity: medium
+  category: correctness
+  languages:
+    - '{{language}}'
+  pattern: '{{call_pattern}}'
+  confidence: 0.6
+  recommendation: '{{required_check}}'

--- a/eval/meta_harness/rule_bench/templates/regex_redos.yaml
+++ b/eval/meta_harness/rule_bench/templates/regex_redos.yaml
@@ -1,0 +1,24 @@
+# Template: flag a regex pattern with classic ReDoS shape.
+template_id: regex_redos
+description: Flag a regex literal that exhibits a known ReDoS-prone shape
+slots:
+  - name: language
+    kind: language
+  - name: pattern_signature
+    kind: regex_fragment
+    description: |
+      Regex matching the suspect regex literal — typically nested
+      quantifiers like ``\\(\\.\\*\\)\\+`` or ``\\(\\\\w\\+\\)\\+``.
+rule:
+  id: 'safety/{{language}}/{{slot_safe_name}}-redos'
+  name: Potential ReDoS regex
+  message: 'Regex {{pattern_signature}} has ReDoS-prone shape'
+  severity: medium
+  category: performance
+  languages:
+    - '{{language}}'
+  pattern: '{{pattern_signature}}'
+  confidence: 0.55
+  recommendation: |
+    Rewrite to avoid nested quantifiers; consider RE2 / linear-time engines
+    or pre-validate input length.

--- a/eval/meta_harness/rule_bench/templates/string_concat_in_loop.yaml
+++ b/eval/meta_harness/rule_bench/templates/string_concat_in_loop.yaml
@@ -1,0 +1,21 @@
+# Template: flag string concatenation inside a loop body.
+template_id: string_concat_in_loop
+description: Flag in-loop string concatenation patterns
+slots:
+  - name: language
+    kind: language
+  - name: concat_pattern
+    kind: regex_fragment
+    description: |
+      Regex matching the in-loop concatenation (e.g. ``\\+=\\s*[''"]``)
+rule:
+  id: 'perf/{{language}}/{{slot_safe_name}}-concat-loop'
+  name: String concatenation in loop
+  message: 'In-loop concatenation creates O(N^2) intermediate strings'
+  severity: low
+  category: performance
+  languages:
+    - '{{language}}'
+  pattern: '{{concat_pattern}}'
+  confidence: 0.5
+  recommendation: 'Use a builder/buffer/join instead of += inside the loop'

--- a/eval/meta_harness/rule_bench/templates/unsafe_deserialization.yaml
+++ b/eval/meta_harness/rule_bench/templates/unsafe_deserialization.yaml
@@ -1,0 +1,23 @@
+# Template: flag unsafe deserialization sinks.
+template_id: unsafe_deserialization
+description: Flag a known-unsafe deserialization sink (RCE risk)
+slots:
+  - name: language
+    kind: language
+  - name: sink_pattern
+    kind: regex_fragment
+    description: Regex matching the unsafe deserializer call site
+rule:
+  id: 'security/{{language}}/{{slot_safe_name}}-unsafe-deser'
+  name: Unsafe deserialization
+  message: 'Unsafe deserialization via {{sink_pattern}}'
+  severity: critical
+  category: security
+  languages:
+    - '{{language}}'
+  pattern: '{{sink_pattern}}'
+  confidence: 0.75
+  cwe: CWE-502
+  recommendation: |
+    Avoid native deserialization on untrusted input. Prefer JSON / a
+    typed schema parser (protobuf, msgpack) and validate before use.

--- a/eval/rule_harness/__init__.py
+++ b/eval/rule_harness/__init__.py
@@ -1,0 +1,13 @@
+"""Rule-harness developer tooling.
+
+This package holds dev-only utilities for the rule-bench harness:
+
+- ``import_pack``: import community rule packs (semgrep-rules, bandit, gosec)
+  with proper license attribution.
+- ``scripts/seed_attocode_fixtures``: scaffold hand-labeled corpus stubs
+  from existing example pack ``examples`` fields.
+
+These are NOT shipped runtime code — they live under ``eval/`` because
+they're invoked by humans (or CI) during pack maintenance, not by the
+attocode runtime.
+"""

--- a/eval/rule_harness/fixtures/attocode/go/go-append-no-prealloc.go
+++ b/eval/rule_harness/fixtures/attocode/go/go-append-no-prealloc.go
@@ -1,0 +1,17 @@
+// Auto-seeded fixture for rule 'go-append-no-prealloc'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+var results []string  // expect: go-append-no-prealloc
+for _, item := range items {
+    results = append(results, item.Name)
+}
+
+// --- GOOD: rule must NOT fire ---
+results := make([]string, 0, len(items))  // ok: go-append-no-prealloc
+for _, item := range items {
+    results = append(results, item.Name)
+}

--- a/eval/rule_harness/fixtures/attocode/go/go-defer-statement.go
+++ b/eval/rule_harness/fixtures/attocode/go/go-defer-statement.go
@@ -1,0 +1,19 @@
+// Auto-seeded fixture for rule 'go-defer-statement'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+for _, f := range files {  // expect: go-defer-statement
+    fd, _ := os.Open(f)
+    defer fd.Close()
+}
+
+// --- GOOD: rule must NOT fire ---
+for _, f := range files {  // ok: go-defer-statement
+    func() {
+        fd, _ := os.Open(f)
+        defer fd.Close()
+    }()
+}

--- a/eval/rule_harness/fixtures/attocode/go/go-error-string-compare.go
+++ b/eval/rule_harness/fixtures/attocode/go/go-error-string-compare.go
@@ -1,0 +1,11 @@
+// Auto-seeded fixture for rule 'go-error-string-compare'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+if err.Error() == "not found" {  // expect: go-error-string-compare
+
+// --- GOOD: rule must NOT fire ---
+if errors.Is(err, ErrNotFound) {  // ok: go-error-string-compare

--- a/eval/rule_harness/fixtures/attocode/go/go-sprintf-allocation.go
+++ b/eval/rule_harness/fixtures/attocode/go/go-sprintf-allocation.go
@@ -1,0 +1,11 @@
+// Auto-seeded fixture for rule 'go-sprintf-allocation'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+key := fmt.Sprintf("cache:%s:%d", prefix, id)  // expect: go-sprintf-allocation
+
+// --- GOOD: rule must NOT fire ---
+key := "cache:" + prefix + ":" + strconv.Itoa(id)  // ok: go-sprintf-allocation

--- a/eval/rule_harness/fixtures/attocode/go/go-sql-string-concat.go
+++ b/eval/rule_harness/fixtures/attocode/go/go-sql-string-concat.go
@@ -1,0 +1,11 @@
+// Auto-seeded fixture for rule 'go-sql-string-concat'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+db.Query("SELECT * FROM users WHERE id=" + id)  // expect: go-sql-string-concat
+
+// --- GOOD: rule must NOT fire ---
+db.Query("SELECT * FROM users WHERE id=?", id)  // ok: go-sql-string-concat

--- a/eval/rule_harness/fixtures/attocode/go/go-string-tolower-compare.go
+++ b/eval/rule_harness/fixtures/attocode/go/go-string-tolower-compare.go
@@ -1,0 +1,11 @@
+// Auto-seeded fixture for rule 'go-string-tolower-compare'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+if strings.ToLower(name) == "admin" {  // expect: go-string-tolower-compare
+
+// --- GOOD: rule must NOT fire ---
+if strings.EqualFold(name, "admin") {  // ok: go-string-tolower-compare

--- a/eval/rule_harness/fixtures/attocode/go/gosec-credentials.go
+++ b/eval/rule_harness/fixtures/attocode/go/gosec-credentials.go
@@ -1,0 +1,16 @@
+// Hand-curated fixture for gosec G101 (hardcoded credentials).
+
+package config
+
+import "os"
+
+// --- GOOD: rule must NOT fire ---
+var (
+	PasswordEnvVar = "DATABASE_PASSWORD" // ok: G101-hardcoded-credentials
+	apiKey         = os.Getenv("API_KEY") // ok: G101-hardcoded-credentials
+)
+
+// --- BAD: rule MUST fire ---
+var DBPassword = "hunter2-supersecret" // expect: G101-hardcoded-credentials
+
+const APIToken = "tok_abcd1234efgh5678" // expect: G101-hardcoded-credentials

--- a/eval/rule_harness/fixtures/attocode/go/gosec-tls-weak.go
+++ b/eval/rule_harness/fixtures/attocode/go/gosec-tls-weak.go
@@ -1,0 +1,36 @@
+// Hand-curated fixture for gosec G402 (weak TLS) and G401 (weak cipher).
+
+package secure
+
+import (
+	"crypto/aes"
+	"crypto/des"
+	"crypto/rc4"
+	"crypto/tls"
+)
+
+func goodTLS() *tls.Config {
+	// --- GOOD: TLS 1.2 minimum ---
+	return &tls.Config{MinVersion: tls.VersionTLS12} // ok: G402-tls-min-version
+}
+
+func badTLS() *tls.Config {
+	// --- BAD: SSLv3 ---
+	return &tls.Config{MinVersion: tls.VersionSSL30} // expect: G402-tls-min-version
+}
+
+func badTLS10() *tls.Config {
+	return &tls.Config{MinVersion: tls.VersionTLS10} // expect: G402-tls-min-version
+}
+
+func goodAES(key []byte) {
+	_, _ = aes.NewCipher(key) // ok: G401-weak-cipher
+}
+
+func badDES(key []byte) {
+	_, _ = des.NewCipher(key) // expect: G401-weak-cipher
+}
+
+func badRC4(key []byte) {
+	_, _ = rc4.NewCipher(key) // expect: G401-weak-cipher
+}

--- a/eval/rule_harness/fixtures/attocode/java/java-string-concat-loop.java
+++ b/eval/rule_harness/fixtures/attocode/java/java-string-concat-loop.java
@@ -1,0 +1,12 @@
+// Auto-seeded fixture for rule 'java-string-concat-loop'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+String result = "";\nfor (String s : items) result += s;  // expect: java-string-concat-loop
+
+// --- GOOD: rule must NOT fire ---
+StringBuilder sb = new StringBuilder();  // ok: java-string-concat-loop
+for (String s : items) sb.append(s);

--- a/eval/rule_harness/fixtures/attocode/python/bandit-secrets.py
+++ b/eval/rule_harness/fixtures/attocode/python/bandit-secrets.py
@@ -1,0 +1,22 @@
+# Hand-curated fixture for bandit-python pack rules.
+# Tests B105 (hardcoded password) plus nearby unrelated code so we
+# measure FP rate too.
+
+import os
+
+
+def boot_with_secret(api_key: str) -> None:
+    """Real flow: read secret from env."""
+    secret = os.environ.get("API_TOKEN", "")  # ok: B105-hardcoded-password
+    if not secret:
+        raise RuntimeError("API_TOKEN missing")
+
+
+# --- BAD: rule MUST fire ---
+api_key = "sk-1234567890abcdef"  # expect: B105-hardcoded-password
+DATABASE_PASSWORD = "supersecret123"  # expect: B105-hardcoded-password
+
+
+# --- GOOD: rule must NOT fire ---
+PLACEHOLDER = "EXAMPLE_VALUE"  # ok: B105-hardcoded-password
+api_key_var = "API_KEY"  # ok: B105-hardcoded-password — env var name, not value

--- a/eval/rule_harness/fixtures/attocode/python/bandit-weak-crypto.py
+++ b/eval/rule_harness/fixtures/attocode/python/bandit-weak-crypto.py
@@ -1,0 +1,23 @@
+# Hand-curated fixture for bandit weak-crypto rules (B303, B324, B304).
+
+import hashlib
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+
+def hash_user(user_id: str) -> str:
+    """Modern hashing — SHA-256."""
+    return hashlib.sha256(user_id.encode()).hexdigest()  # ok: B303-weak-md5
+
+
+def hash_user_md5(user_id: str) -> str:
+    return hashlib.md5(user_id.encode()).hexdigest()  # expect: B303-weak-md5
+
+
+def hash_user_sha1(user_id: str) -> str:
+    return hashlib.sha1(user_id.encode()).hexdigest()  # expect: B324-weak-sha1
+
+
+def encrypt_aes(key: bytes, iv: bytes, data: bytes) -> bytes:
+    cipher = Cipher(algorithms.AES(key), modes.GCM(iv))  # ok: B304-weak-des
+    encryptor = cipher.encryptor()
+    return encryptor.update(data) + encryptor.finalize()

--- a/eval/rule_harness/fixtures/attocode/python/py-bare-except.py
+++ b/eval/rule_harness/fixtures/attocode/python/py-bare-except.py
@@ -1,0 +1,17 @@
+# Auto-seeded fixture for rule 'py-bare-except'.
+# Hand-curate before relying on this for scoring:
+#   - confirm `# expect:` lines target the actual offending line
+#   - add nearby unrelated code so we measure FP rate
+#   - ensure the file compiles in your target toolchain
+
+# --- BAD: rule MUST fire ---
+try:  # expect: py-bare-except
+    risky()
+except:
+    pass
+
+# --- GOOD: rule must NOT fire ---
+try:  # ok: py-bare-except
+    risky()
+except Exception as e:
+    logger.error(e)

--- a/eval/rule_harness/fixtures/attocode/python/py-dict-keys-iteration.py
+++ b/eval/rule_harness/fixtures/attocode/python/py-dict-keys-iteration.py
@@ -1,0 +1,11 @@
+# Auto-seeded fixture for rule 'py-dict-keys-iteration'.
+# Hand-curate before relying on this for scoring:
+#   - confirm `# expect:` lines target the actual offending line
+#   - add nearby unrelated code so we measure FP rate
+#   - ensure the file compiles in your target toolchain
+
+# --- BAD: rule MUST fire ---
+for key in config.keys():  # expect: py-dict-keys-iteration
+
+# --- GOOD: rule must NOT fire ---
+for key in config:  # ok: py-dict-keys-iteration

--- a/eval/rule_harness/fixtures/attocode/python/py-mutable-default-arg.py
+++ b/eval/rule_harness/fixtures/attocode/python/py-mutable-default-arg.py
@@ -1,0 +1,17 @@
+# Auto-seeded fixture for rule 'py-mutable-default-arg'.
+# Hand-curate before relying on this for scoring:
+#   - confirm `# expect:` lines target the actual offending line
+#   - add nearby unrelated code so we measure FP rate
+#   - ensure the file compiles in your target toolchain
+
+# --- BAD: rule MUST fire ---
+def add(item, items=[]):  # expect: py-mutable-default-arg
+    items.append(item)
+    return items
+
+# --- GOOD: rule must NOT fire ---
+def add(item, items=None):  # ok: py-mutable-default-arg
+    if items is None:
+        items = []
+    items.append(item)
+    return items

--- a/eval/rule_harness/fixtures/attocode/python/py-string-concat-loop.py
+++ b/eval/rule_harness/fixtures/attocode/python/py-string-concat-loop.py
@@ -1,0 +1,13 @@
+# Auto-seeded fixture for rule 'py-string-concat-loop'.
+# Hand-curate before relying on this for scoring:
+#   - confirm `# expect:` lines target the actual offending line
+#   - add nearby unrelated code so we measure FP rate
+#   - ensure the file compiles in your target toolchain
+
+# --- BAD: rule MUST fire ---
+result = ''  # expect: py-string-concat-loop
+for item in items:
+    result += str(item)
+
+# --- GOOD: rule must NOT fire ---
+result = ''.join(str(item) for item in items)  # ok: py-string-concat-loop

--- a/eval/rule_harness/fixtures/attocode/rust/rs-unwrap-usage.rs
+++ b/eval/rule_harness/fixtures/attocode/rust/rs-unwrap-usage.rs
@@ -1,0 +1,11 @@
+// Auto-seeded fixture for rule 'rs-unwrap-usage'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+let value = result.unwrap();  // expect: rs-unwrap-usage
+
+// --- GOOD: rule must NOT fire ---
+let value = result.expect("config must be valid");  // ok: rs-unwrap-usage

--- a/eval/rule_harness/fixtures/attocode/typescript/eslint-equality.ts
+++ b/eval/rule_harness/fixtures/attocode/typescript/eslint-equality.ts
@@ -1,0 +1,27 @@
+// Hand-curated fixture for eslint eqeqeq + no-var.
+
+const STRICT_MODE = true;
+
+function badEquality(a: unknown, b: unknown): boolean {
+  if (a == b) {                  // expect: eqeqeq
+    return true;
+  }
+  if (a != null) {               // expect: eqeqeq
+    return false;
+  }
+  return false;
+}
+
+function goodEquality(a: unknown, b: unknown): boolean {
+  if (a === b) {                 // ok: eqeqeq
+    return true;
+  }
+  return a !== null;             // ok: eqeqeq
+}
+
+// --- BAD: var keyword ---
+var legacyName = "old style";    // expect: no-var
+
+// --- GOOD: const / let ---
+const goodName = "modern";       // ok: no-var
+let mutableName = "modern";      // ok: no-var

--- a/eval/rule_harness/fixtures/attocode/typescript/eslint-throw-literal.ts
+++ b/eval/rule_harness/fixtures/attocode/typescript/eslint-throw-literal.ts
@@ -1,0 +1,21 @@
+// Hand-curated fixture for eslint no-throw-literal.
+
+class ValidationError extends Error {}
+
+function validateGood(input: string): void {
+  if (!input) {
+    throw new Error("input required");           // ok: no-throw-literal
+  }
+  if (input.length > 100) {
+    throw new ValidationError("too long");       // ok: no-throw-literal
+  }
+}
+
+function validateBad(input: string): void {
+  if (!input) {
+    throw "input required";                       // expect: no-throw-literal
+  }
+  if (input.length > 100) {
+    throw { code: "TOO_LONG", input };            // expect: no-throw-literal
+  }
+}

--- a/eval/rule_harness/fixtures/attocode/typescript/ts-array-push-spread.ts
+++ b/eval/rule_harness/fixtures/attocode/typescript/ts-array-push-spread.ts
@@ -1,0 +1,11 @@
+// Auto-seeded fixture for rule 'ts-array-push-spread'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+result.push(...bigArray)  // expect: ts-array-push-spread
+
+// --- GOOD: rule must NOT fire ---
+for (const item of bigArray) result.push(item)  // ok: ts-array-push-spread

--- a/eval/rule_harness/fixtures/attocode/typescript/ts-await-in-loop.ts
+++ b/eval/rule_harness/fixtures/attocode/typescript/ts-await-in-loop.ts
@@ -1,0 +1,13 @@
+// Auto-seeded fixture for rule 'ts-await-in-loop'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+for (const id of ids) {  // expect: ts-await-in-loop
+  const data = await fetch(id);
+}
+
+// --- GOOD: rule must NOT fire ---
+const results = await Promise.all(ids.map(id => fetch(id)));  // ok: ts-await-in-loop

--- a/eval/rule_harness/fixtures/attocode/typescript/ts-no-optional-chain.ts
+++ b/eval/rule_harness/fixtures/attocode/typescript/ts-no-optional-chain.ts
@@ -1,0 +1,11 @@
+// Auto-seeded fixture for rule 'ts-no-optional-chain'.
+// Hand-curate before relying on this for scoring:
+//   - confirm `# expect:` lines target the actual offending line
+//   - add nearby unrelated code so we measure FP rate
+//   - ensure the file compiles in your target toolchain
+
+// --- BAD: rule MUST fire ---
+if (user && user.address && user.address.city)  // expect: ts-no-optional-chain
+
+// --- GOOD: rule must NOT fire ---
+if (user?.address?.city)  // ok: ts-no-optional-chain

--- a/eval/rule_harness/import_pack.py
+++ b/eval/rule_harness/import_pack.py
@@ -1,0 +1,373 @@
+"""Community rule pack importer.
+
+Generates the legal scaffold (LICENSE + NOTICE + manifest) for a hand-ported
+community pack so the porting work starts in a license-compliant state.
+
+Supported sources (all permissive licenses — no copyleft entanglement):
+
+- ``bandit``  — Python security scanner, Apache-2.0
+- ``gosec``   — Go security scanner, Apache-2.0
+- ``eslint``  — JS/TS linter core rules, MIT
+
+Each source has a hand-curated list of high-value rule IDs that translate
+cleanly to attocode regex patterns. The importer drops a ``PORTING.md``
+checklist into the output dir; humans then write the actual YAML rules
+under ``rules/`` (each with the attribution comment header).
+
+We intentionally do NOT import semgrep-rules: semgrep ships under
+LGPL-2.1, and its copyleft semantics aren't worth the friction relative
+to the rule yield from pure-permissive sources.
+
+Usage::
+
+    python -m eval.rule_harness.import_pack \\
+        --source bandit --lang python \\
+        --output src/attocode/code_intel/rules/packs/community/bandit-python
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import logging
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).parents[2]
+if str(_PROJECT_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+logger = logging.getLogger(__name__)
+
+# License templates ship under packs/community/_license_templates/
+LICENSE_TEMPLATE_DIR = (
+    _PROJECT_ROOT
+    / "src" / "attocode" / "code_intel" / "rules" / "packs"
+    / "community" / "_license_templates"
+)
+
+# SPDX → license text filename. Only permissive licenses are bundled.
+LICENSE_FILES = {
+    "Apache-2.0": "Apache-2.0.txt",
+    "MIT": "MIT.txt",
+}
+
+
+# Per-source defaults: URL, license, attribution boilerplate, porting targets.
+# Each porting target is a short ID + human-readable name; the importer
+# emits these into PORTING.md so the human porter knows what to write.
+SOURCES: dict[str, dict] = {
+    "bandit": {
+        "url": "https://github.com/PyCQA/bandit",
+        "license": "Apache-2.0",
+        "attribution": (
+            "Rule patterns adapted from Bandit (https://github.com/PyCQA/bandit). "
+            "Original copyright PyCQA. Licensed under Apache-2.0."
+        ),
+        "default_language": "python",
+        "porting_targets": [
+            "B105 hardcoded_password_string",
+            "B303 weak_md5_hash",
+            "B304 weak_des_cipher",
+            "B306 mktemp_temp_dir",
+            "B307 use_of_eval",
+            "B321 ftp_lib_used",
+            "B324 weak_sha1_hash",
+            "B501 request_with_no_cert_validation",
+            "B602 subprocess_with_shell_true",
+            "B608 hardcoded_sql_expressions",
+        ],
+    },
+    "gosec": {
+        "url": "https://github.com/securego/gosec",
+        "license": "Apache-2.0",
+        "attribution": (
+            "Rule patterns adapted from gosec (https://github.com/securego/gosec). "
+            "Original copyright securego authors. Licensed under Apache-2.0."
+        ),
+        "default_language": "go",
+        "porting_targets": [
+            "G101 hardcoded_credentials",
+            "G102 bind_to_all_interfaces",
+            "G103 unsafe_block",
+            "G201 sql_format_string",
+            "G203 unescaped_template_data",
+            "G304 file_path_inclusion",
+            "G401 weak_des_or_rc4_crypto",
+            "G402 tls_min_version",
+            "G501 weak_md5_hash",
+            "G505 weak_sha1_hash",
+        ],
+    },
+    "eslint": {
+        "url": "https://github.com/eslint/eslint",
+        "license": "MIT",
+        "attribution": (
+            "Rule patterns adapted from ESLint core rules "
+            "(https://github.com/eslint/eslint). Original copyright OpenJS "
+            "Foundation and contributors. Licensed under MIT."
+        ),
+        "default_language": "typescript",
+        "porting_targets": [
+            "no-eval",
+            "no-implied-eval",
+            "no-new-func",
+            "no-script-url",
+            "no-return-await",
+            "no-var",
+            "prefer-const",
+            "eqeqeq",
+            "no-with",
+            "no-throw-literal",
+        ],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Output writers
+# ---------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def write_license(output_dir: Path, license_id: str) -> bool:
+    """Copy the bundled license template into the output dir."""
+    template_name = LICENSE_FILES.get(license_id)
+    if not template_name:
+        logger.warning("No bundled template for license %s", license_id)
+        return False
+    src = LICENSE_TEMPLATE_DIR / template_name
+    if not src.is_file():
+        logger.warning("License template missing: %s", src)
+        return False
+    output_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, output_dir / "LICENSE")
+    return True
+
+
+def write_notice(
+    output_dir: Path,
+    *,
+    pack_name: str,
+    source_url: str,
+    source_commit: str,
+    license_id: str,
+    attribution: str,
+) -> None:
+    """Write a NOTICE file with attribution + provenance."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    notice = (
+        f"# NOTICE — {pack_name}\n\n"
+        f"{attribution}\n\n"
+        f"Upstream: {source_url}\n"
+        f"Commit:   {source_commit or '(unspecified)'}\n"
+        f"License:  {license_id}\n\n"
+        f"Modifications:\n"
+        f"- Translated rule patterns to attocode UnifiedRule schema\n"
+        f"- Subset selection (high-value rules first)\n\n"
+        f"See LICENSE for full license terms.\n"
+    )
+    (output_dir / "NOTICE").write_text(notice, encoding="utf-8")
+
+
+def write_manifest(
+    output_dir: Path,
+    *,
+    pack_name: str,
+    languages: list[str],
+    description: str,
+    source_url: str,
+    source_commit: str,
+    source_license: str,
+    attribution: str,
+    upstream_count: int,
+    imported_count: int,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": pack_name,
+        "version": "1.0.0",
+        "languages": languages,
+        "description": description,
+        "source": "community",
+        "source_url": source_url,
+        "source_commit": source_commit,
+        "source_license": source_license,
+        "attribution": attribution,
+        "imported_at": _now_iso(),
+        "upstream_rule_count": upstream_count,
+        "imported_rule_count": imported_count,
+    }
+    (output_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8",
+    )
+
+
+def write_porting_md(
+    output_dir: Path,
+    *,
+    pack_name: str,
+    source: str,
+    source_url: str,
+    porting_targets: list[str],
+) -> None:
+    """Write the human porting checklist."""
+    body = (
+        f"# Porting checklist — {pack_name}\n\n"
+        f"Rules from {source} ({source_url}) are not YAML-defined upstream\n"
+        f"and require manual porting. Each ported rule MUST include the\n"
+        f"attribution comment header at the top of its YAML file:\n\n"
+        f"```yaml\n"
+        f"# Adapted from {source} rule '<original-id>'\n"
+        f"# See ../LICENSE and ../NOTICE for license terms.\n"
+        f"```\n\n"
+        f"Porting targets:\n\n"
+        + "\n".join(f"- [ ] {target}" for target in porting_targets)
+        + "\n"
+    )
+    (output_dir / "PORTING.md").write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Importer driver
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ImportSummary:
+    """Result of an import scaffold run."""
+
+    pack_name: str
+    output_dir: Path
+    source: str
+    license: str
+    upstream_count: int = 0
+    files_written: list[str] = field(default_factory=list)
+
+
+def scaffold_pack(
+    *,
+    source: str,
+    output_dir: Path,
+    pack_name: str,
+    language: str,
+    commit: str = "",
+) -> ImportSummary:
+    """Build the legal + manifest + porting shell for a community pack.
+
+    No rules are written — a ``PORTING.md`` checklist is left for a human
+    to fill in. The pack ships in a license-compliant state from day one.
+    """
+    if source not in SOURCES:
+        raise ValueError(
+            f"Unknown source {source!r}; supported: {sorted(SOURCES)}"
+        )
+    defaults = SOURCES[source]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "rules").mkdir(parents=True, exist_ok=True)
+
+    summary = ImportSummary(
+        pack_name=pack_name,
+        output_dir=output_dir,
+        source=source,
+        license=defaults["license"],
+        upstream_count=len(defaults["porting_targets"]),
+    )
+
+    if write_license(output_dir, defaults["license"]):
+        summary.files_written.append("LICENSE")
+
+    write_manifest(
+        output_dir,
+        pack_name=pack_name,
+        languages=[language],
+        description=(
+            f"Hand-ported subset of {source} rules. "
+            f"See PORTING.md for the porting checklist."
+        ),
+        source_url=defaults["url"],
+        source_commit=commit,
+        source_license=defaults["license"],
+        attribution=defaults["attribution"],
+        upstream_count=len(defaults["porting_targets"]),
+        imported_count=0,
+    )
+    summary.files_written.append("manifest.yaml")
+
+    write_notice(
+        output_dir,
+        pack_name=pack_name,
+        source_url=defaults["url"],
+        source_commit=commit,
+        license_id=defaults["license"],
+        attribution=defaults["attribution"],
+    )
+    summary.files_written.append("NOTICE")
+
+    write_porting_md(
+        output_dir,
+        pack_name=pack_name,
+        source=source,
+        source_url=defaults["url"],
+        porting_targets=defaults["porting_targets"],
+    )
+    summary.files_written.append("PORTING.md")
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="eval.rule_harness.import_pack",
+        description=(
+            "Scaffold a community rule pack with proper license attribution. "
+            "Ports are then written by hand into rules/."
+        ),
+    )
+    parser.add_argument("--source", required=True, choices=list(SOURCES))
+    parser.add_argument("--lang", default="",
+                        help="Target language (defaults per source)")
+    parser.add_argument("--output", required=True,
+                        help="Output dir under packs/community/")
+    parser.add_argument("--pack-name", default="",
+                        help="Pack name (default: derived from --output)")
+    parser.add_argument("--commit", default="",
+                        help="Source commit SHA (recorded in NOTICE/manifest)")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output).resolve()
+    pack_name = args.pack_name or output_dir.name
+    language = args.lang or SOURCES[args.source]["default_language"]
+
+    summary = scaffold_pack(
+        source=args.source,
+        output_dir=output_dir,
+        pack_name=pack_name,
+        language=language,
+        commit=args.commit,
+    )
+
+    print(f"Pack: {summary.pack_name}")
+    print(f"  Source:  {summary.source} ({summary.license})")
+    print(f"  Output:  {summary.output_dir}")
+    print(f"  Upstream targets: {summary.upstream_count}")
+    print(f"  Files written:    {', '.join(summary.files_written)}")
+    print(f"\nNext: hand-port rules listed in {summary.output_dir / 'PORTING.md'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/rule_harness/scripts/seed_attocode_fixtures.py
+++ b/eval/rule_harness/scripts/seed_attocode_fixtures.py
@@ -1,0 +1,210 @@
+"""Scaffold hand-labeled corpus fixtures from example pack rule examples.
+
+Walks ``packs/examples/<lang>/rules/*.yaml``, finds rules with at least
+one ``examples: [{bad, good}]`` entry, and emits a fixture stub at
+``eval/rule_harness/fixtures/attocode/<lang>/<rule-id>.<ext>`` containing:
+
+- the ``bad`` snippet wrapped in a function/scope, with ``# expect:``
+  appended to the offending line
+- the ``good`` snippet with ``# ok:`` appended
+
+The output is a starting point — humans then edit each file to add
+edge cases, ensure it compiles, and add nearby unrelated code so we
+measure FP rate properly.
+
+Usage::
+
+    python -m eval.rule_harness.scripts.seed_attocode_fixtures \\
+        [--overwrite] [--lang python,go,...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).parents[3]
+if str(_PROJECT_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT / "src"))
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+logger = logging.getLogger(__name__)
+
+EXAMPLES_DIR = (
+    _PROJECT_ROOT / "src" / "attocode" / "code_intel" / "rules" / "packs" / "examples"
+)
+FIXTURE_ROOT = (
+    _PROJECT_ROOT / "eval" / "rule_harness" / "fixtures" / "attocode"
+)
+
+# language → file extension + line comment marker
+LANG_INFO: dict[str, tuple[str, str]] = {
+    "python": (".py", "#"),
+    "go": (".go", "//"),
+    "typescript": (".ts", "//"),
+    "javascript": (".js", "//"),
+    "rust": (".rs", "//"),
+    "java": (".java", "//"),
+    "kotlin": (".kt", "//"),
+    "ruby": (".rb", "#"),
+    "php": (".php", "//"),
+    "c": (".c", "//"),
+    "cpp": (".cpp", "//"),
+}
+
+
+def discover_rule_examples(
+    pack_dir: Path,
+) -> list[tuple[str, dict, str]]:
+    """Return ``(rule_id, rule_dict, language)`` triples that have examples."""
+    out: list[tuple[str, dict, str]] = []
+    rules_dir = pack_dir / "rules"
+    if not rules_dir.is_dir():
+        return out
+    for yaml_file in sorted(rules_dir.glob("*.yaml")):
+        try:
+            data = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.warning("Skipping %s: %s", yaml_file, exc)
+            continue
+        items = data if isinstance(data, list) else [data] if isinstance(data, dict) else []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if not item.get("examples"):
+                continue
+            languages = item.get("languages") or []
+            if isinstance(languages, str):
+                languages = [languages]
+            lang = languages[0] if languages else pack_dir.name
+            out.append((str(item["id"]), item, lang))
+    return out
+
+
+def render_fixture(rule_id: str, rule: dict, language: str) -> str:
+    """Build the fixture body from a rule's first example."""
+    if language not in LANG_INFO:
+        raise ValueError(f"Unknown language: {language}")
+    _ext, marker = LANG_INFO[language]
+    examples = rule.get("examples") or []
+    if not examples:
+        raise ValueError(f"Rule {rule_id} has no examples")
+    first = examples[0]
+    bad = str(first.get("bad", "")).rstrip()
+    good = str(first.get("good", "")).rstrip()
+
+    header = (
+        f"{marker} Auto-seeded fixture for rule '{rule_id}'.\n"
+        f"{marker} Hand-curate before relying on this for scoring:\n"
+        f"{marker}   - confirm `# expect:` lines target the actual offending line\n"
+        f"{marker}   - add nearby unrelated code so we measure FP rate\n"
+        f"{marker}   - ensure the file compiles in your target toolchain\n\n"
+    )
+
+    bad_block = _annotate_block(
+        bad, marker=marker, kind="expect", rule_id=rule_id,
+    )
+    good_block = _annotate_block(
+        good, marker=marker, kind="ok", rule_id=rule_id,
+    )
+
+    return (
+        header
+        + f"{marker} --- BAD: rule MUST fire ---\n"
+        + bad_block
+        + f"\n\n{marker} --- GOOD: rule must NOT fire ---\n"
+        + good_block
+        + "\n"
+    )
+
+
+def _annotate_block(code: str, *, marker: str, kind: str, rule_id: str) -> str:
+    """Append ``marker kind: rule_id`` to the first non-empty code line."""
+    if not code.strip():
+        return code
+    lines = code.splitlines()
+    annotated_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() and not line.lstrip().startswith(marker):
+            annotated_idx = i
+            break
+    if annotated_idx is None:
+        return code
+    lines[annotated_idx] = f"{lines[annotated_idx]}  {marker} {kind}: {rule_id}"
+    return "\n".join(lines)
+
+
+def seed_fixtures(
+    *,
+    languages: list[str] | None = None,
+    overwrite: bool = False,
+) -> dict[str, list[str]]:
+    """Walk example packs and emit fixture stubs per rule.
+
+    Returns ``{language: [list of fixture paths written]}``.
+    """
+    summary: dict[str, list[str]] = {}
+    if not EXAMPLES_DIR.is_dir():
+        logger.error("Example packs dir missing: %s", EXAMPLES_DIR)
+        return summary
+
+    for pack_dir in sorted(EXAMPLES_DIR.iterdir()):
+        if not pack_dir.is_dir() or pack_dir.name.startswith("_"):
+            continue
+        for rule_id, rule, language in discover_rule_examples(pack_dir):
+            if languages and language not in languages:
+                continue
+            if language not in LANG_INFO:
+                continue
+            ext, _marker = LANG_INFO[language]
+            target_dir = FIXTURE_ROOT / language
+            target_dir.mkdir(parents=True, exist_ok=True)
+            target_file = target_dir / f"{rule_id}{ext}"
+            if target_file.exists() and not overwrite:
+                logger.info("Skipping (exists): %s", target_file)
+                continue
+            try:
+                body = render_fixture(rule_id, rule, language)
+            except ValueError as exc:
+                logger.warning("Skipping %s: %s", rule_id, exc)
+                continue
+            target_file.write_text(body, encoding="utf-8")
+            summary.setdefault(language, []).append(str(target_file))
+
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="eval.rule_harness.scripts.seed_attocode_fixtures",
+        description=(
+            "Auto-seed hand-labeled corpus stubs from example pack rule examples"
+        ),
+    )
+    parser.add_argument("--lang", default="",
+                        help="Comma-separated languages to seed (default: all)")
+    parser.add_argument("--overwrite", action="store_true",
+                        help="Overwrite existing fixture files")
+    args = parser.parse_args()
+
+    langs = [s.strip() for s in args.lang.split(",") if s.strip()] if args.lang else None
+    summary = seed_fixtures(languages=langs, overwrite=args.overwrite)
+
+    total = sum(len(v) for v in summary.values())
+    print(f"Seeded {total} fixture stub(s)")
+    for lang, files in sorted(summary.items()):
+        print(f"  {lang}: {len(files)}")
+        for path in files:
+            print(f"    {path}")
+
+    if total == 0:
+        print("\nHint: pass --overwrite to regenerate existing fixtures")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
       - Observability: guides/observability.md
       - Architecture Decisions: guides/architecture-decisions.md
       - Evaluation & Benchmarks: guides/evaluation-and-benchmarks.md
+      - Rule-Bench Corpus: guides/rule-bench-corpus.md
       - Providers: PROVIDERS.md
       - Provider Resilience: provider-resilience.md
       - Sandbox: SANDBOX.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "attocode"
-version = "0.2.21"
+version = "0.2.22"
 description = "Production AI coding agent"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -201,7 +201,7 @@ exclude_lines = [
 ]
 
 [tool.bumpversion]
-current_version = "0.2.21"
+current_version = "0.2.22"
 commit = false
 tag = false
 

--- a/scripts/check_pack_licenses.py
+++ b/scripts/check_pack_licenses.py
@@ -1,0 +1,131 @@
+"""License compliance check for community rule packs.
+
+Walks ``src/attocode/code_intel/rules/packs/community/`` and verifies each
+pack ships with a LICENSE file, NOTICE file, and a manifest declaring an
+SPDX license from the allowlist. Exits non-zero on any error so the CI
+job fails when a contributor forgets the legal scaffold.
+
+Usage::
+
+    python scripts/check_pack_licenses.py [--strict]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+
+_PROJECT_ROOT = Path(__file__).parents[1]
+COMMUNITY_DIR = (
+    _PROJECT_ROOT
+    / "src" / "attocode" / "code_intel" / "rules" / "packs" / "community"
+)
+
+# Permissive licenses only — copyleft sources are NOT shipped here.
+ALLOWED_LICENSES = {
+    "Apache-2.0",
+    "MIT",
+    "BSD-3-Clause",
+    "BSD-2-Clause",
+    "ISC",
+}
+
+REQUIRED_FILES = ("LICENSE", "NOTICE", "manifest.yaml")
+REQUIRED_MANIFEST_FIELDS = ("name", "source_license", "source", "attribution")
+
+
+def check_pack(pack_dir: Path) -> list[str]:
+    """Return a list of error strings for *pack_dir*. Empty = compliant."""
+    errors: list[str] = []
+    pack_label = pack_dir.name
+
+    for filename in REQUIRED_FILES:
+        if not (pack_dir / filename).is_file():
+            errors.append(f"{pack_label}: missing {filename}")
+
+    manifest_path = pack_dir / "manifest.yaml"
+    if not manifest_path.is_file():
+        return errors  # Already reported above
+
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:
+        errors.append(f"{pack_label}: manifest unreadable ({exc})")
+        return errors
+
+    for field in REQUIRED_MANIFEST_FIELDS:
+        if not manifest.get(field):
+            errors.append(f"{pack_label}: manifest missing {field!r}")
+
+    license_id = str(manifest.get("source_license") or "")
+    if license_id and license_id not in ALLOWED_LICENSES:
+        errors.append(
+            f"{pack_label}: license {license_id!r} not in allowlist "
+            f"({sorted(ALLOWED_LICENSES)})"
+        )
+
+    license_file = pack_dir / "LICENSE"
+    if license_file.is_file() and license_file.stat().st_size < 200:
+        errors.append(
+            f"{pack_label}: LICENSE looks truncated "
+            f"({license_file.stat().st_size} bytes)"
+        )
+
+    return errors
+
+
+def discover_packs(community_dir: Path = COMMUNITY_DIR) -> list[Path]:
+    if not community_dir.is_dir():
+        return []
+    return [
+        p for p in sorted(community_dir.iterdir())
+        if p.is_dir() and not p.name.startswith("_")
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="scripts.check_pack_licenses",
+        description="Verify every community pack ships license + attribution",
+    )
+    parser.add_argument(
+        "--community-dir", default=str(COMMUNITY_DIR),
+        help="Override the community packs root (default: shipped location)",
+    )
+    parser.add_argument(
+        "--strict", action="store_true",
+        help="Exit non-zero even when no packs are found (CI guard)",
+    )
+    args = parser.parse_args()
+
+    community_dir = Path(args.community_dir)
+    packs = discover_packs(community_dir)
+    if not packs:
+        msg = f"No community packs found under {community_dir}"
+        if args.strict:
+            print(f"error: {msg}", file=sys.stderr)
+            return 1
+        print(msg)
+        return 0
+
+    all_errors: list[str] = []
+    for pack in packs:
+        all_errors.extend(check_pack(pack))
+
+    if all_errors:
+        print(f"License check FAILED — {len(all_errors)} issue(s):")
+        for err in all_errors:
+            print(f"  - {err}")
+        return 1
+
+    print(f"License check OK — {len(packs)} packs verified")
+    for pack in packs:
+        print(f"  ✓ {pack.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/attocode/__init__.py
+++ b/src/attocode/__init__.py
@@ -1,3 +1,3 @@
 """Attocode - Production AI coding agent."""
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"

--- a/src/attocode/code_intel/rules/loader.py
+++ b/src/attocode/code_intel/rules/loader.py
@@ -230,6 +230,10 @@ def _parse_yaml_rule(
     raw_tags = data.get("tags", [])
     tags = [raw_tags] if isinstance(raw_tags, str) else list(raw_tags)
 
+    # External references (CWE links, blog posts, etc.) — preserved on import
+    raw_refs = data.get("references", [])
+    references = [raw_refs] if isinstance(raw_refs, str) else list(raw_refs)
+
     return UnifiedRule(
         id=str(data["id"]),
         name=str(data.get("name", data["id"])),
@@ -255,6 +259,7 @@ def _parse_yaml_rule(
         metavar_regex=metavar_regex,
         metavar_comparison=metavar_comparison,
         composite_pattern=composite_pattern,
+        references=references,
     )
 
 

--- a/src/attocode/code_intel/rules/model.py
+++ b/src/attocode/code_intel/rules/model.py
@@ -157,6 +157,11 @@ class UnifiedRule:
     # Boolean combinators (A3) — when set, executor uses composite evaluation
     composite_pattern: CompositePattern | None = None
 
+    # External references (CWE links, blog posts, doc URLs). Preserved by
+    # community pack importers (e.g. semgrep ``metadata.references``) so the
+    # provenance of a rule is not lost on conversion.
+    references: list[str] = field(default_factory=list)
+
     @property
     def qualified_id(self) -> str:
         """Pack-qualified ID (e.g. 'go/performance/sprintf-in-loop')."""

--- a/src/attocode/code_intel/rules/packs/community/_license_templates/Apache-2.0.txt
+++ b/src/attocode/code_intel/rules/packs/community/_license_templates/Apache-2.0.txt
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS

--- a/src/attocode/code_intel/rules/packs/community/_license_templates/MIT.txt
+++ b/src/attocode/code_intel/rules/packs/community/_license_templates/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDERS>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/LICENSE
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/NOTICE
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/NOTICE
@@ -1,0 +1,13 @@
+# NOTICE — bandit-python
+
+Rule patterns adapted from Bandit (https://github.com/PyCQA/bandit). Original copyright PyCQA. Licensed under Apache-2.0.
+
+Upstream: https://github.com/PyCQA/bandit
+Commit:   (unspecified)
+License:  Apache-2.0
+
+Modifications:
+- Translated rule patterns to attocode UnifiedRule schema
+- Subset selection (high-value rules first)
+
+See LICENSE for full license terms.

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/PORTING.md
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/PORTING.md
@@ -1,0 +1,23 @@
+# Porting checklist — bandit-python
+
+Rules from bandit (https://github.com/PyCQA/bandit) are not YAML-defined upstream
+and require manual porting. Each ported rule MUST include the
+attribution comment header at the top of its YAML file:
+
+```yaml
+# Adapted from bandit rule '<original-id>'
+# See ../LICENSE and ../NOTICE for license terms.
+```
+
+Porting targets:
+
+- [ ] B105 hardcoded_password_string
+- [ ] B303 weak_md5_hash
+- [ ] B304 weak_des_cipher
+- [ ] B306 mktemp_temp_dir
+- [ ] B307 use_of_eval
+- [ ] B321 ftp_lib_used
+- [ ] B324 weak_sha1_hash
+- [ ] B501 request_with_no_cert_validation
+- [ ] B602 subprocess_with_shell_true
+- [ ] B608 hardcoded_sql_expressions

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/manifest.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/manifest.yaml
@@ -1,0 +1,14 @@
+name: bandit-python
+version: 1.0.0
+languages:
+- python
+description: Hand-ported subset of bandit rules. See PORTING.md for the porting checklist.
+source: community
+source_url: https://github.com/PyCQA/bandit
+source_commit: ''
+source_license: Apache-2.0
+attribution: Rule patterns adapted from Bandit (https://github.com/PyCQA/bandit).
+  Original copyright PyCQA. Licensed under Apache-2.0.
+imported_at: '2026-04-16T12:20:09Z'
+upstream_rule_count: 10
+imported_rule_count: 0

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B105-hardcoded-password.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B105-hardcoded-password.yaml
@@ -1,0 +1,23 @@
+# Adapted from bandit rule 'B105 hardcoded_password_string'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B105-hardcoded-password
+name: Hardcoded password string
+message: Possible hardcoded password assignment
+severity: high
+category: security
+languages: [python]
+confidence: 0.7
+cwe: CWE-798
+pattern: '(?i)\b(password|passwd|pwd|secret|token|api_key|apikey)\s*=\s*[''"][^''"]{3,}[''"]'
+explanation: |
+  Storing credentials in source code makes them easy to leak via version
+  control, logs, or stack traces. Bandit B105 catches the string-assignment
+  variant.
+recommendation: |
+  Move credentials to a secret manager (env vars, AWS Secrets Manager,
+  Vault) and read them at runtime. For tests, use clearly-non-credential
+  placeholders (e.g. ``"PLACEHOLDER"``).
+references:
+  - https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
+  - https://cwe.mitre.org/data/definitions/798.html

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B303-weak-md5.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B303-weak-md5.yaml
@@ -1,0 +1,21 @@
+# Adapted from bandit rule 'B303 weak_md5_hash'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B303-weak-md5
+name: Use of weak MD5 hash
+message: MD5 is cryptographically broken; use SHA-256 or stronger
+severity: high
+category: security
+languages: [python]
+confidence: 0.85
+cwe: CWE-327
+pattern: '\bhashlib\.md5\s*\('
+explanation: |
+  MD5 is vulnerable to collision attacks and is no longer considered
+  cryptographically secure. Bandit B303 flags any use as a security issue.
+recommendation: |
+  Use ``hashlib.sha256`` (or SHA-3) for cryptographic hashing. If the use
+  is non-security (e.g. cache key), pass ``usedforsecurity=False`` (Python 3.9+).
+references:
+  - https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html
+  - https://cwe.mitre.org/data/definitions/327.html

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B304-weak-des.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B304-weak-des.yaml
@@ -1,0 +1,20 @@
+# Adapted from bandit rule 'B304 weak_cipher'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B304-weak-des
+name: Use of weak DES cipher
+message: DES/3DES are cryptographically weak; use AES-GCM
+severity: high
+category: security
+languages: [python]
+confidence: 0.85
+cwe: CWE-327
+pattern: '\b(DES|TripleDES|ARC2|ARC4|Blowfish)\.new\s*\('
+explanation: |
+  DES has a 56-bit key (brute-forceable), 3DES is deprecated by NIST,
+  and RC4/RC2 have known biases. These ciphers should not be used.
+recommendation: |
+  Use AES-256-GCM via ``cryptography`` library
+  (``Cipher(algorithms.AES(key), modes.GCM(iv))``).
+references:
+  - https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B307-use-of-eval.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B307-use-of-eval.yaml
@@ -1,0 +1,22 @@
+# Adapted from bandit rule 'B307 use_of_eval'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B307-use-of-eval
+name: Use of dynamic code evaluation
+message: Avoid eval/exec on dynamic input — leads to arbitrary code execution
+severity: critical
+category: security
+languages: [python]
+confidence: 0.8
+cwe: CWE-95
+pattern: '\b(eval|exec)\s*\('
+explanation: |
+  ``eval`` and ``exec`` interpret arbitrary strings as Python code. If any
+  part of the input is influenced by an external source, an attacker can
+  execute commands.
+recommendation: |
+  Use ``ast.literal_eval`` for trusted literal expressions, or a proper
+  parser/DSL for dynamic logic.
+references:
+  - https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html
+  - https://cwe.mitre.org/data/definitions/95.html

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B324-weak-sha1.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B324-weak-sha1.yaml
@@ -1,0 +1,21 @@
+# Adapted from bandit rule 'B324 weak_sha1_hash'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B324-weak-sha1
+name: Use of weak SHA-1 hash
+message: SHA-1 is cryptographically broken; use SHA-256 or stronger
+severity: high
+category: security
+languages: [python]
+confidence: 0.85
+cwe: CWE-327
+pattern: '\bhashlib\.sha1\s*\('
+explanation: |
+  SHA-1 has known collision attacks (SHAttered, 2017) and should not be
+  used for cryptographic purposes.
+recommendation: |
+  Use ``hashlib.sha256`` (or SHA-3). For non-security hashing such as
+  ETags or cache keys, pass ``usedforsecurity=False``.
+references:
+  - https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html
+  - https://cwe.mitre.org/data/definitions/327.html

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B501-no-cert-validation.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B501-no-cert-validation.yaml
@@ -1,0 +1,23 @@
+# Adapted from bandit rule 'B501 request_with_no_cert_validation'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B501-no-cert-validation
+name: HTTPS request with TLS verification disabled
+message: TLS certificate verification disabled — vulnerable to MITM
+severity: high
+category: security
+languages: [python]
+confidence: 0.85
+cwe: CWE-295
+pattern: '\bverify\s*=\s*False\b'
+explanation: |
+  Setting ``verify=False`` on requests/httpx/urllib3 calls disables TLS
+  certificate validation. An attacker on the network can intercept,
+  read, or modify the traffic.
+recommendation: |
+  Leave verification enabled. If self-signed CAs are needed, point
+  ``verify`` at a CA bundle path (``verify="/path/to/ca.crt"``) rather
+  than disabling.
+references:
+  - https://bandit.readthedocs.io/en/latest/plugins/b501_request_with_no_cert_validation.html
+  - https://cwe.mitre.org/data/definitions/295.html

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B602-shell-true.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B602-shell-true.yaml
@@ -1,0 +1,22 @@
+# Adapted from bandit rule 'B602 subprocess_with_shell_true'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B602-shell-true
+name: Subprocess invoked with shell=True
+message: subprocess with shell=True is vulnerable to command injection
+severity: high
+category: security
+languages: [python]
+confidence: 0.8
+cwe: CWE-78
+pattern: '\bsubprocess\.\w+\([^)]*\bshell\s*=\s*True'
+explanation: |
+  ``subprocess.run/Popen/call`` with ``shell=True`` invokes the shell to
+  parse the command. If any argument comes from user input, the shell
+  will interpret meta-characters (``;``, ``|``, ``&&``, backticks).
+recommendation: |
+  Pass arguments as a list (``subprocess.run(["ls", "-la", path])``)
+  without ``shell=True``. The OS calls execve directly — no shell parsing.
+references:
+  - https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
+  - https://cwe.mitre.org/data/definitions/78.html

--- a/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B608-sqli.yaml
+++ b/src/attocode/code_intel/rules/packs/community/bandit-python/rules/B608-sqli.yaml
@@ -1,0 +1,22 @@
+# Adapted from bandit rule 'B608 hardcoded_sql_expressions'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: B608-sqli
+name: SQL string built via concatenation or f-string
+message: SQL string interpolation — possible injection
+severity: high
+category: security
+languages: [python]
+confidence: 0.6
+cwe: CWE-89
+pattern: '(SELECT|INSERT|UPDATE|DELETE)\s+[^;''"]*[''"]\s*[+%]\s*\w+'
+explanation: |
+  Building SQL by concatenating user input or formatting variables into
+  the query string is the classic SQL-injection pattern. The bandit
+  variant catches both ``+`` concatenation and ``%`` formatting.
+recommendation: |
+  Use parameterized queries (``cursor.execute(sql, (var,))``) so the
+  database driver handles escaping. ORMs do this automatically.
+references:
+  - https://bandit.readthedocs.io/en/latest/plugins/b608_hardcoded_sql_expressions.html
+  - https://cwe.mitre.org/data/definitions/89.html

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/LICENSE
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) <YEAR> <COPYRIGHT HOLDERS>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/NOTICE
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/NOTICE
@@ -1,0 +1,13 @@
+# NOTICE — eslint-typescript
+
+Rule patterns adapted from ESLint core rules (https://github.com/eslint/eslint). Original copyright OpenJS Foundation and contributors. Licensed under MIT.
+
+Upstream: https://github.com/eslint/eslint
+Commit:   (unspecified)
+License:  MIT
+
+Modifications:
+- Translated rule patterns to attocode UnifiedRule schema
+- Subset selection (high-value rules first)
+
+See LICENSE for full license terms.

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/PORTING.md
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/PORTING.md
@@ -1,0 +1,23 @@
+# Porting checklist — eslint-typescript
+
+Rules from eslint (https://github.com/eslint/eslint) are not YAML-defined upstream
+and require manual porting. Each ported rule MUST include the
+attribution comment header at the top of its YAML file:
+
+```yaml
+# Adapted from eslint rule '<original-id>'
+# See ../LICENSE and ../NOTICE for license terms.
+```
+
+Porting targets:
+
+- [ ] no-eval
+- [ ] no-implied-eval
+- [ ] no-new-func
+- [ ] no-script-url
+- [ ] no-return-await
+- [ ] no-var
+- [ ] prefer-const
+- [ ] eqeqeq
+- [ ] no-with
+- [ ] no-throw-literal

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/manifest.yaml
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/manifest.yaml
@@ -1,0 +1,14 @@
+name: eslint-typescript
+version: 1.0.0
+languages:
+- typescript
+description: Hand-ported subset of eslint rules. See PORTING.md for the porting checklist.
+source: community
+source_url: https://github.com/eslint/eslint
+source_commit: ''
+source_license: MIT
+attribution: Rule patterns adapted from ESLint core rules (https://github.com/eslint/eslint).
+  Original copyright OpenJS Foundation and contributors. Licensed under MIT.
+imported_at: '2026-04-16T12:20:09Z'
+upstream_rule_count: 10
+imported_rule_count: 0

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/eqeqeq.yaml
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/eqeqeq.yaml
@@ -1,0 +1,20 @@
+# Adapted from eslint rule 'eqeqeq'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: eqeqeq
+name: Loose equality comparison
+message: Use === / !== instead of == / !=
+severity: medium
+category: correctness
+languages: [javascript, typescript]
+confidence: 0.85
+pattern: '[^!=<>]==[^=]|[^!]!=[^=]'
+explanation: |
+  ``==`` and ``!=`` perform implicit type coercion, leading to
+  surprising comparisons (``"" == 0`` is true, ``[] == false`` is true).
+  Strict equality avoids the trap.
+recommendation: |
+  Use ``===`` and ``!==``. If type coercion is genuinely intended,
+  add a comment so the next reader knows it's deliberate.
+references:
+  - https://eslint.org/docs/latest/rules/eqeqeq

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-eval.yaml
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-eval.yaml
@@ -1,0 +1,22 @@
+# Adapted from eslint rule 'no-eval'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: no-eval
+name: Dynamic code evaluation
+message: Avoid dynamic code evaluation — arbitrary code execution risk
+severity: critical
+category: security
+languages: [javascript, typescript]
+confidence: 0.85
+cwe: CWE-95
+pattern: '\beval\s*\('
+explanation: |
+  The eval function interprets arbitrary strings as JavaScript and runs
+  them in the local scope. Hard to sandbox; trivial to abuse if any
+  input crosses a trust boundary.
+recommendation: |
+  Use JSON.parse for JSON, a real parser for DSLs, or feature flags /
+  dispatch tables for dynamic behavior.
+references:
+  - https://eslint.org/docs/latest/rules/no-eval
+  - https://cwe.mitre.org/data/definitions/95.html

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-implied-eval.yaml
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-implied-eval.yaml
@@ -1,0 +1,20 @@
+# Adapted from eslint rule 'no-implied-eval'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: no-implied-eval
+name: Implied dynamic code evaluation
+message: setTimeout/setInterval with a string argument runs as code
+severity: high
+category: security
+languages: [javascript, typescript]
+confidence: 0.8
+cwe: CWE-95
+pattern: '\b(setTimeout|setInterval)\s*\(\s*[''"]'
+explanation: |
+  Passing a string (instead of a function) to setTimeout / setInterval
+  evaluates that string as code at the global scope — equivalent to
+  using the eval function.
+recommendation: |
+  Pass an arrow function or function reference: setTimeout(() => doX(), 100).
+references:
+  - https://eslint.org/docs/latest/rules/no-implied-eval

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-new-func.yaml
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-new-func.yaml
@@ -1,0 +1,21 @@
+# Adapted from eslint rule 'no-new-func'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: no-new-func
+name: Function constructor used to evaluate code
+message: Function constructor compiles strings into code
+severity: high
+category: security
+languages: [javascript, typescript]
+confidence: 0.85
+cwe: CWE-95
+pattern: '\bnew\s+Function\s*\('
+explanation: |
+  Constructing a function from a string source compiles arbitrary code
+  at runtime, bypassing lexical scope and lint/type analysis.
+recommendation: |
+  Define functions inline or via factory closures. If runtime code
+  generation is genuinely needed, isolate it in a worker with limited
+  capabilities.
+references:
+  - https://eslint.org/docs/latest/rules/no-new-func

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-throw-literal.yaml
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-throw-literal.yaml
@@ -1,0 +1,19 @@
+# Adapted from eslint rule 'no-throw-literal'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: no-throw-literal
+name: Throwing a non-Error literal
+message: Throw an Error subclass, not a raw string or object literal
+severity: medium
+category: correctness
+languages: [javascript, typescript]
+confidence: 0.8
+pattern: '\bthrow\s+[''"`{]'
+explanation: |
+  Throwing a string or object literal loses the stack trace and the
+  ``instanceof Error`` check that downstream catch handlers rely on.
+recommendation: |
+  ``throw new Error("...")`` (or a custom subclass) so callers get the
+  expected interface.
+references:
+  - https://eslint.org/docs/latest/rules/no-throw-literal

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-var.yaml
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-var.yaml
@@ -1,0 +1,20 @@
+# Adapted from eslint rule 'no-var'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: no-var
+name: Use of var keyword
+message: Prefer let or const over var
+severity: low
+category: style
+languages: [javascript, typescript]
+confidence: 0.95
+pattern: '^\s*var\s+\w'
+explanation: |
+  ``var`` declarations are function-scoped and hoisted, leading to
+  surprising behavior. ``let`` and ``const`` are block-scoped and
+  match developer intuition.
+recommendation: |
+  Replace ``var`` with ``const`` for constants or ``let`` for
+  reassignable bindings.
+references:
+  - https://eslint.org/docs/latest/rules/no-var

--- a/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-with.yaml
+++ b/src/attocode/code_intel/rules/packs/community/eslint-typescript/rules/no-with.yaml
@@ -1,0 +1,18 @@
+# Adapted from eslint rule 'no-with'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: no-with
+name: Use of with statement
+message: with statement is forbidden in strict mode
+severity: high
+category: correctness
+languages: [javascript, typescript]
+confidence: 0.9
+pattern: '\bwith\s*\('
+explanation: |
+  ``with`` extends the scope chain at runtime, making variable
+  resolution ambiguous. It's banned in strict mode and ES modules.
+recommendation: |
+  Bind the object to a local variable and access fields explicitly.
+references:
+  - https://eslint.org/docs/latest/rules/no-with

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/LICENSE
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/LICENSE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/NOTICE
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/NOTICE
@@ -1,0 +1,13 @@
+# NOTICE — gosec-go
+
+Rule patterns adapted from gosec (https://github.com/securego/gosec). Original copyright securego authors. Licensed under Apache-2.0.
+
+Upstream: https://github.com/securego/gosec
+Commit:   (unspecified)
+License:  Apache-2.0
+
+Modifications:
+- Translated rule patterns to attocode UnifiedRule schema
+- Subset selection (high-value rules first)
+
+See LICENSE for full license terms.

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/PORTING.md
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/PORTING.md
@@ -1,0 +1,23 @@
+# Porting checklist — gosec-go
+
+Rules from gosec (https://github.com/securego/gosec) are not YAML-defined upstream
+and require manual porting. Each ported rule MUST include the
+attribution comment header at the top of its YAML file:
+
+```yaml
+# Adapted from gosec rule '<original-id>'
+# See ../LICENSE and ../NOTICE for license terms.
+```
+
+Porting targets:
+
+- [ ] G101 hardcoded_credentials
+- [ ] G102 bind_to_all_interfaces
+- [ ] G103 unsafe_block
+- [ ] G201 sql_format_string
+- [ ] G203 unescaped_template_data
+- [ ] G304 file_path_inclusion
+- [ ] G401 weak_des_or_rc4_crypto
+- [ ] G402 tls_min_version
+- [ ] G501 weak_md5_hash
+- [ ] G505 weak_sha1_hash

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/manifest.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/manifest.yaml
@@ -1,0 +1,14 @@
+name: gosec-go
+version: 1.0.0
+languages:
+- go
+description: Hand-ported subset of gosec rules. See PORTING.md for the porting checklist.
+source: community
+source_url: https://github.com/securego/gosec
+source_commit: ''
+source_license: Apache-2.0
+attribution: Rule patterns adapted from gosec (https://github.com/securego/gosec).
+  Original copyright securego authors. Licensed under Apache-2.0.
+imported_at: '2026-04-16T12:20:09Z'
+upstream_rule_count: 10
+imported_rule_count: 0

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G101-hardcoded-credentials.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G101-hardcoded-credentials.yaml
@@ -1,0 +1,22 @@
+# Adapted from gosec rule 'G101 hardcoded_credentials'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: G101-hardcoded-credentials
+name: Hardcoded credentials in source
+message: Possible hardcoded credential in source
+severity: high
+category: security
+languages: [go]
+confidence: 0.7
+cwe: CWE-798
+pattern: '(?i)(password|passwd|pwd|secret|token|apikey|api_key)\s*[:=]\s*"[^"]{4,}"'
+explanation: |
+  Storing credentials in Go source — whether as struct fields, package
+  vars, or const literals — leaks them to anyone with read access to the
+  binary or repo.
+recommendation: |
+  Read secrets from env vars (``os.Getenv``), KMS, Vault, or Kubernetes
+  secrets at runtime.
+references:
+  - https://github.com/securego/gosec
+  - https://cwe.mitre.org/data/definitions/798.html

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G102-bind-all-interfaces.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G102-bind-all-interfaces.yaml
@@ -1,0 +1,21 @@
+# Adapted from gosec rule 'G102 bind_to_all_interfaces'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: G102-bind-all-interfaces
+name: Bind to all network interfaces
+message: Service bound to 0.0.0.0 — exposes all network interfaces
+severity: medium
+category: security
+languages: [go]
+confidence: 0.75
+cwe: CWE-200
+pattern: '"0\.0\.0\.0:'
+explanation: |
+  Binding to ``0.0.0.0`` makes the service reachable on every network
+  interface (including public IPs). Often unintended, especially in
+  development services that should be loopback-only.
+recommendation: |
+  Bind to ``127.0.0.1`` for local-only services. For services that need
+  external access, document the exposure and pair with firewall rules.
+references:
+  - https://github.com/securego/gosec

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G103-unsafe-block.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G103-unsafe-block.yaml
@@ -1,0 +1,21 @@
+# Adapted from gosec rule 'G103 unsafe_block'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: G103-unsafe-block
+name: Use of unsafe package
+message: Package 'unsafe' bypasses Go type safety
+severity: medium
+category: suspicious
+languages: [go]
+confidence: 0.85
+pattern: '\bunsafe\.(Pointer|Sizeof|Alignof|Offsetof|String|StringData|Slice|SliceData)\b'
+explanation: |
+  ``unsafe`` lets you bypass Go's type system and memory-safety
+  guarantees. Code paths that touch ``unsafe`` need extra review for
+  data-race, alignment, and pointer-aliasing bugs.
+recommendation: |
+  Audit each ``unsafe`` call site. Document why type safety must be
+  bypassed and which invariants the surrounding code maintains.
+references:
+  - https://github.com/securego/gosec
+  - https://pkg.go.dev/unsafe

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G201-sql-format.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G201-sql-format.yaml
@@ -1,0 +1,21 @@
+# Adapted from gosec rule 'G201 sql_format_string'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: G201-sql-format
+name: SQL string built via fmt.Sprintf
+message: SQL built with fmt.Sprintf — possible injection
+severity: high
+category: security
+languages: [go]
+confidence: 0.7
+cwe: CWE-89
+pattern: '\bfmt\.Sprintf\s*\(\s*"[^"]*\b(SELECT|INSERT|UPDATE|DELETE)\b'
+explanation: |
+  ``fmt.Sprintf`` formats values without SQL escaping. Any user-supplied
+  string in the format args can break the query and inject statements.
+recommendation: |
+  Use ``db.Exec(query, args...)`` / ``db.Query(query, args...)`` with
+  positional placeholders (``$1``, ``?``) so the driver handles escaping.
+references:
+  - https://github.com/securego/gosec
+  - https://cwe.mitre.org/data/definitions/89.html

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G304-file-inclusion.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G304-file-inclusion.yaml
@@ -1,0 +1,23 @@
+# Adapted from gosec rule 'G304 file_path_inclusion'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: G304-file-inclusion
+name: Variable file path passed to file IO
+message: Tainted file path — possible directory traversal
+severity: medium
+category: security
+languages: [go]
+confidence: 0.55
+cwe: CWE-22
+pattern: '\bos\.(Open|ReadFile|Create|OpenFile)\s*\(\s*[a-zA-Z_]\w*\s*[,)]'
+explanation: |
+  Reading or writing to a file path that comes from a variable (rather
+  than a const) risks directory traversal if the variable is influenced
+  by user input.
+recommendation: |
+  Validate the path against an allowlist or wrap with ``filepath.Clean``
+  + ``filepath.Rel`` to confirm the result stays within the intended
+  base directory.
+references:
+  - https://github.com/securego/gosec
+  - https://cwe.mitre.org/data/definitions/22.html

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G401-weak-cipher.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G401-weak-cipher.yaml
@@ -1,0 +1,20 @@
+# Adapted from gosec rule 'G401 weak_des_or_rc4_crypto'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: G401-weak-cipher
+name: Use of weak cipher (DES/RC4)
+message: DES and RC4 are cryptographically weak
+severity: high
+category: security
+languages: [go]
+confidence: 0.85
+cwe: CWE-327
+pattern: '\b(des|rc4)\.New(?:Cipher|TripleDESCipher)?\s*\('
+explanation: |
+  ``crypto/des`` and ``crypto/rc4`` are obsolete. DES has a 56-bit key
+  (brute-forceable); RC4 has known biases.
+recommendation: |
+  Use ``crypto/aes`` with GCM mode for symmetric encryption.
+references:
+  - https://github.com/securego/gosec
+  - https://pkg.go.dev/crypto/aes

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G402-tls-min-version.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G402-tls-min-version.yaml
@@ -1,0 +1,20 @@
+# Adapted from gosec rule 'G402 tls_min_version'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: G402-tls-min-version
+name: TLS MinVersion below TLS 1.2
+message: TLS configured with old protocol version (SSLv3/TLS1.0/TLS1.1)
+severity: high
+category: security
+languages: [go]
+confidence: 0.85
+cwe: CWE-326
+pattern: '\bMinVersion\s*:\s*tls\.Version(SSL30|TLS10|TLS11)\b'
+explanation: |
+  TLS 1.0/1.1 and SSL 3.0 have known vulnerabilities (BEAST, POODLE,
+  Lucky13). Modern services should require TLS 1.2 or 1.3.
+recommendation: |
+  Use ``MinVersion: tls.VersionTLS12`` (or ``VersionTLS13``).
+references:
+  - https://github.com/securego/gosec
+  - https://cwe.mitre.org/data/definitions/326.html

--- a/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G501-md5-import.yaml
+++ b/src/attocode/code_intel/rules/packs/community/gosec-go/rules/G501-md5-import.yaml
@@ -1,0 +1,21 @@
+# Adapted from gosec rule 'G501 weak_md5_hash'
+# See ../LICENSE and ../NOTICE for license terms.
+
+id: G501-md5-import
+name: Import of crypto/md5
+message: crypto/md5 is cryptographically broken
+severity: medium
+category: security
+languages: [go]
+confidence: 0.7
+cwe: CWE-327
+pattern: '"crypto/md5"'
+explanation: |
+  MD5 is vulnerable to collision attacks. Importing ``crypto/md5`` is a
+  smell — even when the use is intentional, it's worth a comment
+  explaining why.
+recommendation: |
+  Use ``crypto/sha256`` for hashing. If MD5 is needed for non-security
+  reasons (legacy file formats, etag compatibility), document why.
+references:
+  - https://github.com/securego/gosec

--- a/src/attocode/code_intel/rules/packs/pack_loader.py
+++ b/src/attocode/code_intel/rules/packs/pack_loader.py
@@ -24,6 +24,11 @@ logger = logging.getLogger(__name__)
 # Example packs ship here — NOT auto-loaded
 _EXAMPLES_DIR = Path(__file__).parent / "examples"
 
+# Community packs (imported from upstream sources like semgrep-rules, bandit,
+# gosec) ship under ``community/`` with their own LICENSE + NOTICE files.
+# They are NOT auto-loaded — the rule-bench harness loads them explicitly.
+_COMMUNITY_DIR = Path(__file__).parent / "community"
+
 
 @dataclass(slots=True)
 class PackManifest:
@@ -34,6 +39,17 @@ class PackManifest:
     languages: list[str] = field(default_factory=list)
     description: str = ""
     pack_dir: str = ""
+
+    # Provenance fields — populated by the community pack importer.
+    # Kept additive so older manifests (without these keys) continue to load.
+    source: str = ""  # "community" | "example" | "user"
+    source_url: str = ""
+    source_commit: str = ""
+    source_license: str = ""  # SPDX identifier
+    attribution: str = ""  # human-readable attribution string
+    imported_at: str = ""  # ISO-8601 timestamp
+    upstream_rule_count: int = 0
+    imported_rule_count: int = 0
 
 
 def _load_manifest(pack_dir: Path) -> PackManifest | None:
@@ -67,6 +83,14 @@ def _load_manifest(pack_dir: Path) -> PackManifest | None:
         languages=data.get("languages", [pack_dir.name]),
         description=str(data.get("description", "")),
         pack_dir=str(pack_dir),
+        source=str(data.get("source", "")),
+        source_url=str(data.get("source_url", "")),
+        source_commit=str(data.get("source_commit", "")),
+        source_license=str(data.get("source_license", "")),
+        attribution=str(data.get("attribution", "")),
+        imported_at=str(data.get("imported_at", "")),
+        upstream_rule_count=int(data.get("upstream_rule_count", 0) or 0),
+        imported_rule_count=int(data.get("imported_rule_count", 0) or 0),
     )
 
 
@@ -119,6 +143,28 @@ def list_example_packs() -> list[PackManifest]:
                 if m:
                     manifests.append(m)
     return manifests
+
+
+def list_community_packs() -> list[PackManifest]:
+    """List community packs imported from upstream sources.
+
+    Community packs live under ``packs/community/<name>/`` with their own
+    ``LICENSE`` and ``NOTICE`` files. They are NOT auto-loaded — the
+    rule-bench harness loads them explicitly when running evaluations.
+    """
+    manifests: list[PackManifest] = []
+    if _COMMUNITY_DIR.is_dir():
+        for entry in sorted(_COMMUNITY_DIR.iterdir()):
+            if entry.is_dir() and not entry.name.startswith("_"):
+                m = _load_manifest(entry)
+                if m:
+                    manifests.append(m)
+    return manifests
+
+
+def get_community_pack_dir() -> Path:
+    """Return the directory where community packs are stored."""
+    return _COMMUNITY_DIR
 
 
 def install_pack(pack_name: str, project_dir: str) -> str:

--- a/src/attocode/code_intel/rules/testing.py
+++ b/src/attocode/code_intel/rules/testing.py
@@ -25,8 +25,10 @@ from attocode.code_intel.rules.model import EnrichedFinding, UnifiedRule
 # ---------------------------------------------------------------------------
 
 # Matches: # expect: rule-id, // expect: rule-id, # ok: rule-id, etc.
+# Also accepts the semgrep-rules ``ruleid:`` marker as an alias for ``expect:``
+# so test fixtures imported from semgrep work without preprocessing.
 _ANNOTATION_RE = re.compile(
-    r"(?:#|//)\s*(expect|ok|todoruleid):\s*([\w./-]+)"
+    r"(?:#|//)\s*(expect|ok|todoruleid|ruleid):\s*([\w./-]+)"
 )
 
 
@@ -46,9 +48,13 @@ def parse_annotations(file_path: str) -> list[Expectation]:
         with open(file_path, encoding="utf-8") as f:
             for i, line in enumerate(f, 1):
                 for m in _ANNOTATION_RE.finditer(line):
+                    kind = m.group(1)
+                    # semgrep "ruleid" is treated as our "expect"
+                    if kind == "ruleid":
+                        kind = "expect"
                     expectations.append(Expectation(
                         line=i,
-                        kind=m.group(1),
+                        kind=kind,
                         rule_id=m.group(2),
                     ))
     except OSError:
@@ -124,6 +130,10 @@ def _finding_matches_rule(finding_rule_id: str, expected_rule_id: str) -> bool:
     if finding_rule_id.endswith("/" + expected_rule_id):
         return True
     return False
+
+
+# Public alias — the rule-bench harness reuses this matcher.
+match_finding_to_expectation = _finding_matches_rule
 
 
 # ---------------------------------------------------------------------------

--- a/src/attoswarm/__init__.py
+++ b/src/attoswarm/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.21"
+__version__ = "0.2.22"

--- a/tests/integration/test_rule_bench_floor_e2e.py
+++ b/tests/integration/test_rule_bench_floor_e2e.py
@@ -1,0 +1,154 @@
+"""Integration: per-language floor rejects regressions inside ``MetaHarnessRunner``.
+
+We drive the runner with a stubbed bench spec so the end-to-end flow runs
+in milliseconds. The runner must:
+
+1. Accept a candidate that improves the composite while keeping every
+   language above the floor.
+2. Reject a candidate whose composite goes UP but where a single language
+   drops more than 5% — and record the floor_violation reason in the
+   evolution journal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from attoswarm.research.evaluator import EvalResult
+
+from eval.meta_harness.meta_loop import MetaHarnessRunner, _BenchSpec
+from eval.meta_harness.rule_bench.predicate import rule_accept_predicate
+
+
+@dataclass
+class _StubConfig:
+    """Minimal config that satisfies _ConfigLike."""
+
+    label: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"label": self.label}
+
+    def save_yaml(self, path: str) -> None:
+        Path(path).write_text(f"label: {self.label}\n", encoding="utf-8")
+
+    def validate(self) -> list[str]:
+        return []
+
+
+class _ScriptedEvaluator:
+    """Replays a fixed sequence of EvalResults so we can drive the runner."""
+
+    def __init__(self, results: list[EvalResult]) -> None:
+        self._results = list(results)
+        self._idx = 0
+
+    async def evaluate(self, working_dir: str) -> EvalResult:  # noqa: ARG002
+        if self._idx >= len(self._results):
+            return EvalResult(
+                metric_value=0.0, error="ran out of scripted results", success=False,
+            )
+        result = self._results[self._idx]
+        self._idx += 1
+        return result
+
+
+def _make_propose(plan: list[tuple[_StubConfig, str]]):
+    """Return a propose_fn that yields the planned candidates over iterations."""
+    cursor = {"i": 0}
+
+    def propose(
+        current_best: Any,  # noqa: ARG001
+        eval_metadata: dict[str, Any],  # noqa: ARG001
+        history: list[dict[str, Any]],  # noqa: ARG001
+        n_candidates: int,
+        iteration: int,  # noqa: ARG001
+    ) -> list[tuple[_StubConfig, str]]:
+        out: list[tuple[_StubConfig, str]] = []
+        for _ in range(n_candidates):
+            if cursor["i"] >= len(plan):
+                break
+            out.append(plan[cursor["i"]])
+            cursor["i"] += 1
+        return out
+
+    return propose
+
+
+@pytest.fixture()
+def isolated_results_dir(monkeypatch, tmp_path):
+    """Direct meta-harness artifact writes into tmp_path."""
+    monkeypatch.setenv("ATTOCODE_META_HARNESS_RESULTS", str(tmp_path))
+    return tmp_path
+
+
+def test_floor_rejects_regression_accepts_balanced(
+    isolated_results_dir: Path,
+) -> None:
+    # Baseline: python=0.6, go=0.5 → composite ~0.55
+    baseline = EvalResult(
+        metric_value=0.55,
+        metadata={"per_language": {"python": 0.6, "go": 0.5}},
+        success=True,
+    )
+    # Candidate A: composite UP (0.65) but go drops to 0.35 (floor breach)
+    candidate_a = EvalResult(
+        metric_value=0.65,
+        metadata={"per_language": {"python": 0.95, "go": 0.35}},
+        success=True,
+    )
+    # Candidate B: composite UP (0.6) and go stays above floor (0.48 > 0.475)
+    candidate_b = EvalResult(
+        metric_value=0.6,
+        metadata={"per_language": {"python": 0.72, "go": 0.48}},
+        success=True,
+    )
+
+    evaluator = _ScriptedEvaluator([baseline, candidate_a, candidate_b])
+
+    plan = [
+        (_StubConfig(label="A"), "candidate A"),
+        (_StubConfig(label="B"), "candidate B"),
+    ]
+
+    spec = _BenchSpec(
+        name="rule",
+        evaluator=evaluator,
+        config_default=_StubConfig(label="default"),
+        config_filename="rule_harness_config.yaml",
+        propose_sweep=_make_propose(plan),
+        propose_llm=_make_propose(plan),  # unused but required
+        accept_predicate=rule_accept_predicate,
+        artifact_prefix="rule_",
+    )
+
+    runner = MetaHarnessRunner(
+        iterations=2,
+        candidates_per_iteration=1,
+        propose_mode="sweep",
+        bench_spec=spec,
+    )
+    asyncio.run(runner.run())
+
+    # Inspect the evolution journal
+    evo_path = isolated_results_dir / "rule_evolution_summary.jsonl"
+    assert evo_path.is_file(), f"missing {evo_path}"
+    entries = [json.loads(line) for line in evo_path.read_text().splitlines()]
+    assert len(entries) == 2
+
+    # Iteration 1: candidate A → REJECTED with floor_violation:go
+    a = entries[0]
+    assert a["status"] == "rejected"
+    assert a["reject_reason"] is not None
+    assert "floor_violation:go" in a["reject_reason"]
+
+    # Iteration 2: candidate B → ACCEPTED
+    b = entries[1]
+    assert b["status"] == "accepted"
+    assert b["per_language"] == {"python": 0.72, "go": 0.48}

--- a/tests/unit/eval/test_rule_bench_config.py
+++ b/tests/unit/eval/test_rule_bench_config.py
@@ -1,0 +1,258 @@
+"""Unit tests for ``RuleBenchConfig`` + ``RuleOverride`` + ``apply_to_registry``."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from attocode.code_intel.rules.model import (
+    RuleCategory,
+    RuleSeverity,
+    RuleSource,
+    UnifiedRule,
+)
+from attocode.code_intel.rules.registry import RuleRegistry
+
+from eval.meta_harness.rule_bench.config import (
+    RuleBenchConfig,
+    RuleOverride,
+    merge_overrides,
+)
+
+
+def _stub_rule(
+    rid: str = "py-foo",
+    *,
+    pack: str = "python",
+    severity: RuleSeverity = RuleSeverity.MEDIUM,
+    confidence: float = 0.8,
+    enabled: bool = True,
+) -> UnifiedRule:
+    return UnifiedRule(
+        id=rid,
+        name=rid,
+        description="stub",
+        severity=severity,
+        category=RuleCategory.CORRECTNESS,
+        languages=["python"],
+        pattern=re.compile("foo"),
+        source=RuleSource.PACK,
+        pack=pack,
+        confidence=confidence,
+        enabled=enabled,
+    )
+
+
+@pytest.fixture()
+def base_registry() -> RuleRegistry:
+    reg = RuleRegistry()
+    reg.register(_stub_rule("py-foo"))
+    reg.register(_stub_rule("py-bar", severity=RuleSeverity.HIGH))
+    reg.register(_stub_rule("go-baz", pack="go"))
+    return reg
+
+
+class TestRuleBenchConfigDefaults:
+    def test_default_validates_clean(self) -> None:
+        assert RuleBenchConfig.default().validate() == []
+
+    def test_apply_default_returns_clone_with_same_rules(
+        self, base_registry: RuleRegistry,
+    ) -> None:
+        cfg = RuleBenchConfig.default()
+        cloned = cfg.apply_to_registry(base_registry)
+        assert cloned.count == base_registry.count
+        # Different object identities
+        assert cloned is not base_registry
+
+
+class TestValidate:
+    def test_invalid_confidence_caught(self) -> None:
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "py-foo": RuleOverride(rule_id="py-foo", confidence_override=1.5),
+            },
+        )
+        errors = cfg.validate()
+        assert any("confidence_override" in e for e in errors)
+
+    def test_invalid_severity_caught(self) -> None:
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "py-foo": RuleOverride(rule_id="py-foo", severity_override="apocalyptic"),
+            },
+        )
+        errors = cfg.validate()
+        assert any("severity_override" in e for e in errors)
+
+    def test_invalid_min_confidence_caught(self) -> None:
+        cfg = RuleBenchConfig(global_min_confidence=1.2)
+        errors = cfg.validate()
+        assert any("global_min_confidence" in e for e in errors)
+
+
+class TestApplyToRegistry:
+    def test_disabling_via_override(self, base_registry: RuleRegistry) -> None:
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "python/py-foo": RuleOverride(rule_id="python/py-foo", enabled=False),
+            },
+        )
+        cloned = cfg.apply_to_registry(base_registry)
+        rule = cloned.get("python/py-foo")
+        assert rule is not None
+        assert rule.enabled is False
+
+    def test_disabling_via_bare_id(self, base_registry: RuleRegistry) -> None:
+        # Override keyed by bare id should still match a pack-qualified rule
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "py-foo": RuleOverride(rule_id="py-foo", enabled=False),
+            },
+        )
+        cloned = cfg.apply_to_registry(base_registry)
+        rule = cloned.get("python/py-foo")
+        assert rule is not None
+        assert rule.enabled is False
+
+    def test_confidence_override_applied(self, base_registry: RuleRegistry) -> None:
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "python/py-foo": RuleOverride(
+                    rule_id="python/py-foo", confidence_override=0.42,
+                ),
+            },
+        )
+        cloned = cfg.apply_to_registry(base_registry)
+        rule = cloned.get("python/py-foo")
+        assert rule is not None
+        assert rule.confidence == pytest.approx(0.42)
+
+    def test_severity_override_applied(self, base_registry: RuleRegistry) -> None:
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "python/py-foo": RuleOverride(
+                    rule_id="python/py-foo", severity_override="critical",
+                ),
+            },
+        )
+        cloned = cfg.apply_to_registry(base_registry)
+        rule = cloned.get("python/py-foo")
+        assert rule is not None
+        assert rule.severity == RuleSeverity.CRITICAL
+
+    def test_pack_deactivation_disables_all_pack_rules(
+        self, base_registry: RuleRegistry,
+    ) -> None:
+        cfg = RuleBenchConfig(pack_activation={"python": False})
+        cloned = cfg.apply_to_registry(base_registry)
+        py_foo = cloned.get("python/py-foo")
+        py_bar = cloned.get("python/py-bar")
+        go_baz = cloned.get("go/go-baz")
+        assert py_foo is not None and py_foo.enabled is False
+        assert py_bar is not None and py_bar.enabled is False
+        assert go_baz is not None and go_baz.enabled is True  # untouched
+
+    def test_apply_does_not_mutate_caller(self, base_registry: RuleRegistry) -> None:
+        original = base_registry.get("python/py-foo")
+        assert original is not None
+        original_confidence = original.confidence
+
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "python/py-foo": RuleOverride(
+                    rule_id="python/py-foo", confidence_override=0.1,
+                ),
+            },
+        )
+        cfg.apply_to_registry(base_registry)
+
+        # Caller's registry must be unchanged
+        still_original = base_registry.get("python/py-foo")
+        assert still_original is not None
+        assert still_original.confidence == original_confidence
+
+
+class TestSerialization:
+    def test_round_trip_yaml(self, tmp_path: Path) -> None:
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "python/py-foo": RuleOverride(
+                    rule_id="python/py-foo",
+                    enabled=False,
+                    confidence_override=0.6,
+                    severity_override="high",
+                ),
+            },
+            pack_activation={"python": True, "go": False},
+            global_min_confidence=0.7,
+            enabled_languages=["python", "go"],
+        )
+        path = tmp_path / "rule_harness_config.yaml"
+        cfg.save_yaml(str(path))
+
+        reloaded = RuleBenchConfig.load_yaml(str(path))
+        assert reloaded.global_min_confidence == pytest.approx(0.7)
+        assert reloaded.pack_activation == {"python": True, "go": False}
+        assert reloaded.enabled_languages == ["python", "go"]
+        assert "python/py-foo" in reloaded.rule_overrides
+        ov = reloaded.rule_overrides["python/py-foo"]
+        assert ov.enabled is False
+        assert ov.confidence_override == pytest.approx(0.6)
+        assert ov.severity_override == "high"
+
+    def test_from_dict_tolerates_dict_overrides(self) -> None:
+        # Some hand-written configs use {rule_id: payload} instead of a list
+        cfg = RuleBenchConfig.from_dict({
+            "rule_overrides": {
+                "py-foo": {"enabled": False, "confidence_override": 0.3},
+            },
+        })
+        assert "py-foo" in cfg.rule_overrides
+        ov = cfg.rule_overrides["py-foo"]
+        assert ov.enabled is False
+        assert ov.confidence_override == pytest.approx(0.3)
+
+
+class TestExtraRules:
+    def test_extra_rule_registered(self, base_registry: RuleRegistry) -> None:
+        cfg = RuleBenchConfig(
+            extra_rules=[
+                {
+                    "id": "synth-1",
+                    "message": "synthetic rule",
+                    "severity": "high",
+                    "pattern": "TODO",
+                    "languages": ["python"],
+                    "category": "style",
+                },
+            ],
+        )
+        cloned = cfg.apply_to_registry(base_registry)
+        synth = cloned.get("rule_bench_synth/synth-1")
+        assert synth is not None
+        assert synth.severity == RuleSeverity.HIGH
+
+    def test_invalid_extra_rule_skipped(self, base_registry: RuleRegistry) -> None:
+        # Missing required ``message`` field — loader returns None
+        cfg = RuleBenchConfig(
+            extra_rules=[
+                {"id": "broken-1", "severity": "high"},
+            ],
+        )
+        cloned = cfg.apply_to_registry(base_registry)
+        # No new rule registered; original count preserved
+        assert cloned.count == base_registry.count
+
+
+class TestMergeOverrides:
+    def test_merge_adds_override(self) -> None:
+        base = RuleBenchConfig.default()
+        merged = merge_overrides(
+            base,
+            RuleOverride(rule_id="py-foo", confidence_override=0.5),
+        )
+        assert "py-foo" in merged.rule_overrides
+        assert base.rule_overrides == {}  # base untouched

--- a/tests/unit/eval/test_rule_bench_corpus.py
+++ b/tests/unit/eval/test_rule_bench_corpus.py
@@ -1,0 +1,179 @@
+"""Unit tests for the rule-bench corpus loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eval.meta_harness.rule_bench.corpus import CorpusLoader
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture()
+def synthetic_corpus(tmp_path: Path) -> dict[str, Path]:
+    """Build a 3-source synthetic corpus inside tmp_path."""
+    community = tmp_path / "community"
+    attocode = tmp_path / "attocode"
+    legacy = tmp_path / "legacy"
+
+    # Community: pack-a + pack-b
+    _write(
+        community / "pack-a" / "manifest.yaml",
+        "name: pack-a\nversion: '1.0.0'\nlanguages: [python]\n",
+    )
+    _write(
+        community / "pack-a" / "fixtures" / "rule-x" / "positive.py",
+        "value = compute()  # expect: rule-x\n",
+    )
+    _write(
+        community / "pack-a" / "fixtures" / "rule-x" / "negative.py",
+        "value = safe_compute()  # ok: rule-x\n",
+    )
+    _write(
+        community / "pack-b" / "manifest.yaml",
+        "name: pack-b\nversion: '1.0.0'\nlanguages: [go]\n",
+    )
+    _write(
+        community / "pack-b" / "fixtures" / "rule-y" / "positive.go",
+        "package main\nfunc f() { format(s) } // expect: rule-y\n",
+    )
+
+    # Attocode hand-labeled
+    _write(
+        attocode / "python" / "py-foo.py",
+        "x = 1  # expect: py-foo\ny = 2  # ok: py-foo\n",
+    )
+
+    # Legacy CWE-organized
+    _write(
+        legacy / "python" / "CWE-89" / "tp_sqli.py",
+        "execute(query)  # expect: sqli-rule\n",
+    )
+
+    return {
+        "community_dir": community,
+        "attocode_dir": attocode,
+        "legacy_dir": legacy,
+    }
+
+
+class TestCorpusLoader:
+    def test_disable_community(self, synthetic_corpus: dict[str, Path]) -> None:
+        loader = CorpusLoader(
+            include_community=False,
+            community_dir=synthetic_corpus["community_dir"],
+            attocode_dir=synthetic_corpus["attocode_dir"],
+            legacy_dir=synthetic_corpus["legacy_dir"],
+        )
+        samples = list(loader.iter_samples())
+        for s in samples:
+            assert s.pack not in {"pack-a", "pack-b"}
+
+    def test_disable_attocode(self, synthetic_corpus: dict[str, Path]) -> None:
+        loader = CorpusLoader(
+            include_community=False,
+            include_attocode=False,
+            community_dir=synthetic_corpus["community_dir"],
+            attocode_dir=synthetic_corpus["attocode_dir"],
+            legacy_dir=synthetic_corpus["legacy_dir"],
+        )
+        samples = list(loader.iter_samples())
+        # Only legacy left
+        for s in samples:
+            assert s.pack == "legacy"
+
+    def test_disable_legacy(self, synthetic_corpus: dict[str, Path]) -> None:
+        loader = CorpusLoader(
+            include_community=False,
+            include_legacy=False,
+            community_dir=synthetic_corpus["community_dir"],
+            attocode_dir=synthetic_corpus["attocode_dir"],
+            legacy_dir=synthetic_corpus["legacy_dir"],
+        )
+        samples = list(loader.iter_samples())
+        for s in samples:
+            assert s.pack == "attocode"
+
+    def test_skips_files_without_annotations(self, tmp_path: Path) -> None:
+        attocode = tmp_path / "attocode"
+        _write(attocode / "python" / "scaffold.py", "import json\nx = json.loads('{}')\n")
+        loader = CorpusLoader(
+            include_community=False,
+            include_legacy=False,
+            attocode_dir=attocode,
+        )
+        samples = list(loader.iter_samples())
+        assert samples == []
+
+    def test_parses_expect_and_ok(
+        self, synthetic_corpus: dict[str, Path],
+    ) -> None:
+        loader = CorpusLoader(
+            include_community=False,
+            include_legacy=False,
+            attocode_dir=synthetic_corpus["attocode_dir"],
+        )
+        samples = list(loader.iter_samples())
+        assert len(samples) == 1
+        sample = samples[0]
+        assert sample.language == "python"
+        kinds = {f.kind for f in sample.expected_findings}
+        assert "expect" in kinds
+        assert "ok" in kinds
+        assert sample.has_negative_assertions is True
+
+    def test_parses_ruleid_alias(self, tmp_path: Path) -> None:
+        # semgrep "# ruleid:" alias should map to "expect" via Step-1 normalization
+        attocode = tmp_path / "attocode"
+        _write(
+            attocode / "python" / "semgrep_compat.py",
+            "value = something()  # ruleid: dangerous-call\n",
+        )
+        loader = CorpusLoader(
+            include_community=False,
+            include_legacy=False,
+            attocode_dir=attocode,
+        )
+        samples = list(loader.iter_samples())
+        assert len(samples) == 1
+        finding = samples[0].expected_findings[0]
+        assert finding.kind == "expect"  # normalized from "ruleid"
+        assert finding.rule_id == "dangerous-call"
+
+    def test_legacy_corpus_attaches_cwe(
+        self, synthetic_corpus: dict[str, Path],
+    ) -> None:
+        loader = CorpusLoader(
+            include_community=False,
+            include_attocode=False,
+            legacy_dir=synthetic_corpus["legacy_dir"],
+        )
+        samples = list(loader.iter_samples())
+        assert len(samples) == 1
+        assert samples[0].cwe == "CWE-89"
+        assert samples[0].pack == "legacy"
+
+    def test_sample_count_by_language(
+        self, synthetic_corpus: dict[str, Path],
+    ) -> None:
+        loader = CorpusLoader(
+            include_community=False,
+            attocode_dir=synthetic_corpus["attocode_dir"],
+            legacy_dir=synthetic_corpus["legacy_dir"],
+        )
+        counts = loader.sample_count_by_language()
+        assert counts.get("python") == 2  # 1 attocode + 1 legacy
+
+    def test_handles_missing_directories(self, tmp_path: Path) -> None:
+        loader = CorpusLoader(
+            community_dir=tmp_path / "nope1",
+            attocode_dir=tmp_path / "nope2",
+            legacy_dir=tmp_path / "nope3",
+        )
+        samples = list(loader.iter_samples())
+        assert samples == []

--- a/tests/unit/eval/test_rule_bench_evaluator.py
+++ b/tests/unit/eval/test_rule_bench_evaluator.py
@@ -1,0 +1,186 @@
+"""Unit tests for ``RuleBenchEvaluator``.
+
+We exercise the evaluator against a fully synthetic registry + corpus so
+the test is deterministic and independent of which packs ship today.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+import pytest
+
+from attocode.code_intel.rules.model import (
+    RuleCategory,
+    RuleSeverity,
+    RuleSource,
+    UnifiedRule,
+)
+from attocode.code_intel.rules.registry import RuleRegistry
+
+from eval.meta_harness.rule_bench.config import RuleBenchConfig, RuleOverride
+from eval.meta_harness.rule_bench.corpus import (
+    CorpusLoader,
+    ExpectedFinding,
+    LabeledSample,
+)
+from eval.meta_harness.rule_bench.evaluator import RuleBenchEvaluator
+
+
+def _stub_rule(
+    rid: str,
+    *,
+    pattern: str,
+    severity: RuleSeverity = RuleSeverity.HIGH,
+    languages: tuple[str, ...] = ("python",),
+    pack: str = "synth",
+    confidence: float = 0.9,
+) -> UnifiedRule:
+    return UnifiedRule(
+        id=rid,
+        name=rid,
+        description="stub",
+        severity=severity,
+        category=RuleCategory.CORRECTNESS,
+        languages=list(languages),
+        pattern=re.compile(pattern),
+        source=RuleSource.PACK,
+        pack=pack,
+        confidence=confidence,
+    )
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+@pytest.fixture()
+def synthetic_evaluator(tmp_path: Path) -> RuleBenchEvaluator:
+    """An evaluator wired to a synthetic corpus and registry."""
+    # Build a corpus of two python fixtures.
+    corpus_root = tmp_path / "fixtures"
+    _write(
+        corpus_root / "python" / "fires.py",
+        "x = bad_call()  # expect: bad-call\n"
+        "y = good_call()  # ok: bad-call\n",
+    )
+    _write(
+        corpus_root / "python" / "double.py",
+        "a = bad_call()  # expect: bad-call\n",
+    )
+
+    # Patch the loader's attocode dir to point at our synthetic corpus.
+    evaluator = RuleBenchEvaluator(
+        packs=[],
+        include_community=False,
+        include_attocode=True,
+        include_legacy=False,
+    )
+
+    base = RuleRegistry()
+    base.register(_stub_rule("bad-call", pattern=r"\bbad_call\("))
+    evaluator._base_registry = base  # noqa: SLF001 - test injection
+
+    samples = []
+    for fixture in [
+        corpus_root / "python" / "fires.py",
+        corpus_root / "python" / "double.py",
+    ]:
+        loaded = CorpusLoader._load_sample(str(fixture), pack="attocode")  # noqa: SLF001
+        if loaded is not None:
+            samples.append(loaded)
+    evaluator._corpus = samples  # noqa: SLF001
+    return evaluator
+
+
+def _run(coro):  # tiny helper — pytest-asyncio AUTO mode handles awaits but
+    # this evaluator is plain async and the synthetic test doesn't need the
+    # event loop fixture.
+    return asyncio.run(coro)
+
+
+class TestRuleBenchEvaluator:
+    def test_baseline_full_recall(
+        self, synthetic_evaluator: RuleBenchEvaluator, tmp_path: Path,
+    ) -> None:
+        result = _run(synthetic_evaluator.evaluate(str(tmp_path)))
+        assert result.success is True
+        assert result.metric_value > 0.0
+
+        rule_bench = result.metadata["rule_bench"]
+        assert rule_bench["fixtures_total"] == 2
+
+        per_rule = rule_bench["per_rule"]
+        bad_call = per_rule["synth/bad-call"]
+        # Both expect lines should fire — TP=2, FP=0 (the ok line stays clean)
+        assert bad_call["tp"] == 2
+        assert bad_call["fp"] == 0
+        assert bad_call["fn"] == 0
+
+        # Per-language entry exists for python
+        assert "python" in result.metadata["per_language"]
+        assert result.metadata["per_language"]["python"] > 0.0
+
+    def test_disabled_rule_misses_everything(
+        self, synthetic_evaluator: RuleBenchEvaluator, tmp_path: Path,
+    ) -> None:
+        cfg = RuleBenchConfig(
+            rule_overrides={
+                "synth/bad-call": RuleOverride(
+                    rule_id="synth/bad-call", enabled=False,
+                ),
+            },
+        )
+        config_path = tmp_path / "rule_harness_config.yaml"
+        cfg.save_yaml(str(config_path))
+
+        result = _run(synthetic_evaluator.evaluate(str(tmp_path)))
+        assert result.success is True
+        # No rules fire → every expect becomes an FN credited to the
+        # disabled rule (so the proposer can see what it lost by disabling).
+        rule_bench = result.metadata["rule_bench"]
+        bad_call = rule_bench["per_rule"]["synth/bad-call"]
+        assert bad_call["tp"] == 0
+        assert bad_call["fp"] == 0
+        assert bad_call["fn"] == 2
+        assert bad_call["enabled"] is False
+        # Recall collapses to 0, so composite is 0
+        assert result.metric_value == 0.0
+
+    def test_invalid_config_returns_failure(
+        self, synthetic_evaluator: RuleBenchEvaluator, tmp_path: Path,
+    ) -> None:
+        bad = tmp_path / "rule_harness_config.yaml"
+        bad.write_text(
+            "global_min_confidence: 1.5\nrule_overrides: []\n",
+            encoding="utf-8",
+        )
+        result = _run(synthetic_evaluator.evaluate(str(tmp_path)))
+        assert result.success is False
+        assert "Invalid config" in result.error
+
+    def test_empty_corpus_returns_failure(self, tmp_path: Path) -> None:
+        evaluator = RuleBenchEvaluator(
+            packs=[], include_community=False, include_attocode=False,
+            include_legacy=False,
+        )
+        evaluator._base_registry = RuleRegistry()  # noqa: SLF001
+        evaluator._base_registry.register(_stub_rule("x", pattern="x"))  # noqa: SLF001
+        evaluator._corpus = []  # noqa: SLF001
+        result = _run(evaluator.evaluate(str(tmp_path)))
+        assert result.success is False
+
+    def test_empty_registry_returns_failure(self, tmp_path: Path) -> None:
+        evaluator = RuleBenchEvaluator(
+            packs=[], include_community=False, include_attocode=False,
+            include_legacy=False,
+        )
+        evaluator._base_registry = RuleRegistry()  # noqa: SLF001
+        evaluator._corpus = []  # noqa: SLF001
+        # corpus is also empty so we expect the registry-empty message first
+        result = _run(evaluator.evaluate(str(tmp_path)))
+        assert result.success is False
+        assert "registry" in result.error.lower() or "corpus" in result.error.lower()

--- a/tests/unit/eval/test_rule_bench_predicate.py
+++ b/tests/unit/eval/test_rule_bench_predicate.py
@@ -1,0 +1,78 @@
+"""Unit tests for the per-language floor predicate."""
+
+from __future__ import annotations
+
+from attoswarm.research.evaluator import EvalResult
+
+from eval.meta_harness.rule_bench.predicate import (
+    DEFAULT_FLOOR_RATIO,
+    make_rule_accept_predicate,
+    rule_accept_predicate,
+)
+
+
+def _result(score: float, per_lang: dict[str, float] | None = None) -> EvalResult:
+    md: dict = {}
+    if per_lang is not None:
+        md["per_language"] = dict(per_lang)
+    return EvalResult(metric_value=score, metadata=md, success=True)
+
+
+class TestRuleAcceptPredicate:
+    def test_strict_improvement_no_per_lang_data_accepts(self) -> None:
+        # Without per_language metadata the predicate falls back to score check.
+        candidate = _result(0.7)
+        baseline = _result(0.5)
+        accepted, reason = rule_accept_predicate(candidate, baseline, current_best=0.5)
+        assert accepted is True
+        assert "improved" in reason
+
+    def test_no_improvement_rejected(self) -> None:
+        candidate = _result(0.5, {"python": 0.6, "go": 0.5})
+        baseline = _result(0.5, {"python": 0.6, "go": 0.5})
+        accepted, reason = rule_accept_predicate(candidate, baseline, current_best=0.6)
+        assert accepted is False
+        assert "no_improvement" in reason
+
+    def test_floor_violation_rejects_even_when_score_up(self) -> None:
+        baseline = _result(0.55, {"python": 0.6, "go": 0.5})
+        # Composite up, but go drops 30% — floor breached
+        candidate = _result(0.65, {"python": 0.95, "go": 0.35})
+        accepted, reason = rule_accept_predicate(candidate, baseline, current_best=0.55)
+        assert accepted is False
+        assert "floor_violation:go" in reason
+
+    def test_per_lang_above_floor_accepts(self) -> None:
+        baseline = _result(0.55, {"python": 0.6, "go": 0.5})
+        # go drops to 0.48 — within 5% of 0.5 (floor = 0.475), accepted
+        candidate = _result(0.6, {"python": 0.72, "go": 0.48})
+        accepted, reason = rule_accept_predicate(candidate, baseline, current_best=0.55)
+        assert accepted is True
+        assert reason == "improved"
+
+    def test_zero_baseline_lang_skipped(self) -> None:
+        # Baseline F1=0 for "rust" means there's no signal — never floor-fail
+        baseline = _result(0.5, {"python": 0.6, "rust": 0.0})
+        candidate = _result(0.7, {"python": 0.7, "rust": 0.0})
+        accepted, reason = rule_accept_predicate(candidate, baseline, current_best=0.5)
+        assert accepted is True
+        assert reason == "improved"
+
+    def test_missing_lang_treated_as_zero_signal(self) -> None:
+        # Candidate doesn't expose "go" in per_language → treated as 0 → floor breach
+        baseline = _result(0.55, {"python": 0.6, "go": 0.5})
+        candidate = _result(0.7, {"python": 0.95})
+        accepted, reason = rule_accept_predicate(candidate, baseline, current_best=0.55)
+        assert accepted is False
+        assert "floor_violation:go" in reason
+
+    def test_custom_floor_ratio(self) -> None:
+        # 80% floor — 0.5 * 0.8 = 0.4, so 0.42 should pass
+        permissive = make_rule_accept_predicate(floor_ratio=0.8)
+        baseline = _result(0.55, {"python": 0.6, "go": 0.5})
+        candidate = _result(0.6, {"python": 0.78, "go": 0.42})
+        accepted, reason = permissive(candidate, baseline, current_best=0.55)
+        assert accepted is True
+
+    def test_default_floor_ratio_is_95_percent(self) -> None:
+        assert DEFAULT_FLOOR_RATIO == 0.95

--- a/tests/unit/eval/test_rule_bench_scoring.py
+++ b/tests/unit/eval/test_rule_bench_scoring.py
@@ -1,0 +1,172 @@
+"""Unit tests for rule-bench scoring (severity-weighted F1, per-language agg)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from eval.meta_harness.rule_bench.scoring import (
+    DEFAULT_SEVERITY_WEIGHTS,
+    LanguageScore,
+    RuleScore,
+    aggregate_per_language,
+    compute_composite,
+    severity_weighted_f1,
+)
+
+
+def _approx(value: float) -> float:
+    return round(value, 4)
+
+
+class TestSeverityWeightedF1:
+    def test_perfect_recall_perfect_precision(self) -> None:
+        precision, recall, f1 = severity_weighted_f1(10.0, 0.0, 0.0)
+        assert precision == 1.0
+        assert recall == 1.0
+        assert f1 == 1.0
+
+    def test_zero_inputs_no_division_error(self) -> None:
+        precision, recall, f1 = severity_weighted_f1(0.0, 0.0, 0.0)
+        assert precision == 0.0
+        assert recall == 0.0
+        assert f1 == 0.0
+
+    def test_only_false_positives(self) -> None:
+        precision, recall, f1 = severity_weighted_f1(0.0, 5.0, 0.0)
+        assert precision == 0.0
+        assert recall == 0.0  # no positives to recall
+        assert f1 == 0.0
+
+    def test_only_false_negatives(self) -> None:
+        precision, recall, f1 = severity_weighted_f1(0.0, 0.0, 5.0)
+        assert precision == 0.0
+        assert recall == 0.0
+        assert f1 == 0.0
+
+    def test_balanced_known_values(self) -> None:
+        # 6 TP, 2 FP, 4 FN → precision = 6/8 = 0.75, recall = 6/10 = 0.6,
+        # F1 = 2*0.75*0.6 / 1.35 = 0.6667
+        precision, recall, f1 = severity_weighted_f1(6.0, 2.0, 4.0)
+        assert math.isclose(precision, 0.75)
+        assert math.isclose(recall, 0.6)
+        assert math.isclose(f1, 2 * 0.75 * 0.6 / (0.75 + 0.6))
+
+
+class TestAggregatePerLanguage:
+    def test_empty_input_returns_empty(self) -> None:
+        result = aggregate_per_language({})
+        assert result == {}
+
+    def test_single_rule_single_language(self) -> None:
+        rules = {
+            "py-foo": RuleScore(
+                rule_id="py-foo", pack="python", language="python",
+                severity="high", tp=3, fp=1, fn=2,
+            ),
+        }
+        per_lang = aggregate_per_language(rules)
+        assert set(per_lang.keys()) == {"python"}
+
+        score = per_lang["python"]
+        # high weight = 3.0, so tp_w = 9, fp_w = 3, fn_w = 6
+        assert score.true_positives_weighted == 9.0
+        assert score.false_positives_weighted == 3.0
+        assert score.false_negatives_weighted == 6.0
+        # precision = 9/(9+3) = 0.75, recall = 9/(9+6) = 0.6, F1 = 0.667
+        assert math.isclose(score.precision, 0.75)
+        assert math.isclose(score.recall, 0.6)
+        assert math.isclose(score.weighted_f1, 2 * 0.75 * 0.6 / 1.35)
+        assert score.rule_count == 1
+
+    def test_critical_rule_outweighs_info_rule(self) -> None:
+        # Critical rule (weight 4) with same TP/FN as info rule (weight 0.5)
+        # should dominate the language score.
+        rules = {
+            "py-critical": RuleScore(
+                rule_id="py-critical", pack="python", language="python",
+                severity="critical", tp=2, fp=0, fn=0,
+            ),
+            "py-info": RuleScore(
+                rule_id="py-info", pack="python", language="python",
+                severity="info", tp=0, fp=0, fn=2,
+            ),
+        }
+        per_lang = aggregate_per_language(rules)
+        score = per_lang["python"]
+        # tp_w = 2*4 = 8, fn_w = 2*0.5 = 1
+        assert score.true_positives_weighted == 8.0
+        assert score.false_negatives_weighted == 1.0
+        # recall = 8/9 = 0.889 — info-rule misses barely register
+        assert math.isclose(score.recall, 8.0 / 9.0)
+
+    def test_multiple_languages_buckets_correctly(self) -> None:
+        rules = {
+            "py-r": RuleScore("py-r", "python", "python", "high", tp=3, fp=0, fn=1),
+            "go-r": RuleScore("go-r", "go", "go", "medium", tp=2, fp=1, fn=1),
+        }
+        per_lang = aggregate_per_language(rules)
+        assert set(per_lang.keys()) == {"python", "go"}
+        assert per_lang["python"].rule_count == 1
+        assert per_lang["go"].rule_count == 1
+
+    def test_universal_rule_buckets_under_star(self) -> None:
+        rules = {
+            "any-r": RuleScore("any-r", "core", "", "high", tp=1, fp=0, fn=0),
+        }
+        per_lang = aggregate_per_language(rules)
+        assert "*" in per_lang
+
+    def test_zero_signal_rules_excluded(self) -> None:
+        # A rule with no findings/expectations should not contribute.
+        rules = {
+            "py-real": RuleScore("py-real", "python", "python", "high", tp=1, fp=0, fn=0),
+            "py-noise": RuleScore("py-noise", "python", "python", "high", tp=0, fp=0, fn=0),
+        }
+        per_lang = aggregate_per_language(rules)
+        assert per_lang["python"].rule_count == 1
+
+    def test_custom_severity_weights(self) -> None:
+        rules = {
+            "py-r": RuleScore("py-r", "python", "python", "high", tp=2, fp=0, fn=0),
+        }
+        # Custom weight: high = 10x
+        per_lang = aggregate_per_language(rules, severity_weights={"high": 10.0})
+        assert per_lang["python"].true_positives_weighted == 20.0
+
+
+class TestComputeComposite:
+    def test_empty_returns_zero(self) -> None:
+        assert compute_composite({}) == 0.0
+
+    def test_macro_average(self) -> None:
+        per_lang = {
+            "python": LanguageScore(language="python", weighted_f1=0.8),
+            "go": LanguageScore(language="go", weighted_f1=0.6),
+        }
+        # Mean = 0.7 (macro, not weighted by rule count)
+        assert math.isclose(compute_composite(per_lang), 0.7)
+
+    def test_three_languages_macro(self) -> None:
+        per_lang = {
+            "python": LanguageScore(language="python", weighted_f1=0.9),
+            "go": LanguageScore(language="go", weighted_f1=0.5),
+            "rust": LanguageScore(language="rust", weighted_f1=0.7),
+        }
+        assert math.isclose(compute_composite(per_lang), (0.9 + 0.5 + 0.7) / 3)
+
+
+class TestDefaults:
+    def test_severity_weight_ordering(self) -> None:
+        # critical > high > medium > low > info
+        assert (
+            DEFAULT_SEVERITY_WEIGHTS["critical"]
+            > DEFAULT_SEVERITY_WEIGHTS["high"]
+            > DEFAULT_SEVERITY_WEIGHTS["medium"]
+            > DEFAULT_SEVERITY_WEIGHTS["low"]
+            > DEFAULT_SEVERITY_WEIGHTS["info"]
+        )
+
+    def test_critical_is_4x_low(self) -> None:
+        assert DEFAULT_SEVERITY_WEIGHTS["critical"] == 4 * DEFAULT_SEVERITY_WEIGHTS["low"]

--- a/tests/unit/eval/test_rule_bench_template_engine.py
+++ b/tests/unit/eval/test_rule_bench_template_engine.py
@@ -1,0 +1,195 @@
+"""Unit tests for the rule-bench template engine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from eval.meta_harness.rule_bench.corpus import ExpectedFinding, LabeledSample
+from eval.meta_harness.rule_bench.template_engine import (
+    SUPPORTED_LANGUAGES,
+    Template,
+    TEMPLATES_DIR,
+    gate_against_corpus,
+    load_templates,
+    substitute_slots,
+    validate_template_instance,
+)
+
+
+class TestLoadTemplates:
+    def test_loads_shipped_templates(self) -> None:
+        templates = load_templates()
+        assert TEMPLATES_DIR.is_dir()
+        assert len(templates) >= 6
+        # Spot-check the key ones
+        for name in (
+            "deprecated_api_call",
+            "missing_error_check",
+            "insecure_default_arg",
+            "regex_redos",
+            "string_concat_in_loop",
+            "unsafe_deserialization",
+        ):
+            assert name in templates, f"Missing template: {name}"
+
+    def test_each_template_has_slots_and_rule(self) -> None:
+        for tid, template in load_templates().items():
+            assert template.slots, f"{tid} has no slots"
+            assert "id" in template.rule_body, f"{tid} rule_body missing id"
+            assert "pattern" in template.rule_body, f"{tid} rule_body missing pattern"
+
+
+class TestValidateTemplateInstance:
+    def test_valid_instance(self) -> None:
+        templates = load_templates()
+        t = templates["string_concat_in_loop"]
+        errors = validate_template_instance(
+            t, {"language": "python", "concat_pattern": r"\+=\s*['\"]"},
+        )
+        assert errors == []
+
+    def test_invalid_regex_caught(self) -> None:
+        templates = load_templates()
+        t = templates["string_concat_in_loop"]
+        errors = validate_template_instance(
+            t, {"language": "python", "concat_pattern": "(unbalanced"},
+        )
+        assert any("invalid regex" in e for e in errors)
+
+    def test_unsupported_language_caught(self) -> None:
+        templates = load_templates()
+        t = templates["string_concat_in_loop"]
+        errors = validate_template_instance(
+            t, {"language": "klingon", "concat_pattern": r"\+="},
+        )
+        assert any("unsupported language" in e for e in errors)
+
+    def test_missing_slot_caught(self) -> None:
+        templates = load_templates()
+        t = templates["deprecated_api_call"]
+        errors = validate_template_instance(t, {"language": "python"})
+        assert any("missing slots" in e for e in errors)
+
+    def test_enum_slot_validates(self) -> None:
+        templates = load_templates()
+        t = templates["insecure_default_arg"]
+        errors = validate_template_instance(
+            t, {
+                "language": "python",
+                "arg_pattern": r"verify\s*=\s*False",
+                "severity": "apocalyptic",
+            },
+        )
+        assert any("not in enum" in e for e in errors)
+
+
+class TestSubstituteSlots:
+    def test_substitutes_placeholders(self) -> None:
+        templates = load_templates()
+        t = templates["string_concat_in_loop"]
+        rule = substitute_slots(t, {
+            "language": "python",
+            "concat_pattern": r"\+=\s*['\"]",
+        })
+        assert rule["languages"] == ["python"]
+        assert rule["pattern"] == r"\+=\s*['\"]"
+        # slot_safe_name auto-derived from first slot value
+        assert "python" in rule["id"].lower()
+
+    def test_missing_slot_raises(self) -> None:
+        templates = load_templates()
+        t = templates["string_concat_in_loop"]
+        with pytest.raises(KeyError):
+            substitute_slots(t, {"language": "python"})
+
+
+class TestGateAgainstCorpus:
+    def _sample_with_pattern(self, tmp_path: Path, lines: list[str], expects: dict[int, str]) -> LabeledSample:
+        path = tmp_path / "sample.py"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return LabeledSample(
+            file_path=str(path),
+            language="python",
+            pack="attocode",
+            expected_findings=[
+                ExpectedFinding(line=ln, rule_id=rid, kind="expect")
+                for ln, rid in expects.items()
+            ],
+        )
+
+    def test_accepts_well_targeted_rule(self, tmp_path: Path) -> None:
+        # Two TPs, zero FPs
+        sample = self._sample_with_pattern(
+            tmp_path,
+            [
+                "BAD_TOKEN = 1",
+                "OTHER = 2",
+                "BAD_TOKEN = 3",
+            ],
+            expects={1: "perf/python/foo-test", 3: "perf/python/foo-test"},
+        )
+        rule = {
+            "id": "perf/python/foo-test",
+            "message": "uses BAD_TOKEN",
+            "severity": "low",
+            "category": "performance",
+            "pattern": r"\bBAD_TOKEN\b",
+            "languages": ["python"],
+        }
+        accepted, reason = gate_against_corpus(rule, [sample])
+        assert accepted, reason
+
+    def test_rejects_too_few_tps(self, tmp_path: Path) -> None:
+        sample = self._sample_with_pattern(
+            tmp_path,
+            ["BAD_TOKEN = 1"],
+            expects={1: "perf/python/foo-test"},
+        )
+        rule = {
+            "id": "perf/python/foo-test",
+            "message": "uses BAD_TOKEN",
+            "severity": "low",
+            "category": "performance",
+            "pattern": r"\bBAD_TOKEN\b",
+            "languages": ["python"],
+        }
+        accepted, reason = gate_against_corpus(rule, [sample], min_tp=2)
+        assert not accepted
+        assert "insufficient TPs" in reason
+
+    def test_rejects_too_broad_rule(self, tmp_path: Path) -> None:
+        # Rule matches everything → many FPs
+        path = tmp_path / "wide.py"
+        path.write_text(
+            "import os\nimport sys\nimport json\n", encoding="utf-8",
+        )
+        sample = LabeledSample(
+            file_path=str(path),
+            language="python",
+            pack="attocode",
+            expected_findings=[
+                ExpectedFinding(line=99, rule_id="perf/python/wide-test", kind="expect"),
+            ],
+        )
+        rule = {
+            "id": "perf/python/wide-test",
+            "message": "any import",
+            "severity": "low",
+            "category": "performance",
+            "pattern": r"import",
+            "languages": ["python"],
+        }
+        accepted, reason = gate_against_corpus(rule, [sample], min_tp=1, max_fp=1)
+        assert not accepted
+        # Rule fires on every import line (FP) but the expected line is 99
+        # (no TP). Either rejection reason is acceptable; what matters is
+        # that an over-broad rule never makes it through.
+        assert "FPs" in reason or "TPs" in reason
+
+
+class TestSupportedLanguages:
+    def test_includes_attocode_targets(self) -> None:
+        for lang in ("python", "go", "typescript", "rust", "java"):
+            assert lang in SUPPORTED_LANGUAGES

--- a/tests/unit/eval/test_rule_harness_import.py
+++ b/tests/unit/eval/test_rule_harness_import.py
@@ -1,0 +1,169 @@
+"""Unit tests for ``eval.rule_harness.import_pack``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from eval.rule_harness.import_pack import (
+    LICENSE_FILES,
+    LICENSE_TEMPLATE_DIR,
+    SOURCES,
+    scaffold_pack,
+    write_license,
+    write_manifest,
+    write_notice,
+    write_porting_md,
+)
+
+
+class TestSources:
+    def test_sources_are_permissive_only(self) -> None:
+        # No copyleft licenses — keeps redistribution simple.
+        for source, defaults in SOURCES.items():
+            assert defaults["license"] in {"Apache-2.0", "MIT"}, (
+                f"{source} declares non-permissive license {defaults['license']!r}"
+            )
+
+    def test_each_source_has_porting_targets(self) -> None:
+        for source, defaults in SOURCES.items():
+            assert len(defaults["porting_targets"]) >= 5, (
+                f"{source} has too few porting targets to be useful"
+            )
+
+    def test_all_license_templates_exist(self) -> None:
+        for license_id in {d["license"] for d in SOURCES.values()}:
+            template = LICENSE_TEMPLATE_DIR / LICENSE_FILES[license_id]
+            assert template.is_file(), f"Missing license template: {template}"
+
+
+class TestWriteLicense:
+    def test_writes_apache(self, tmp_path: Path) -> None:
+        ok = write_license(tmp_path, "Apache-2.0")
+        assert ok is True
+        license_file = tmp_path / "LICENSE"
+        assert license_file.is_file()
+        content = license_file.read_text(encoding="utf-8")
+        assert "Apache License" in content
+
+    def test_writes_mit(self, tmp_path: Path) -> None:
+        ok = write_license(tmp_path, "MIT")
+        assert ok is True
+        content = (tmp_path / "LICENSE").read_text(encoding="utf-8")
+        assert "MIT License" in content
+
+    def test_unknown_license_returns_false(self, tmp_path: Path) -> None:
+        assert write_license(tmp_path, "GPL-3.0") is False
+        assert not (tmp_path / "LICENSE").exists()
+
+
+class TestWriteNotice:
+    def test_notice_includes_attribution(self, tmp_path: Path) -> None:
+        write_notice(
+            tmp_path,
+            pack_name="bandit-python",
+            source_url="https://github.com/PyCQA/bandit",
+            source_commit="abc123",
+            license_id="Apache-2.0",
+            attribution="Adapted from Bandit. Copyright PyCQA.",
+        )
+        text = (tmp_path / "NOTICE").read_text(encoding="utf-8")
+        assert "bandit-python" in text
+        assert "Adapted from Bandit" in text
+        assert "abc123" in text
+        assert "Apache-2.0" in text
+
+
+class TestWriteManifest:
+    def test_manifest_round_trip(self, tmp_path: Path) -> None:
+        write_manifest(
+            tmp_path,
+            pack_name="bandit-python",
+            languages=["python"],
+            description="hand-port",
+            source_url="https://github.com/PyCQA/bandit",
+            source_commit="abc",
+            source_license="Apache-2.0",
+            attribution="Bandit attribution",
+            upstream_count=10,
+            imported_count=0,
+        )
+        manifest = yaml.safe_load((tmp_path / "manifest.yaml").read_text())
+        assert manifest["name"] == "bandit-python"
+        assert manifest["languages"] == ["python"]
+        assert manifest["source"] == "community"
+        assert manifest["source_license"] == "Apache-2.0"
+        assert manifest["upstream_rule_count"] == 10
+        assert manifest["imported_rule_count"] == 0
+        assert "imported_at" in manifest
+
+
+class TestWritePortingMd:
+    def test_lists_targets_as_checklist(self, tmp_path: Path) -> None:
+        write_porting_md(
+            tmp_path,
+            pack_name="bandit-python",
+            source="bandit",
+            source_url="https://github.com/PyCQA/bandit",
+            porting_targets=["B105 hardcoded_password", "B602 subprocess"],
+        )
+        text = (tmp_path / "PORTING.md").read_text(encoding="utf-8")
+        assert "B105 hardcoded_password" in text
+        assert "B602 subprocess" in text
+        assert "- [ ]" in text  # checkbox format
+        assert "attribution comment header" in text
+
+
+class TestScaffoldPack:
+    def test_scaffolds_bandit(self, tmp_path: Path) -> None:
+        output = tmp_path / "bandit-python"
+        summary = scaffold_pack(
+            source="bandit",
+            output_dir=output,
+            pack_name="bandit-python",
+            language="python",
+            commit="deadbeef",
+        )
+        assert summary.source == "bandit"
+        assert summary.license == "Apache-2.0"
+        assert summary.upstream_count == 10
+        assert (output / "LICENSE").is_file()
+        assert (output / "NOTICE").is_file()
+        assert (output / "manifest.yaml").is_file()
+        assert (output / "PORTING.md").is_file()
+        assert (output / "rules").is_dir()  # empty dir for human porting
+
+    def test_scaffolds_gosec(self, tmp_path: Path) -> None:
+        output = tmp_path / "gosec-go"
+        summary = scaffold_pack(
+            source="gosec",
+            output_dir=output,
+            pack_name="gosec-go",
+            language="go",
+        )
+        manifest = yaml.safe_load((output / "manifest.yaml").read_text())
+        assert manifest["languages"] == ["go"]
+        assert manifest["source_license"] == "Apache-2.0"
+
+    def test_scaffolds_eslint(self, tmp_path: Path) -> None:
+        output = tmp_path / "eslint-typescript"
+        summary = scaffold_pack(
+            source="eslint",
+            output_dir=output,
+            pack_name="eslint-typescript",
+            language="typescript",
+        )
+        assert summary.license == "MIT"
+        license_text = (output / "LICENSE").read_text(encoding="utf-8")
+        assert "MIT License" in license_text
+
+    def test_unknown_source_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="Unknown source"):
+            scaffold_pack(
+                source="rubocop",
+                output_dir=tmp_path / "x",
+                pack_name="x",
+                language="ruby",
+            )

--- a/tests/unit/eval/test_seed_attocode_fixtures.py
+++ b/tests/unit/eval/test_seed_attocode_fixtures.py
@@ -1,0 +1,77 @@
+"""Unit tests for the fixture-seed scaffolder."""
+
+from __future__ import annotations
+
+import pytest
+
+from eval.rule_harness.scripts.seed_attocode_fixtures import (
+    LANG_INFO,
+    _annotate_block,
+    render_fixture,
+)
+
+
+class TestAnnotateBlock:
+    def test_appends_marker_to_first_code_line(self) -> None:
+        out = _annotate_block(
+            "x = 1\ny = 2\n", marker="#", kind="expect", rule_id="r-foo",
+        )
+        first = out.splitlines()[0]
+        assert "# expect: r-foo" in first
+
+    def test_skips_blank_leading_lines(self) -> None:
+        out = _annotate_block(
+            "\n\nactual = 1\n", marker="#", kind="expect", rule_id="r",
+        )
+        # Annotation goes on `actual = 1`, not the blank lines
+        for line in out.splitlines():
+            if "actual = 1" in line:
+                assert "# expect: r" in line
+
+    def test_empty_input_unchanged(self) -> None:
+        assert _annotate_block("", marker="#", kind="expect", rule_id="r") == ""
+
+
+class TestRenderFixture:
+    def test_python_fixture_has_both_blocks(self) -> None:
+        rule = {
+            "examples": [
+                {"bad": "result += '!'", "good": "result = ''.join(parts)"},
+            ],
+        }
+        body = render_fixture("py-test", rule, "python")
+        assert "# expect: py-test" in body
+        assert "# ok: py-test" in body
+        assert "BAD: rule MUST fire" in body
+        assert "GOOD: rule must NOT fire" in body
+
+    def test_go_fixture_uses_double_slash(self) -> None:
+        rule = {"examples": [{"bad": "x := y", "good": "x = y"}]}
+        body = render_fixture("go-test", rule, "go")
+        assert "// expect: go-test" in body
+        assert "// ok: go-test" in body
+
+    def test_unknown_language_raises(self) -> None:
+        rule = {"examples": [{"bad": "x", "good": "y"}]}
+        with pytest.raises(ValueError, match="Unknown language"):
+            render_fixture("r", rule, "klingon")
+
+    def test_no_examples_raises(self) -> None:
+        with pytest.raises(ValueError, match="no examples"):
+            render_fixture("r", {"examples": []}, "python")
+
+
+class TestLangInfo:
+    def test_supports_five_target_langs(self) -> None:
+        for lang in ("python", "go", "typescript", "rust", "java"):
+            assert lang in LANG_INFO
+
+    def test_python_uses_hash_marker(self) -> None:
+        ext, marker = LANG_INFO["python"]
+        assert ext == ".py"
+        assert marker == "#"
+
+    def test_go_uses_slash_marker(self) -> None:
+        ext, marker = LANG_INFO["go"]
+        assert ext == ".go"
+        assert marker == "//"

--- a/tests/unit/scripts/test_check_pack_licenses.py
+++ b/tests/unit/scripts/test_check_pack_licenses.py
@@ -1,0 +1,128 @@
+"""Unit tests for ``scripts/check_pack_licenses.py``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Path-import the script (it lives outside any package)
+import importlib.util
+import sys
+
+
+def _import_script() -> object:
+    project_root = Path(__file__).parents[3]
+    script_path = project_root / "scripts" / "check_pack_licenses.py"
+    spec = importlib.util.spec_from_file_location("check_pack_licenses", script_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_pack_licenses"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cpl = _import_script()
+
+
+def _write_pack(
+    root: Path,
+    name: str,
+    *,
+    license_text: str = "Apache License Version 2.0\n" * 20,
+    notice_text: str = "NOTICE text",
+    manifest: dict | None = None,
+) -> Path:
+    """Build a synthetic pack dir with the optional pieces written."""
+    import yaml as _yaml
+
+    pack = root / name
+    pack.mkdir(parents=True, exist_ok=True)
+    (pack / "LICENSE").write_text(license_text, encoding="utf-8")
+    (pack / "NOTICE").write_text(notice_text, encoding="utf-8")
+    if manifest is None:
+        manifest = {
+            "name": name,
+            "source": "community",
+            "source_license": "Apache-2.0",
+            "attribution": "test attribution",
+        }
+    (pack / "manifest.yaml").write_text(
+        _yaml.safe_dump(manifest), encoding="utf-8",
+    )
+    return pack
+
+
+class TestCheckPack:
+    def test_complete_pack_passes(self, tmp_path: Path) -> None:
+        pack = _write_pack(tmp_path, "good-pack")
+        assert cpl.check_pack(pack) == []
+
+    def test_missing_license_caught(self, tmp_path: Path) -> None:
+        pack = _write_pack(tmp_path, "bad")
+        (pack / "LICENSE").unlink()
+        errors = cpl.check_pack(pack)
+        assert any("LICENSE" in e for e in errors)
+
+    def test_missing_notice_caught(self, tmp_path: Path) -> None:
+        pack = _write_pack(tmp_path, "bad")
+        (pack / "NOTICE").unlink()
+        errors = cpl.check_pack(pack)
+        assert any("NOTICE" in e for e in errors)
+
+    def test_missing_manifest_caught(self, tmp_path: Path) -> None:
+        pack = _write_pack(tmp_path, "bad")
+        (pack / "manifest.yaml").unlink()
+        errors = cpl.check_pack(pack)
+        assert any("manifest.yaml" in e for e in errors)
+
+    def test_unknown_license_caught(self, tmp_path: Path) -> None:
+        pack = _write_pack(
+            tmp_path, "bad",
+            manifest={
+                "name": "bad",
+                "source": "community",
+                "source_license": "GPL-3.0",
+                "attribution": "x",
+            },
+        )
+        errors = cpl.check_pack(pack)
+        assert any("not in allowlist" in e for e in errors)
+
+    def test_missing_required_field_caught(self, tmp_path: Path) -> None:
+        pack = _write_pack(
+            tmp_path, "bad",
+            manifest={"name": "bad", "source_license": "MIT"},  # missing attribution
+        )
+        errors = cpl.check_pack(pack)
+        assert any("attribution" in e for e in errors)
+
+    def test_truncated_license_flagged(self, tmp_path: Path) -> None:
+        pack = _write_pack(tmp_path, "thin", license_text="MIT")
+        errors = cpl.check_pack(pack)
+        assert any("truncated" in e for e in errors)
+
+
+class TestDiscoverPacks:
+    def test_skips_underscore_prefixed_dirs(self, tmp_path: Path) -> None:
+        _write_pack(tmp_path, "real-pack")
+        (tmp_path / "_internal").mkdir()
+        (tmp_path / "_internal" / "manifest.yaml").write_text("name: _internal\n")
+        packs = cpl.discover_packs(tmp_path)
+        names = {p.name for p in packs}
+        assert "real-pack" in names
+        assert "_internal" not in names
+
+    def test_handles_missing_dir(self, tmp_path: Path) -> None:
+        assert cpl.discover_packs(tmp_path / "nope") == []
+
+
+class TestIntegration:
+    def test_real_community_packs_compliant(self) -> None:
+        # The repo's actual community packs must all pass — guards against
+        # someone landing a pack without LICENSE/NOTICE.
+        packs = cpl.discover_packs()
+        assert packs, "No community packs found in real repo"
+        for pack in packs:
+            errs = cpl.check_pack(pack)
+            assert errs == [], f"{pack.name} has issues: {errs}"

--- a/uv.lock
+++ b/uv.lock
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "attocode"
-version = "0.2.21"
+version = "0.2.22"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

Extends the meta-harness with a rule-quality optimizer (`--bench rule`) and significantly expands language coverage by importing community rule packs from permissive-licensed sources. The optimizer can tune existing rule fields (stage 1) and generate new rules from templates with a fixture-coverage gate (stage 2). A per-language F1 floor predicate prevents the "win-Python-break-Go" regression pattern observed in earlier search-bench experiments.

- **Rule-bench harness** — severity-weighted F1 macro-averaged per language with 5% per-language floor; staged proposer (sweep → templates); composite mode runs search + rule legs in parallel
- **3 hand-ported community packs** — bandit-python (Apache-2.0, 8 rules), gosec-go (Apache-2.0, 8 rules), eslint-typescript (MIT, 7 rules), each with full LICENSE + NOTICE attribution
- **CI license check** — fails any PR landing a community pack without LICENSE/NOTICE/manifest provenance
- **207 unit + integration tests pass**; baseline composite F1 = 0.857 across 6 languages

Bumps version 0.2.21 → 0.2.22. See `CHANGELOG.md` for the full breakdown.

## Commit-by-step layout

12 commits, each independently reviewable:

| # | Commit | Scope |
|---|--------|-------|
| 1 | schema groundwork | annotation regex, UnifiedRule.references, PackManifest provenance fields |
| 2 | meta-harness refactor | pluggable BenchSpec; backward-compatible default |
| 3 | scoring + corpus | severity-weighted F1, CorpusLoader |
| 4 | config + evaluator | RuleBenchConfig, RuleBenchEvaluator |
| 5 | floor + CLI wiring | predicate, sweep proposer, --bench rule live |
| 6 | pack scaffolding tool | import_pack.py + license templates |
| 7 | three community packs | bandit / gosec / eslint hand-ports |
| 8 | hand-labeled fixtures | seed scaffolder + 21 fixtures |
| 9 | stage-2 templates | 6 templates + LLM proposer + fixture-coverage gate |
| 10 | composite + license CI | --bench composite + check_pack_licenses.py + CI job |
| 11 | docs | rule-bench-corpus.md + bench-modes section |
| 12 | release | version bump + CHANGELOG |

## Test plan

- [ ] `uv run pytest tests/unit/eval/ tests/unit/scripts/ tests/integration/test_rule_bench_floor_e2e.py tests/unit/code_intel/test_rules_engine.py` — expect 207 passed
- [ ] `uv run python scripts/check_pack_licenses.py` — expect 3 packs verified
- [ ] `python -m eval.meta_harness baseline --search-repos attocode --no-split` — search bench unchanged (regression check after meta_loop refactor)
- [ ] `python -m eval.meta_harness --bench rule baseline` — composite F1 ≈ 0.85 across 6 languages
- [ ] `python -m eval.meta_harness --bench rule run --iterations 1 --propose-mode sweep` — at least one accepted candidate
- [ ] `python -m eval.meta_harness --bench composite baseline` — composite mode runs without error
- [ ] CI job `pack-license-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)