### PR TITLE
fix(code-intel): remote-mode parity — local fallback, learning routing, startup dedup

### DIFF
--- a/src/attocode/code_intel/_shared.py
+++ b/src/attocode/code_intel/_shared.py
@@ -165,6 +165,39 @@ def _get_service() -> CodeIntelService | RemoteTextService:
     return _service
 
 
+def _get_local_service() -> CodeIntelService:
+    """Return the local CodeIntelService, bypassing any remote proxy.
+
+    Some tools (e.g. ``regex_search``, ``call_graph``) have no server-side
+    HTTP route, so they cannot be proxied to a remote. They call this to run
+    against the local index even when a remote is configured, instead of
+    crashing with ``AttributeError`` on the missing remote method.
+    """
+    global _service
+    srv = sys.modules.get("attocode.code_intel.server")
+    if srv is not None and "_service" in srv.__dict__:
+        override = srv.__dict__["_service"]
+        if override is not None and not _is_remote_service(override):
+            return override  # type: ignore[return-value]
+        if override is None:
+            _service = None
+    if _service is not None:
+        from attocode.code_intel import service as code_intel_service_module
+
+        if _service.project_dir not in code_intel_service_module._instances:
+            _service = None
+    if _service is None:
+        from attocode.code_intel.service import CodeIntelService
+
+        _service = CodeIntelService.get_instance(_get_project_dir())
+    return _service
+
+
+def _is_remote_service(obj: object) -> bool:
+    """True when *obj* is a remote proxy rather than the local service."""
+    return type(obj).__name__ == "RemoteTextService"
+
+
 def _get_remote_service() -> RemoteTextService | None:
     """Return the configured remote text service, if any."""
     srv = sys.modules.get("attocode.code_intel.server")
@@ -233,6 +266,35 @@ def clear_remote_service() -> None:
 def get_remote_degraded_reason() -> str:
     """Why remote mode is inactive despite being configured ('' when N/A)."""
     return _remote_degraded_reason
+
+
+def enable_remote_if_configured(
+    project_dir: str,
+    *,
+    local_only: bool = False,
+    remote_url: str = "",
+    remote_token: str = "",
+    remote_repo_id: str = "",
+) -> None:
+    """Enable remote mode from explicit args / config / env, else stay local.
+
+    Single source of truth for the startup wiring previously duplicated (and
+    divergent) between ``server.main`` and ``cli._cmd_serve``. Explicit
+    ``remote_*`` args win; otherwise ``.attocode/config.toml`` + env are read
+    via :func:`load_remote_config`. ``configure_remote_service`` then health/
+    expiry-gates the remote and falls back to local on any problem.
+    """
+    clear_remote_service()
+    if local_only:
+        return
+    if not remote_url:
+        from attocode.code_intel.config import load_remote_config
+
+        rc = load_remote_config(project_dir)
+        if rc.is_configured:
+            remote_url, remote_token, remote_repo_id = rc.server, rc.token, rc.repo_id
+    if remote_url:
+        configure_remote_service(remote_url, remote_token, remote_repo_id)
 
 
 def _get_explorer() -> HierarchicalExplorer:

--- a/src/attocode/code_intel/cli.py
+++ b/src/attocode/code_intel/cli.py
@@ -306,19 +306,12 @@ def _cmd_serve(args: list[str], *, debug: bool = False) -> None:
     abs_dir = os.path.abspath(project_dir)
     os.environ["ATTOCODE_PROJECT_DIR"] = abs_dir
 
-    # Remote config handling — mirror the logic in server.py main()
-    from attocode.code_intel._shared import clear_remote_service
-    clear_remote_service()
-
+    # Remote config handling — shared with server.py main() so both startup
+    # paths behave identically (config + env, health/expiry-gated fallback).
+    from attocode.code_intel._shared import enable_remote_if_configured
     if local_only:
         os.environ["ATTOCODE_LOCAL_ONLY"] = "1"
