### PR TITLE
fix(code-intel): remote→local reliability + pack activation (release 0.2.24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Code-Intel reliability (remote/local mode + activation)
+
+The code-intel MCP could be left almost entirely non-functional by a stale
+`[remote]` config, and the rule engine shipped without its language packs.
+This restores a working local-mode baseline.
+
+- **Graceful remote→local fallback.** A configured remote (`.attocode/config.toml`
+  `[remote]`) with an expired JWT or an unreachable server previously routed
+  every service-backed tool there unconditionally, so they all failed with
+  "Connection refused" and no fallback. `configure_remote_service()` now gates
+  on JWT expiry (`config.token_is_expired`) and a `/health` reachability probe
+  (`RemoteTextService.ping`), degrades to local mode with a readable reason
+  (`get_remote_degraded_reason`), and closes the prior client to avoid a socket
+  leak on reconfigure.
+- **IndexStore v2→v3 schema migration.** Opening an existing pre-v3
+  `symbols.db` crashed (`no such column: caller_qualified_name`) because the
+  v3 indexes were created before the schema-version check could migrate — which
+  blocked local mode on any already-indexed repo. Stale data tables are now
+  dropped before recreation on a version mismatch; data rebuilds from source on
+  next index.
+- **BM25 status reporting.** `cache_status_all` / `verify_all_caches` reported
+  the keyword index empty/broken because the store definition queried a
+  non-existent `documents` table; corrected to `kw_docs`.
+- **Remote config persistence.** `save_remote_config` now escapes quotes and
+  backslashes in its TOML writer (previously produced invalid TOML that was
+  silently dropped on reload).
+
+### Changed — Rule packs load by default
+
+- **Shipped language packs are now auto-loaded.** Previously the registry
+  loaded only the 109 builtin regex rules (`list_rules` → `Packs: 0`); the 10
+  shipped example packs — including the ast-grep Tier-2 structural rules — were
+  never loaded. `load_all_packs()` now also loads the shipped packs by default
+  (≈200 rules total, 30 structural). User-installed packs of the same name
+  still shadow the shipped copy; `discover_packs()` keeps its project-local-only
+  contract. Opt out with `ATTOCODE_NO_SHIPPED_PACKS=1`.
+
 ## [0.2.23] - 2026-05-03
 
 ### Added — Phase 1 Code-Intel Roadmap (call graph + rule-engine evolution)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.24] - 2026-05-29
+
 ### Fixed — Code-Intel reliability (remote/local mode + activation)
 
 The code-intel MCP could be left almost entirely non-functional by a stale

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "attocode"
-version = "0.2.23"
+version = "0.2.24"
 description = "Production AI coding agent"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -201,7 +201,7 @@ exclude_lines = [
 ]
 
 [tool.bumpversion]
-current_version = "0.2.23"
+current_version = "0.2.24"
 commit = false
 tag = false
 

--- a/src/attocode/__init__.py
+++ b/src/attocode/__init__.py
@@ -1,3 +1,3 @@
 """Attocode - Production AI coding agent."""
 
-__version__ = "0.2.23"
+__version__ = "0.2.24"

--- a/src/attocode/code_intel/_shared.py
+++ b/src/attocode/code_intel/_shared.py
@@ -58,6 +58,7 @@ _memory_store: object | None = None  # Backward compat: tests may set this direc
 _explorer: HierarchicalExplorer | None = None
 _service: CodeIntelService | None = None
 _remote_service: RemoteTextService | None = None
+_remote_degraded_reason: str = ""
 
 
 def _check_server_override(name: str) -> object | None:
@@ -173,23 +174,65 @@ def _get_remote_service() -> RemoteTextService | None:
 
 
 def configure_remote_service(remote_url: str, remote_token: str, remote_repo_id: str) -> None:
-    """Configure the shared service getter to proxy through a remote HTTP service."""
-    global _remote_service, _service
+    """Proxy the shared service through a remote HTTP server **if it is usable**.
+
+    Gracefully degrades to local mode (leaving ``_remote_service`` unset) when
+    the JWT is expired or the server is unreachable, recording a human-readable
+    reason in :func:`get_remote_degraded_reason`. This prevents a stale or dead
+    ``[remote]`` config from making every tool fail with "Connection refused".
+    """
+    global _remote_service, _service, _remote_degraded_reason
     from attocode.code_intel.api.providers.remote_provider import RemoteTextService
+    from attocode.code_intel.config import token_is_expired
 
-    _service = None
-    _remote_service = RemoteTextService(remote_url, remote_token, remote_repo_id)
-
-
-def clear_remote_service() -> None:
-    """Reset remote service wiring."""
-    global _remote_service
+    # Drop any previously-configured client (avoid a socket leak on reconfigure).
     if _remote_service is not None:
         try:
             _remote_service.close()
         except Exception:
             pass
     _remote_service = None
+    _service = None
+    _remote_degraded_reason = ""
+
+    if token_is_expired(remote_token):
+        _remote_degraded_reason = (
+            f"remote token expired — using local mode (server={remote_url})"
+        )
+        logger.warning("Code-intel %s", _remote_degraded_reason)
+        return
+
+    candidate = RemoteTextService(remote_url, remote_token, remote_repo_id)
+    if not candidate.ping():
+        _remote_degraded_reason = (
+            f"remote server unreachable at {remote_url} — using local mode"
+        )
+        logger.warning("Code-intel %s", _remote_degraded_reason)
+        try:
+            candidate.close()
+        except Exception:
+            pass
+        return
+
+    _remote_service = candidate
+    logger.info("Code-intel remote mode active: %s (repo=%s)", remote_url, remote_repo_id)
+
+
+def clear_remote_service() -> None:
+    """Reset remote service wiring (back to local mode)."""
+    global _remote_service, _remote_degraded_reason
+    if _remote_service is not None:
+        try:
+            _remote_service.close()
+        except Exception:
+            pass
+    _remote_service = None
+    _remote_degraded_reason = ""
+
+
+def get_remote_degraded_reason() -> str:
+    """Why remote mode is inactive despite being configured ('' when N/A)."""
+    return _remote_degraded_reason
 
 
 def _get_explorer() -> HierarchicalExplorer:

--- a/src/attocode/code_intel/api/providers/remote_provider.py
+++ b/src/attocode/code_intel/api/providers/remote_provider.py
@@ -59,6 +59,19 @@ class RemoteTextService:
     def close(self) -> None:
         self._client.close()
 
+    def ping(self, timeout: float = 2.0) -> bool:
+        """Best-effort reachability probe (does NOT validate the token).
+
+        Returns True when the server answers with a status < 500, False on
+        connection/timeout errors or a 5xx. Token expiry is checked separately
+        (before this is called) since ``/health`` is typically unauthenticated.
+        """
+        try:
+            resp = self._client.get("/health", timeout=timeout)
+            return resp.status_code < 500
+        except Exception:
+            return False
+
     @staticmethod
     def _unwrap_text(payload: dict[str, Any]) -> str:
         if "result" in payload and isinstance(payload["result"], str):

--- a/src/attocode/code_intel/config.py
+++ b/src/attocode/code_intel/config.py
@@ -120,6 +120,34 @@ class RemoteConfig:
         return bool(self.server and self.token)
 
 
+def token_is_expired(token: str, *, leeway_seconds: int = 30) -> bool:
+    """Best-effort check whether a JWT's ``exp`` claim is in the past.
+
+    Decodes the token payload WITHOUT verifying the signature — we don't hold
+    the remote server's signing key, we only need the expiry. Returns ``False``
+    when the token has no ``exp`` claim or can't be parsed (we can't prove it's
+    expired, so let the reachability probe decide). ``leeway_seconds`` treats a
+    token as expired slightly early so we don't start a session on a token
+    about to lapse.
+    """
+    import base64
+    import json
+    import time
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        return False
+    try:
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+    except Exception:
+        return False
+    exp = payload.get("exp")
+    if not isinstance(exp, (int, float)):
+        return False
+    return time.time() >= (float(exp) - leeway_seconds)
+
+
 def load_remote_config(project_dir: str) -> RemoteConfig:
     """Load remote config from .attocode/config.toml, falling back to env vars."""
     config_path = Path(project_dir) / ".attocode" / "config.toml"
@@ -179,7 +207,8 @@ def save_remote_config(project_dir: str, rc: RemoteConfig) -> Path:
                 if isinstance(v, bool):
                     lines.append(f"{k} = {'true' if v else 'false'}")
                 elif isinstance(v, str):
-                    lines.append(f'{k} = "{v}"')
+                    esc = v.replace("\\", "\\\\").replace('"', '\\"')
+                    lines.append(f'{k} = "{esc}"')
                 else:
                     lines.append(f"{k} = {v}")
             lines.append("")

--- a/src/attocode/code_intel/rules/packs/pack_loader.py
+++ b/src/attocode/code_intel/rules/packs/pack_loader.py
@@ -12,6 +12,7 @@ Each pack directory contains:
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -212,9 +213,31 @@ def load_pack(manifest: PackManifest) -> list[UnifiedRule]:
     return rules
 
 
-def load_all_packs(project_dir: str = "") -> tuple[list[PackManifest], list[UnifiedRule]]:
-    """Discover and load all user-activated packs."""
+def load_all_packs(
+    project_dir: str = "", *, include_shipped: bool | None = None,
+) -> tuple[list[PackManifest], list[UnifiedRule]]:
+    """Discover and load packs.
+
+    Loads user-activated packs from ``.attocode/packs/`` and, by default, the
+    shipped example packs (the language packs that carry the ast-grep
+    structural rules) — otherwise the engine would ship with only the builtin
+    regex rules. A user-installed pack shadows the shipped pack of the same
+    name. Set ``ATTOCODE_NO_SHIPPED_PACKS=1`` (or ``include_shipped=False``)
+    to load only user packs.
+    """
+    if include_shipped is None:
+        include_shipped = os.environ.get("ATTOCODE_NO_SHIPPED_PACKS", "") not in (
+            "1", "true", "True",
+        )
+
     manifests = discover_packs(project_dir)
+    if include_shipped:
+        seen = {m.name for m in manifests}
+        for m in list_example_packs():
+            if m.name not in seen:
+                manifests.append(m)
+                seen.add(m.name)
+
     all_rules: list[UnifiedRule] = []
     for m in manifests:
         all_rules.extend(load_pack(m))

--- a/src/attocode/code_intel/server.py
+++ b/src/attocode/code_intel/server.py
@@ -718,8 +718,9 @@ def main() -> None:
             remote_repo_id = rc.repo_id
 
     if remote_url:
+        # configure_remote_service logs the outcome and gracefully falls back to
+        # local mode if the remote is unreachable or its token is expired.
         configure_remote_service(remote_url, remote_token, remote_repo_id)
-        logger.info("Remote mode: proxying through %s (repo: %s)", remote_url, remote_repo_id)
 
     # Start file watcher and notification queue poller in background
     _start_file_watcher(project_dir)

--- a/src/attocode/code_intel/tools/pin_store.py
+++ b/src/attocode/code_intel/tools/pin_store.py
@@ -76,7 +76,7 @@ _STORE_DEFS: tuple[dict[str, Any], ...] = (
     {
         "name": "kw_index",
         "path_fragment": os.path.join("index", "kw_index.db"),
-        "tables": ("documents",),
+        "tables": ("kw_docs",),
         "timestamp_table": None,
         "timestamp_col": None,
         "schema_meta": None,

--- a/src/attocode/integrations/context/index_store.py
+++ b/src/attocode/integrations/context/index_store.py
@@ -89,6 +89,7 @@ class IndexStore:
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._conn.execute("PRAGMA foreign_keys=ON")
+        self._migrate_stale_schema()
         self._create_tables()
         self._check_schema_version()
 
@@ -96,6 +97,41 @@ class IndexStore:
         if self._conn is None:
             raise RuntimeError("IndexStore connection is closed")
         return self._conn
+
+    def _migrate_stale_schema(self) -> None:
+        """Drop stale data tables BEFORE (re)creating them when the on-disk
+        schema predates the current version.
+
+        ``_create_tables`` builds the v3 indexes (e.g. ``ix_refs_caller`` on
+        ``refs(caller_qualified_name)``). On a pre-v3 DB whose ``refs`` table
+        lacks that column, creating the index raises ``OperationalError`` and
+        the store can't even open — so the wipe in ``_check_schema_version``
+        never runs. Dropping the stale tables here keeps the upgrade path
+        working; data is rebuilt from source on the next index. Children are
+        dropped before ``files`` to respect FK ordering.
+        """
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT value FROM metadata WHERE key = 'schema_version'"
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return  # no metadata table => brand-new DB, nothing to migrate
+        if not row or row[0] == SCHEMA_VERSION:
+            return
+        logger.warning(
+            "Index schema is stale (%s, expected %s); dropping data tables in "
+            "%r so the new schema can be created — a full re-index will run on "
+            "next access.",
+            row[0], SCHEMA_VERSION, self.db_path,
+        )
+        conn.executescript(
+            "DROP TABLE IF EXISTS refs;"
+            "DROP TABLE IF EXISTS symbols;"
+            "DROP TABLE IF EXISTS dependencies;"
+            "DROP TABLE IF EXISTS files;"
+        )
+        conn.commit()
 
     def _create_tables(self) -> None:
         conn = self._get_conn()

--- a/src/attoswarm/__init__.py
+++ b/src/attoswarm/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.2.23"
+__version__ = "0.2.24"

--- a/tests/integration/code_intel/test_remote_mcp_http_integration.py
+++ b/tests/integration/code_intel/test_remote_mcp_http_integration.py
@@ -79,10 +79,14 @@ def test_remote_mcp_tools_proxy_through_live_http_app(monkeypatch) -> None:
 
     srv.configure_remote_service("http://test", "tok_test", "default")
     try:
-        assert srv.repo_map() == "stub:repo_map"
-        assert srv.dead_code() == "stub:dead_code"
-        assert change_coupling("src/main.py") == "stub:change_coupling"
-        assert srv.fast_search("main") == "stub:fast_search"
+        # Ranked-result tools append a deterministic pin footer
+        # ("\n\n---\nindex_pin: ...") via _stamp_pin, so assert the proxied
+        # payload is present rather than exact-equals. assert_called_once below
+        # is what actually proves the call was proxied to the remote service.
+        assert srv.repo_map().startswith("stub:repo_map")
+        assert srv.dead_code().startswith("stub:dead_code")
+        assert change_coupling("src/main.py").startswith("stub:change_coupling")
+        assert srv.fast_search("main").startswith("stub:fast_search")
 
         mock_service.repo_map.assert_called_once()
         mock_service.dead_code.assert_called_once()

--- a/tests/unit/code_intel/test_config_remote.py
+++ b/tests/unit/code_intel/test_config_remote.py
@@ -180,3 +180,17 @@ class TestSaveRemoteConfig:
         assert loaded.server == "https://new.io"
         assert loaded.token == "new"
         assert loaded.repo_id == "r2"
+
+    def test_round_trip_with_special_chars(self, tmp_path, monkeypatch):
+        # Tokens/URLs containing quotes or backslashes must survive the manual
+        # TOML writer — otherwise it emits invalid TOML that load silently drops.
+        monkeypatch.delenv("ATTOCODE_REMOTE_URL", raising=False)
+        monkeypatch.delenv("ATTOCODE_REMOTE_TOKEN", raising=False)
+        monkeypatch.delenv("ATTOCODE_REMOTE_REPO_ID", raising=False)
+
+        rc = RemoteConfig(server='https://h.io/p"q', token='a\\b"c', repo_id="r")
+        save_remote_config(str(tmp_path), rc)
+        loaded = load_remote_config(str(tmp_path))
+
+        assert loaded.server == 'https://h.io/p"q'
+        assert loaded.token == 'a\\b"c'

--- a/tests/unit/code_intel/test_index_store_migration.py
+++ b/tests/unit/code_intel/test_index_store_migration.py
@@ -1,0 +1,62 @@
+"""Regression: opening a pre-v3 IndexStore DB must migrate (drop+rebuild)
+without crashing.
+
+A v2 ``refs`` table lacks ``caller_qualified_name``. The v3 ``_create_tables``
+builds ``CREATE INDEX ix_refs_caller ON refs(caller_qualified_name)``, which
+raises ``OperationalError`` on the stale table — and because that ran *before*
+the schema-version check, the store could never open to perform the migration.
+This blocks local mode entirely on any existing v2 ``.attocode/index/symbols.db``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def _seed_v2_db(path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        INSERT INTO metadata (key, value) VALUES ('schema_version', '2');
+        CREATE TABLE files (
+            path TEXT PRIMARY KEY, mtime REAL NOT NULL, size INTEGER NOT NULL,
+            language TEXT NOT NULL DEFAULT '', line_count INTEGER NOT NULL DEFAULT 0,
+            content_hash TEXT NOT NULL DEFAULT ''
+        );
+        CREATE TABLE symbols (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, file_path TEXT NOT NULL,
+            name TEXT NOT NULL, qualified_name TEXT NOT NULL, kind TEXT NOT NULL,
+            line INTEGER NOT NULL DEFAULT 0, end_line INTEGER NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'tree-sitter'
+        );
+        -- v2 refs: NO caller_qualified_name column
+        CREATE TABLE refs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, file_path TEXT NOT NULL,
+            symbol_name TEXT NOT NULL, ref_kind TEXT NOT NULL DEFAULT 'call',
+            line INTEGER NOT NULL DEFAULT 0, col INTEGER NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'tree-sitter'
+        );
+        CREATE TABLE dependencies (
+            source_path TEXT NOT NULL, target_path TEXT NOT NULL,
+            PRIMARY KEY (source_path, target_path)
+        );
+        INSERT INTO files (path, mtime, size) VALUES ('a.py', 1.0, 10);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_indexstore_opens_and_migrates_stale_v2_schema(tmp_path):
+    from attocode.integrations.context.index_store import SCHEMA_VERSION, IndexStore
+
+    db = tmp_path / "symbols.db"
+    _seed_v2_db(str(db))
+
+    # Must NOT raise OperationalError("no such column: caller_qualified_name").
+    store = IndexStore(db_path=str(db))
+
+    assert store.get_meta("schema_version") == SCHEMA_VERSION
+    cols = [r[1] for r in store._get_conn().execute("PRAGMA table_info(refs)").fetchall()]
+    assert "caller_qualified_name" in cols

--- a/tests/unit/code_intel/test_kw_index_status.py
+++ b/tests/unit/code_intel/test_kw_index_status.py
@@ -1,0 +1,28 @@
+"""Regression: the kw_index (BM25) store definition must target the real
+`kw_docs` table, not the non-existent `documents` — otherwise cache_status_all
+and verify_all_caches falsely report the BM25 index empty/broken.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+
+def test_kw_index_rows_counted_via_store_def(tmp_path):
+    from attocode.code_intel.tools.maintenance_tools import _store_row_count
+    from attocode.code_intel.tools.pin_tools import _STORE_DEFS
+
+    idx = tmp_path / ".attocode" / "index"
+    idx.mkdir(parents=True)
+    db = idx / "kw_index.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE kw_docs (id TEXT PRIMARY KEY)")
+    conn.executemany("INSERT INTO kw_docs (id) VALUES (?)", [("a",), ("b",), ("c",)])
+    conn.commit()
+    conn.close()
+
+    kw_def = next(d for d in _STORE_DEFS if d["name"] == "kw_index")
+    path = os.path.join(str(tmp_path), ".attocode", kw_def["path_fragment"])
+    # Uses the ACTUAL store-def table tuple — fails while it says ("documents",).
+    assert _store_row_count(path, kw_def["tables"]) == 3

--- a/tests/unit/code_intel/test_pack_autoload.py
+++ b/tests/unit/code_intel/test_pack_autoload.py
@@ -1,0 +1,44 @@
+"""The analysis engine must ship usable: load the shipped example packs
+(10 language packs incl. ast-grep structural rules) by default, so the live
+registry isn't just the 109 builtin regex rules.
+
+``discover_packs`` keeps its documented project-local contract (only
+``.attocode/packs/``); the auto-load lives in ``load_all_packs`` and is
+opt-out via ``ATTOCODE_NO_SHIPPED_PACKS``.
+"""
+
+from __future__ import annotations
+
+
+def test_load_all_packs_includes_shipped_example_packs_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("ATTOCODE_NO_SHIPPED_PACKS", raising=False)
+    from attocode.code_intel.rules.packs.pack_loader import load_all_packs
+
+    manifests, rules = load_all_packs(str(tmp_path))  # fresh project, no .attocode/packs
+
+    names = {m.name for m in manifests}
+    assert {"python", "go", "typescript"} <= names
+
+    rule_ids = {r.id for r in rules}
+    # a Tier-2 ast-grep structural rule from the python pack is now active
+    assert "py-debug-print-leftover" in rule_ids
+
+
+def test_shipped_packs_opt_out(tmp_path, monkeypatch):
+    monkeypatch.setenv("ATTOCODE_NO_SHIPPED_PACKS", "1")
+    from attocode.code_intel.rules.packs.pack_loader import load_all_packs
+
+    manifests, rules = load_all_packs(str(tmp_path))
+    assert manifests == []  # only user packs (none in a fresh project)
+    assert rules == []
+
+
+def test_user_pack_takes_precedence_over_shipped(tmp_path, monkeypatch):
+    monkeypatch.delenv("ATTOCODE_NO_SHIPPED_PACKS", raising=False)
+    from attocode.code_intel.rules.packs.pack_loader import install_pack, load_all_packs
+
+    install_pack("python", str(tmp_path))  # user installs python into .attocode/packs
+    manifests, _ = load_all_packs(str(tmp_path))
+
+    # exactly one 'python' manifest (user copy), not duplicated by the shipped one
+    assert [m.name for m in manifests].count("python") == 1

--- a/tests/unit/code_intel/test_remote_reliability.py
+++ b/tests/unit/code_intel/test_remote_reliability.py
@@ -1,0 +1,122 @@
+"""Tests for remote-mode graceful degradation.
+
+When the configured remote is unusable — an expired JWT or an unreachable
+server — code-intel must NOT hard-fail. It should leave ``_remote_service``
+unset (so every tool transparently runs against the local engine) and record
+a human-readable reason. These tests pin that behaviour.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import httpx
+import respx
+
+import attocode.code_intel._shared as shared
+from attocode.code_intel.api.providers.remote_provider import RemoteTextService
+from attocode.code_intel.config import token_is_expired
+
+SERVER = "https://ci.example.com"
+REPO_ID = "repo-abc-123"
+
+
+def _b64url(payload: dict) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+
+
+def _make_jwt(payload: dict) -> str:
+    """Build a syntactically-valid JWT (signature is not checked by the gate)."""
+    return f"{_b64url({'alg': 'HS256', 'typ': 'JWT'})}.{_b64url(payload)}.sig"
+
+
+_EXPIRED = _make_jwt({"exp": 1_000_000_000})  # 2001-09-09
+_FUTURE = _make_jwt({"exp": 9_999_999_999})  # 2286-11-20
+
+
+# ---------------------------------------------------------------------------
+# token_is_expired — decodes the exp claim WITHOUT verifying the signature
+# (we don't hold the remote server's signing key).
+# ---------------------------------------------------------------------------
+
+
+class TestTokenIsExpired:
+    def test_past_exp_is_expired(self):
+        assert token_is_expired(_EXPIRED) is True
+
+    def test_future_exp_not_expired(self):
+        assert token_is_expired(_FUTURE) is False
+
+    def test_no_exp_claim_not_expired(self):
+        # Can't prove expiry without an exp claim — let the health check decide.
+        assert token_is_expired(_make_jwt({"sub": "u"})) is False
+
+    def test_garbage_not_expired(self):
+        assert token_is_expired("not-a-jwt") is False
+        assert token_is_expired("only.two") is False
+        assert token_is_expired("") is False
+
+
+# ---------------------------------------------------------------------------
+# RemoteTextService.ping — best-effort reachability probe
+# ---------------------------------------------------------------------------
+
+
+class TestRemotePing:
+    def test_ping_true_when_reachable(self):
+        with respx.mock:
+            respx.get(f"{SERVER}/health").mock(return_value=httpx.Response(200, json={}))
+            svc = RemoteTextService(SERVER, "tok", REPO_ID)
+            try:
+                assert svc.ping() is True
+            finally:
+                svc.close()
+
+    def test_ping_false_on_connection_error(self):
+        with respx.mock:
+            respx.get(f"{SERVER}/health").mock(side_effect=httpx.ConnectError("refused"))
+            svc = RemoteTextService(SERVER, "tok", REPO_ID)
+            try:
+                assert svc.ping() is False
+            finally:
+                svc.close()
+
+    def test_ping_false_on_server_error(self):
+        with respx.mock:
+            respx.get(f"{SERVER}/health").mock(return_value=httpx.Response(503))
+            svc = RemoteTextService(SERVER, "tok", REPO_ID)
+            try:
+                assert svc.ping() is False
+            finally:
+                svc.close()
+
+
+# ---------------------------------------------------------------------------
+# configure_remote_service — gate on expiry + reachability, fall back to local
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureRemoteGraceful:
+    def teardown_method(self):
+        shared.clear_remote_service()
+
+    def test_skips_remote_when_token_expired(self):
+        shared.clear_remote_service()
+        shared.configure_remote_service("http://127.0.0.1:8080", _EXPIRED, REPO_ID)
+        assert shared._remote_service is None
+        assert "expired" in shared.get_remote_degraded_reason().lower()
+
+    def test_skips_remote_when_unreachable(self, monkeypatch):
+        shared.clear_remote_service()
+        monkeypatch.setattr(RemoteTextService, "ping", lambda self, timeout=2.0: False)
+        shared.configure_remote_service("http://127.0.0.1:8080", _FUTURE, REPO_ID)
+        assert shared._remote_service is None
+        assert "unreachable" in shared.get_remote_degraded_reason().lower()
+
+    def test_uses_remote_when_healthy(self, monkeypatch):
+        shared.clear_remote_service()
+        monkeypatch.setattr(RemoteTextService, "ping", lambda self, timeout=2.0: True)
+        shared.configure_remote_service("http://127.0.0.1:8080", _FUTURE, REPO_ID)
+        assert shared._remote_service is not None
+        assert shared.get_remote_degraded_reason() == ""

--- a/tests/unit/test_code_intel.py
+++ b/tests/unit/test_code_intel.py
@@ -47,6 +47,8 @@ def _make_service_with_mocks(
     svc = CodeIntelService.__new__(CodeIntelService)
     svc._project_dir = project_dir
     svc._config = None
+    svc._scoring_config = None
+    svc._context_config = None
     svc._init_lock = threading.Lock()
     svc._ast_service = ast_service
     svc._context_mgr = context_mgr
@@ -56,6 +58,8 @@ def _make_service_with_mocks(
     svc._security_scanner = None
     svc._semantic_search = None
     svc._memory_store = None
+    svc._temporal_analyzer = None
+    svc._lsp_auto_started = False
     return svc
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "attocode"
-version = "0.2.23"
+version = "0.2.24"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Why
The code-intel MCP was effectively ~90% dark: a stale `[remote]` config (expired JWT, dead local server) routed every service-backed tool there with no fallback, and the rule engine shipped without its language packs (`list_rules` → `Packs: 0`, zero structural rules). This restores a working, useful **local-mode** baseline.

## What changed
**Reliability (`4ea4dc7`)**
- **Graceful remote→local fallback** — `configure_remote_service()` now gates on JWT expiry (`token_is_expired`) + a `/health` reachability probe (`RemoteTextService.ping`), degrades to local with a readable reason (`get_remote_degraded_reason`), and closes the prior client (socket-leak fix).
- **IndexStore v2→v3 migration** — opening an existing pre-v3 `symbols.db` crashed (`no such column: caller_qualified_name`), which also blocked local mode; stale tables are now dropped before recreation on a version mismatch.
- **BM25 status** — `cache_status_all`/`verify_all_caches` queried a non-existent `documents` table → corrected to `kw_docs`.
- **Config persistence** — `save_remote_config` escapes quotes/backslashes in its TOML writer.

**Activation (`7375f5b`)**
- **Shipped language packs auto-load** — `load_all_packs()` now loads the 10 shipped example packs by default (≈200 rules total, **30 ast-grep structural**). User packs still shadow shipped ones; `discover_packs()` keeps its project-local contract; opt-out via `ATTOCODE_NO_SHIPPED_PACKS=1`.

**Release (`2aacf1a`, `51df4fd`)** — CHANGELOG `[0.2.24]` + version bump (0.2.23→0.2.24) across pyproject/both `__init__`/uv.lock. Framed as a **Phase-0 reliability/activation** release; roadmap Phase 2 (inter-procedural dataflow) shifts to a later slot.

## Verification
- New tests (TDD): `test_remote_reliability`, `test_kw_index_status`, `test_index_store_migration`, `test_pack_autoload` (+ stale-helper fix).
- Full code-intel + integration suites green; `scripts/validate_release_version.py --expected-tag v0.2.24` passes.
- Verified live on the real repo config: it now resolves to **local mode** instead of `Connection refused`.

## Note
Tag `v0.2.24` intentionally **not** created yet — recommend tagging the merge commit on `main` after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)