### PR TITLE
Fix code-intel global server startup

### DIFF
--- a/src/attocode/code_intel/server.py
+++ b/src/attocode/code_intel/server.py
@@ -63,6 +63,7 @@ from attocode.code_intel._shared import (  # noqa: F401
     _walk_up,
     clear_remote_service,
     configure_remote_service,
+    enable_remote_if_configured,
     mcp,
 )
 


### PR DESCRIPTION
## Summary

Fixes the global `attocode-code-intel` MCP startup path by importing `enable_remote_if_configured` in `server.py`.

## Root Cause

The no-arg global server path calls `enable_remote_if_configured(...)` after inferring the project root from the current working directory, but `server.py` did not import that helper from `_shared`. As a result, Claude user-level MCP entry (`attocode-code-intel` with no args) crashed with `NameError` before the server could start.

## Validation

- Ran `attocode-code-intel status`
- Ran `claude mcp get attocode-code-intel` and confirmed `Status: ✔ Connected` for the global user config entry with empty args.