-    else:
-        # Load remote config from .attocode/config.toml when not local-only
-        from attocode.code_intel._shared import configure_remote_service
-        from attocode.code_intel.config import load_remote_config
-        rc = load_remote_config(abs_dir)
-        if rc.is_configured:
-            configure_remote_service(rc.server, rc.token, rc.repo_id)
+    enable_remote_if_configured(abs_dir, local_only=local_only)
 
     if debug:
         import logging

--- a/src/attocode/code_intel/server.py
+++ b/src/attocode/code_intel/server.py
@@ -707,20 +707,15 @@ def main() -> None:
     if local_only:
         os.environ["ATTOCODE_LOCAL_ONLY"] = "1"
 
-    # Load remote config from .attocode/config.toml if not explicitly provided
-    clear_remote_service()
-    if not remote_url and not local_only:
-        from attocode.code_intel.config import load_remote_config
-        rc = load_remote_config(project_dir)
-        if rc.is_configured:
-            remote_url = rc.server
-            remote_token = rc.token
-            remote_repo_id = rc.repo_id
-
-    if remote_url:
-        # configure_remote_service logs the outcome and gracefully falls back to
-        # local mode if the remote is unreachable or its token is expired.
-        configure_remote_service(remote_url, remote_token, remote_repo_id)
+    # Enable remote mode from CLI flags / config.toml / env (shared with the
+    # CLI serve path); gracefully falls back to local on a dead/expired remote.
+    enable_remote_if_configured(
+        project_dir,
+        local_only=local_only,
+        remote_url=remote_url,
+        remote_token=remote_token,
+        remote_repo_id=remote_repo_id,
+    )
 
     # Start file watcher and notification queue poller in background
     _start_file_watcher(project_dir)

--- a/src/attocode/code_intel/tools/analysis_tools.py
+++ b/src/attocode/code_intel/tools/analysis_tools.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from attocode.code_intel._shared import (
     _get_code_analyzer,
     _get_context_mgr,
+    _get_local_service,
     _get_project_dir,
     _get_remote_service,
     _get_service,
@@ -109,7 +110,9 @@ def call_graph(
         direction: "callees" (forward) or "callers" (reverse).
         depth: Maximum BFS hops (default 1).
     """
-    return _get_service().call_graph(symbol, direction=direction, depth=depth)
+    # call_graph has no server-side HTTP route, so it runs locally even when a
+    # remote is configured (the local symbol index carries the call edges).
+    return _get_local_service().call_graph(symbol, direction=direction, depth=depth)
 
 
 @mcp.tool()

--- a/src/attocode/code_intel/tools/learning_tools.py
+++ b/src/attocode/code_intel/tools/learning_tools.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from attocode.code_intel._shared import (
     _get_project_dir,
+    _get_remote_service,
     mcp,
 )
 
@@ -67,6 +68,9 @@ def recall(query: str, scope: str = "", max_results: int = 10) -> str:
         scope: Optional directory scope to filter learnings.
         max_results: Maximum number of learnings to return.
     """
+    remote = _get_remote_service()
+    if remote is not None:
+        return remote.recall(query, scope=scope, max_results=max_results)
     store = _get_memory_store()
     results = store.recall(query, scope=scope, max_results=max_results)
     if not results:
@@ -115,6 +119,12 @@ def record_learning(
             learning survives renames and ``orphan_scan`` can verify
             reachability via git.
     """
+    remote = _get_remote_service()
+    if remote is not None:
+        return remote.record_learning(
+            type=type, description=description, details=details,
+            scope=scope, confidence=confidence,
+        )
     store = _get_memory_store()
 
     # Auto-compute the anchor when the caller didn't supply one and the
@@ -164,6 +174,9 @@ def learning_feedback(learning_id: int, helpful: bool) -> str:
         learning_id: The ID from a previous recall result.
         helpful: Whether the learning was actually useful.
     """
+    remote = _get_remote_service()
+    if remote is not None:
+        return remote.learning_feedback(learning_id, helpful)
     store = _get_memory_store()
     store.record_feedback(learning_id, helpful)
     action = "boosted" if helpful else "reduced"
@@ -183,6 +196,9 @@ def list_learnings(
         type: Optional filter by type (pattern/antipattern/workaround/convention/gotcha).
         scope: Optional filter by directory scope.
     """
+    remote = _get_remote_service()
+    if remote is not None:
+        return remote.list_learnings(status=status, type=type, scope=scope)
     store = _get_memory_store()
     results = store.list_all(status=status, type=type or None)
     if scope:

--- a/src/attocode/code_intel/tools/search_tools.py
+++ b/src/attocode/code_intel/tools/search_tools.py
@@ -480,15 +480,9 @@ def regex_search(
         max_results: Maximum number of matching lines to return.
         case_insensitive: Whether to match case-insensitively.
     """
-    remote = _get_remote_service()
-    if remote is not None:
-        return remote.regex_search(
-            pattern=pattern,
-            path=path,
-            max_results=max_results,
-            case_insensitive=case_insensitive,
-        )
-
+    # NOTE: regex_search has no server-side HTTP route, so it cannot be
+    # proxied to a remote. It always runs locally (against the trigram index /
+    # local files), even when a remote is configured.
     import re
     from pathlib import Path
 

--- a/tests/unit/code_intel/test_call_graph_tool.py
+++ b/tests/unit/code_intel/test_call_graph_tool.py
@@ -149,7 +149,9 @@ class TestMcpToolDelegation:
 
         svc = CodeIntelService(project_with_calls)
         svc.reindex()
-        monkeypatch.setattr(at, "_get_service", lambda: svc)
+        # call_graph has no server-side route, so it dispatches via
+        # _get_local_service() (bypassing any remote proxy), not _get_service().
+        monkeypatch.setattr(at, "_get_local_service", lambda: svc)
 
         result = at.call_graph("caller", direction="callees", depth=1)
         assert "helper" in result

--- a/tests/unit/code_intel/test_remote_local_fallback.py
+++ b/tests/unit/code_intel/test_remote_local_fallback.py
@@ -1,0 +1,113 @@
+"""Route-less tools must run locally even when a remote is configured.
+
+`call_graph` and `regex_search` have no server-side HTTP route, so dispatching
+them through the remote proxy raises AttributeError in remote mode. They must
+fall back to the local engine regardless of remote configuration.
+"""
+
+from __future__ import annotations
+
+import attocode.code_intel._shared as shared
+
+
+class _FakeRemote:
+    """Stand-in remote proxy that lacks call_graph / regex_search (like the real one)."""
+
+    project_dir = "remote:fake"
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def test_get_local_service_bypasses_remote(monkeypatch, tmp_path):
+    monkeypatch.setenv("ATTOCODE_PROJECT_DIR", str(tmp_path))
+    (tmp_path / "m.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(shared, "_remote_service", _FakeRemote(), raising=False)
+    monkeypatch.setattr(shared, "_service", None, raising=False)
+
+    # _get_service() returns the remote proxy when configured...
+    assert isinstance(shared._get_service(), _FakeRemote)
+
+    # ...but _get_local_service() always returns the real local service.
+    local = shared._get_local_service()
+    from attocode.code_intel.service import CodeIntelService
+
+    assert isinstance(local, CodeIntelService)
+    assert not isinstance(local, _FakeRemote)
+
+
+def test_regex_search_runs_locally_when_remote_configured(monkeypatch, tmp_path):
+    monkeypatch.setenv("ATTOCODE_PROJECT_DIR", str(tmp_path))
+    (tmp_path / "hello.py").write_text(
+        "def greet():\n    return 'hello world'\n", encoding="utf-8",
+    )
+
+    # Remote proxy is set but has no regex_search — must NOT be used.
+    monkeypatch.setattr(shared, "_remote_service", _FakeRemote(), raising=False)
+
+    from attocode.code_intel.tools.search_tools import regex_search
+
+    out = regex_search("hello world", path="", max_results=10)
+    assert "hello.py" in out  # local grep found it; no AttributeError
+
+
+class _RecordingRemote:
+    """Remote proxy that records learning calls (parity with adr_tools)."""
+
+    project_dir = "remote:fake"
+    calls: list[tuple]
+
+    def __init__(self) -> None:
+        self.calls = []
+
+    def record_learning(self, **kw) -> str:
+        self.calls.append(("record_learning", kw))
+        return "remote-recorded"
+
+    def recall(self, query, scope="", max_results=10) -> str:
+        self.calls.append(("recall", query))
+        return "remote-recalled"
+
+    def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def test_record_learning_routes_to_remote_when_configured(monkeypatch, tmp_path):
+    monkeypatch.setenv("ATTOCODE_PROJECT_DIR", str(tmp_path))
+    fake = _RecordingRemote()
+    monkeypatch.setattr(shared, "_remote_service", fake, raising=False)
+
+    from attocode.code_intel.tools.learning_tools import record_learning
+
+    out = record_learning(type="pattern", description="use X")
+    assert out == "remote-recorded"
+    assert fake.calls and fake.calls[0][0] == "record_learning"
+
+
+def test_recall_routes_to_remote_when_configured(monkeypatch, tmp_path):
+    monkeypatch.setenv("ATTOCODE_PROJECT_DIR", str(tmp_path))
+    fake = _RecordingRemote()
+    monkeypatch.setattr(shared, "_remote_service", fake, raising=False)
+
+    from attocode.code_intel.tools.learning_tools import recall
+
+    out = recall("how to X")
+    assert out == "remote-recalled"
+    assert fake.calls and fake.calls[0][0] == "recall"
+
+
+def test_enable_remote_if_configured_local_only(monkeypatch, tmp_path):
+    """The shared startup helper is a no-op in local-only mode."""
+    shared.clear_remote_service()
+    shared.enable_remote_if_configured(str(tmp_path), local_only=True)
+    assert shared._remote_service is None
+
+
+def test_enable_remote_if_configured_no_config(monkeypatch, tmp_path):
+    """No [remote] config and no env => stays local, no crash."""
+    for var in ("ATTOCODE_REMOTE_URL", "ATTOCODE_REMOTE_TOKEN", "ATTOCODE_REMOTE_REPO_ID"):
+        monkeypatch.delenv(var, raising=False)
+    shared.clear_remote_service()
+    shared.enable_remote_if_configured(str(tmp_path), local_only=False)
+    assert shared._remote_service is None


### PR DESCRIPTION
## Why
Follow-ups to the remote/local reliability work (#91, v0.2.24). These are the remaining remote-mode correctness gaps surfaced by the bug-hunt.

## What changed
- **Route-less tools fall back to local.** `regex_search` and `call_graph` have no server-side HTTP route, so proxying them crashed with `AttributeError` in remote mode. They now run against the local index via a new `_shared._get_local_service()` that bypasses the remote proxy.
- **Learning split-brain fixed.** `learning_tools` (recall / record_learning / learning_feedback / list_learnings) always ran local while `adr_tools` routed to remote — so in remote mode, learnings never reached the server. They now branch to the remote proxy like `adr_tools`.
- **Startup dedup.** `server.main()` and `cli._cmd_serve()` duplicated (and had diverged on) the remote-enable wiring. Extracted one shared `_shared.enable_remote_if_configured()` used by both.

## Tests
- New `test_remote_local_fallback.py` (local fallback + learning routing + the shared startup helper).
- Fixed `test_call_graph_tool.py` to patch the getter the tool now uses.
- Full code-intel suite: **1182 passed, 5 skipped**. (3 pre-existing errors in `test_deps`/`test_middleware` are unrelated — they fail identically on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)